### PR TITLE
Gui: Create Start page before opening documents

### DIFF
--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -428,6 +428,8 @@ private Q_SLOTS:
     void clearStatus();
 
 Q_SIGNALS:
+    /// GUI initialization is complete; command-line files have not yet been processed.
+    void guiInitialized();
     void timeEvent();
     void windowStateChanged(QWidget*);
     void workbenchActivated(const QString&);

--- a/src/Gui/StartupProcess.cpp
+++ b/src/Gui/StartupProcess.cpp
@@ -238,6 +238,7 @@ void StartupPostProcess::execute()
     activateWorkbench();
     checkParameters();
     checkVersionMigration();
+    Q_EMIT mainWindow->guiInitialized();
 }
 
 void StartupPostProcess::setWindowTitle()

--- a/src/Mod/Start/Gui/AppStartGui.cpp
+++ b/src/Mod/Start/Gui/AppStartGui.cpp
@@ -21,8 +21,7 @@
  *                                                                          *
  ***************************************************************************/
 
-#include <QString>
-#include <QTimer>
+#include <QPointer>
 
 
 #include <App/Application.h>
@@ -68,52 +67,6 @@ public:
     }
 };
 
-class StartLauncher
-{
-public:
-    StartLauncher()
-    {
-        if (Gui::isInternalGuiTestRun()) {
-            return;
-        }
-
-        // QTimers don't fire until the event loop starts, which is our signal that the GUI is up
-        QTimer::singleShot(100, [this] { Launch(); });
-    }
-
-    void Launch()
-    {
-        if (Gui::isInternalGuiTestRun()) {
-            return;
-        }
-
-        auto hGrp = App::GetApplication().GetParameterGroupByPath(
-            "User parameter:BaseApp/Preferences/Mod/Start"
-        );
-        bool showOnStartup = hGrp->GetBool("ShowOnStartup", true);
-        if (showOnStartup) {
-            Gui::Application::Instance->commandManager().runCommandByName("Start_Start");
-            QTimer::singleShot(100, [this] { EnsureLaunched(); });
-        }
-    }
-
-    void EnsureLaunched()
-    {
-        if (Gui::isInternalGuiTestRun()) {
-            return;
-        }
-
-        // It's possible that "Start_Start" didn't result in the creation of an MDI window, if it
-        // was called to early. This polls the views to make sure the view was created, and if it
-        // was not, re-calls the command.
-        auto mw = Gui::getMainWindow();
-        auto existingView = mw->findChild<StartGui::StartView*>(QLatin1String("StartView"));
-        if (!existingView) {
-            Launch();
-        }
-    }
-};
-
 PyObject* initModule()
 {
     auto newModule = gsl::owner<Module*>(new Module);
@@ -125,9 +78,6 @@ PyObject* initModule()
 /* Python entry */
 PyMOD_INIT_FUNC(StartGui)
 {
-    static StartGui::StartLauncher* launcher = new StartGui::StartLauncher();
-    Q_UNUSED(launcher)
-
     Base::Console().log("Loading GUI of Start module… ");
     PyObject* mod = StartGui::initModule();
     auto manipulator = std::make_shared<StartGui::Manipulator>();
@@ -138,6 +88,25 @@ PyMOD_INIT_FUNC(StartGui)
 
     // register preferences pages
     new Gui::PrefPageProducer<StartGui::DlgStartPreferencesImp>(QT_TRANSLATE_NOOP("QObject", "Start"));
+
+    auto mw = Gui::getMainWindow();
+    QObject::connect(mw, &Gui::MainWindow::guiInitialized, mw, [mw] {
+        if (Gui::isInternalGuiTestRun()) {
+            return;
+        }
+
+        auto hGrp = App::GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/Preferences/Mod/Start"
+        );
+        if (hGrp->GetBool("ShowOnStartup", true)) {
+            // An initialization script may already have opened a document.
+            QPointer<Gui::MDIView> activeView = mw->activeWindow();
+            Gui::Application::Instance->commandManager().runCommandByName("Start_Start");
+            if (activeView) {
+                mw->setActiveWindow(activeView);
+            }
+        }
+    });
 
     PyMOD_Return(mod);
 }

--- a/src/Mod/Start/Gui/Manipulator.cpp
+++ b/src/Mod/Start/Gui/Manipulator.cpp
@@ -54,7 +54,7 @@ void CmdStart::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     auto mw = Gui::getMainWindow();
-    auto existingView = mw->findChild<StartGui::StartView*>(QLatin1String("StartView"));
+    auto existingView = mw->findChild<StartGui::StartView*>();
     if (!existingView) {
         existingView = gsl::owner<StartGui::StartView*>(new StartGui::StartView(mw));
         mw->addWindow(existingView);  // Transfers ownership


### PR DESCRIPTION
- Added guiInitialized, emitted after GUI initialization and before command-line file processing
- Start subscribes to that signal and opens synchronously
- Removed both Start timers, the retry loop, and StartLauncher

Assisted-by: GPT-6-Astra

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes https://github.com/FreeCAD/FreeCAD/issues/27342
Closes https://github.com/FreeCAD/FreeCAD/pull/31551/


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
