### PR TITLE
CAM: Fix review findings in the toolbit editor

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathToolBitSerializer.py
+++ b/src/Mod/CAM/CAMTests/TestPathToolBitSerializer.py
@@ -30,6 +30,8 @@ class _BaseToolBitSerializerTestCase(PathTestWithAssets):
     def setUp(self):
         """Create a tool bit for each test."""
         super().setUp()
+        # Some tests switch the schema to check a bit stores its own units.
+        self._entry_schema = FreeCAD.Units.getSchema()
         if self.serializer_class is None or not issubclass(self.serializer_class, AssetSerializer):
             raise NotImplementedError("Subclasses must define a valid serializer_class")
 
@@ -37,6 +39,10 @@ class _BaseToolBitSerializerTestCase(PathTestWithAssets):
         self.test_tool_bit.label = "Test Tool"
         self.test_tool_bit.set_diameter(FreeCAD.Units.Quantity("4.12 mm"))
         self.test_tool_bit.set_length(FreeCAD.Units.Quantity("15.0 mm"))
+
+    def tearDown(self):
+        FreeCAD.Units.setSchema(self._entry_schema)
+        super().tearDown()
 
     def test_serialize(self):
         """Test serialization of a toolbit."""
@@ -123,102 +129,6 @@ class TestFCTBSerializer(_BaseToolBitSerializerTestCase):
             data = json.loads(self.serializer_class.serialize(self.test_tool_bit).decode("utf-8"))
             diameter = data["parameter"]["Diameter"]
             self.assertEqual(diameter, "0.3750 in", f"with the {active} schema active")
-        setToolBitSchema("Metric")
-
-    def test_serialize_keeps_tool_precision(self):
-        """Two decimals would save a 0.375" tap as 0.37" - 0.127mm out."""
-        cases = (("Metric", "9.525 mm"), ("Imperial", "0.3750 in"))
-        for units, expected in cases:
-            self.test_tool_bit.obj.Units = units
-            self.test_tool_bit.set_diameter(FreeCAD.Units.Quantity("0.375 in"))
-            data = json.loads(self.serializer_class.serialize(self.test_tool_bit).decode("utf-8"))
-            stored = data["parameter"]["Diameter"]
-            self.assertEqual(stored, expected)
-            self.assertAlmostEqual(
-                FreeCAD.Units.Quantity(stored).Value,
-                self.test_tool_bit.obj.Diameter.Value,
-                places=6,
-            )
-
-    def test_extract_dependencies(self):
-        """Test dependency extraction."""
-        # This test assumes that the serializers don't have dependencies
-        # and can be overridden in subclasses if needed.
-        serialized_data = self.serializer_class.serialize(self.test_tool_bit)
-        dependencies = self.serializer_class.extract_dependencies(serialized_data)
-        self.assertIsInstance(dependencies, list)
-        self.assertEqual(len(dependencies), 0)
-
-
-class TestCamoticsToolBitSerializer(_BaseToolBitSerializerTestCase):
-    serializer_class = CamoticsToolBitSerializer
-
-    def test_serialize(self):
-        super().test_serialize()
-        serialized_data = self.serializer_class.serialize(self.test_tool_bit)
-        # Camotics specific assertions
-        expected_substrings = [
-            b'"units": "metric"',
-            b'"shape": "Cylindrical"',
-            b'"length": 15',
-            b'"diameter": 4.12',
-            b'"description": "Test Tool"',
-        ]
-        for substring in expected_substrings:
-            self.assertIn(substring, serialized_data)
-
-    def test_deserialize(self):
-        # Create a known serialized data string based on the Camotics format
-        camotics_data = (
-            b'{"units": "metric", "shape": "Cylindrical", "length": 15, '
-            b'"diameter": 4.12, "description": "Test Tool"}'
-        )
-        deserialized_bit = cast(
-            ToolBitEndmill,
-            self.serializer_class.deserialize(camotics_data, id="test_id", dependencies=None),
-        )
-
-        self.assertIsInstance(deserialized_bit, ToolBit)
-        self.assertEqual(deserialized_bit.label, "Test Tool")
-        self.assertEqual(
-            deserialized_bit.get_diameter(), FreeCAD.Units.Quantity(4.12, FreeCAD.Units.Length)
-        )
-        self.assertEqual(
-            deserialized_bit.get_length(), FreeCAD.Units.Quantity(15.0, FreeCAD.Units.Length)
-        )
-        self.assertEqual(deserialized_bit.get_shape_name(), "Endmill")
-
-
-class TestFCTBSerializer(_BaseToolBitSerializerTestCase):
-    serializer_class = FCTBSerializer
-
-    def test_serialize(self):
-        super().test_serialize()
-        serialized_data = self.serializer_class.serialize(self.test_tool_bit)
-        # FCTB specific assertions (JSON format)
-        data = json.loads(serialized_data.decode("utf-8"))
-        self.assertEqual(data.get("name"), "Test Tool")
-        self.assertEqual(data.get("shape"), "endmill.fcstd")
-        self.assertEqual(
-            FreeCAD.Units.Quantity(data.get("parameter", {}).get("Diameter")),
-            FreeCAD.Units.Quantity(4.12, FreeCAD.Units.Length),
-        )
-        self.assertEqual(
-            FreeCAD.Units.Quantity(data.get("parameter", {}).get("Length")),
-            FreeCAD.Units.Quantity(15.0, FreeCAD.Units.Length),
-        )
-
-    def test_serialize_uses_the_bits_own_units(self):
-        """A bit stores itself in the units it is specified in, not the ones on screen."""
-        self.test_tool_bit.obj.Units = "Imperial"
-        self.test_tool_bit.set_diameter(FreeCAD.Units.Quantity("0.375 in"))
-
-        for active in ("Metric", "Imperial"):
-            setToolBitSchema(active)
-            data = json.loads(self.serializer_class.serialize(self.test_tool_bit).decode("utf-8"))
-            diameter = data["parameter"]["Diameter"]
-            self.assertEqual(diameter, "0.3750 in", f"with the {active} schema active")
-        setToolBitSchema("Metric")
 
     def test_serialize_keeps_tool_precision(self):
         """Two decimals would save a 0.375" tap as 0.37" - 0.127mm out."""

--- a/src/Mod/CAM/Path/Tool/docobject/ui/property.py
+++ b/src/Mod/CAM/Path/Tool/docobject/ui/property.py
@@ -121,10 +121,13 @@ class QuantityPropertyEditorWidget(BasePropertyEditorWidget):
 
     def updateWidget(self):
         value: FreeCAD.Units.Quantity = self._obj.getPropertyByName(self._prop_name)
-        # Block signals temporarily to prevent feedback loops
+        # Block signals temporarily to prevent feedback loops. A value
+        # at_tool_precision rejects would otherwise leave them blocked for good.
         self._editor_widget.blockSignals(True)
-        self._editor_widget.setProperty("value", at_tool_precision(value))
-        self._editor_widget.blockSignals(False)
+        try:
+            self._editor_widget.setProperty("value", at_tool_precision(value))
+        finally:
+            self._editor_widget.blockSignals(False)
         self._editor_widget.setEnabled(not self._is_read_only)
 
     def updateProperty(self):

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/panel.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/panel.py
@@ -35,6 +35,9 @@ class TaskPanel:
         Path.Log.track(vobj.Object.Label)
         self.vobj = vobj
         self.obj = vobj.Object
+        # The editor switches the global schema to the bit's units, and the
+        # panel outlives it, so the panel is what has to put it back.
+        self._entry_schema = FreeCAD.Units.getSchema()
         self.editor = ToolBitEditorPanel(self.obj.Proxy)
         # The task dialog supplies its own OK/Cancel.
         self.editor._button_box.hide()
@@ -46,6 +49,8 @@ class TaskPanel:
         # The transaction holds every edit made in the panel, so aborting it
         # is the undo; the editor has nothing of its own to roll back.
         FreeCAD.ActiveDocument.abortTransaction()
+        FreeCAD.Units.setSchema(self._entry_schema)
+        FreeCADGui.ActiveDocument.resetEdit()
         FreeCADGui.Control.closeDialog()
         if self.deleteOnReject:
             FreeCAD.ActiveDocument.openTransaction("Uncreate ToolBit")
@@ -57,6 +62,7 @@ class TaskPanel:
     def accept(self):
         self.editor.save_toolbit()
         FreeCAD.ActiveDocument.commitTransaction()
+        FreeCAD.Units.setSchema(self._entry_schema)
         FreeCADGui.ActiveDocument.resetEdit()
         FreeCADGui.Control.closeDialog()
         FreeCAD.ActiveDocument.recompute()

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/view.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/view.py
@@ -99,7 +99,11 @@ class ViewProvider(object):
         return []
 
     def doubleClicked(self, vobj):
-        return self.setEdit(vobj)
+        # Through the document rather than straight to setEdit: that registers
+        # the object as in edit, so unsetEdit runs when the panel closes and
+        # resetEdit in the panel means something.
+        FreeCADGui.ActiveDocument.setEdit(vobj.Object.Name)
+        return True
 
     def setupContextMenu(self, vobj, menu):
         # Override the base class method to prevent adding the "Edit" action


### PR DESCRIPTION
Drop the duplicate serializer test classes that shadowed the originals, keep a value at_tool_precision rejects from leaving a field's signals blocked, and enter edit mode through the document so unsetEdit runs and resetEdit means something.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
