### PR TITLE
Fix 32425 empty chamfer warning

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
@@ -455,8 +455,6 @@ bool TaskDlgChamferParameters::accept()
         getViewObject()->showPreviousFeature(false);
     }
 
-    parameter->apply();
-
     return TaskDlgDressUpParameters::accept();
 }
 

--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
@@ -341,8 +341,8 @@ void TaskChamferParameters::apply()
             break;
     }
 
-    // Alert user if he created an empty feature
-    if (ui->listWidgetReferences->count() == 0) {
+    // Alert user if he created an empty feature (ignore when UseAllEdges)
+    if (ui->listWidgetReferences->count() == 0 && !chamfer->UseAllEdges.getValue()) {
         Base::Console().warning(tr("Empty chamfer created!\n").toStdString().c_str());
     }
 }

--- a/src/Mod/PartDesign/Gui/TaskDefeaturingParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDefeaturingParameters.cpp
@@ -142,8 +142,6 @@ bool TaskDlgDefeaturingParameters::accept()
         getViewObject()->showPreviousFeature(false);
     }
 
-    parameter->apply();
-
     return TaskDlgDressUpParameters::accept();
 }
 

--- a/src/Mod/PartDesign/Gui/TaskDraftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDraftParameters.cpp
@@ -401,8 +401,6 @@ bool TaskDlgDraftParameters::accept()
         getViewObject()->showPreviousFeature(false);
     }
 
-    parameter->apply();
-
     std::vector<std::string> strings;
     App::DocumentObject* obj = nullptr;
     TaskDraftParameters* draftparameter = static_cast<TaskDraftParameters*>(parameter);

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
@@ -200,8 +200,9 @@ void TaskFilletParameters::apply()
 {
     ui->filletRadius->apply();
 
-    // Alert user if he created an empty feature
-    if (ui->listWidgetReferences->count() == 0) {
+    // Alert user if he created an empty feature (ignore when UseAllEdges)
+    auto fillet = getObject<PartDesign::Fillet>();
+    if (ui->listWidgetReferences->count() == 0 && !fillet->UseAllEdges.getValue()) {
         std::string text = tr("Empty fillet created!").toStdString();
         Base::Console().warning("%s\n", text.c_str());
     }

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
@@ -287,8 +287,6 @@ bool TaskDlgFilletParameters::accept()
         getViewObject()->showPreviousFeature(false);
     }
 
-    parameter->apply();
-
     return TaskDlgDressUpParameters::accept();
 }
 

--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.cpp
@@ -335,8 +335,6 @@ bool TaskDlgThicknessParameters::accept()
         getViewObject()->showPreviousFeature(false);
     }
 
-    parameter->apply();
-
     auto draftparameter = dynamic_cast<TaskThicknessParameters*>(parameter);
 
     FCMD_OBJ_CMD(obj, "Value = " << draftparameter->getValue());


### PR DESCRIPTION
Fixes #32425

Problem was with Use all edges checked and an empty base list ok still printed Empty chamfer created! same for fillet even though the feature is fine it also showed up twice because the task dialog only looked at the edge list and ignored UseAllEdges and dressup accept called apply() twice once in the child once again from the parent, so the warning ran twice same leftover apply on draft, thickness, defeaturing

Fix: skip the empty warning when UseAllEdges is on (chamfer + fillet) and drop the extra parameter apply() in those dressup accepts so the parent applies once

Manually verified
AI assistance: Cursor



https://github.com/user-attachments/assets/e8e1dc8d-1642-4b13-b9e6-2ab9b1ab5919

