### PR TITLE
CAM: remove bogus output_units in machine-editor:Postprocessor tab

### DIFF
--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -606,17 +606,6 @@ class PostProcessor:
                 ),
             },
             {
-                "name": "output_units",
-                "scope": SCOPE_MACHINE,
-                "type": "str",
-                "label": translate("CAM", "Unit-command in output"),
-                "default": OutputUnits.METRIC,
-                "help": translate(
-                    "CAM",
-                    "Unit-command in output",
-                ),
-            },
-            {
                 "name": "axis_precision",
                 "scope": SCOPE_MACHINE,
                 "type": "int",


### PR DESCRIPTION
I was overzealous making sure all .values where in an editor.

Remove bogus (duplicate)  `output_units`
cf https://discord.com/channels/870877411049357352/1416090431497965751/1543079310607515703

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
