### PR TITLE
Measure: fix number suffix placed after result value in label

### DIFF
--- a/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
@@ -478,9 +478,8 @@ void ViewProviderMeasureBase::updateData(const App::Property* prop)
         // being appended after the result value.
         std::string userLabel(obj->Label.getValue());
         auto colonPos = userLabel.find(':');
-        std::string name = colonPos != std::string::npos
-            ? userLabel.substr(0, colonPos)
-            : obj->getNameInDocument();
+        std::string name = colonPos != std::string::npos ? userLabel.substr(0, colonPos)
+                                                         : obj->getNameInDocument();
         obj->Label.setValue((name + ": ") + obj->getResultString());
     }
 

--- a/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
@@ -471,9 +471,16 @@ void ViewProviderMeasureBase::updateData(const App::Property* prop)
     if (doUpdate) {
         redrawAnnotation();
 
-        // Update label
+        // Update label with measurement result.
+        // Use the name part before ":" if the label was already formatted,
+        // otherwise fall back to the internal object name (which carries
+        // the unique suffix, e.g. "Length001") to avoid the dedup suffix
+        // being appended after the result value.
         std::string userLabel(obj->Label.getValue());
-        std::string name = userLabel.substr(0, userLabel.find(":"));
+        auto colonPos = userLabel.find(':');
+        std::string name = colonPos != std::string::npos
+            ? userLabel.substr(0, colonPos)
+            : obj->getNameInDocument();
         obj->Label.setValue((name + ": ") + obj->getResultString());
     }
 


### PR DESCRIPTION
When creating duplicate measurements, the uniqueness suffix (e.g. 001) was appended after the full label including the result value, producing "Length: 10.000 mm001" instead of "Length001: 10.000 mm".

The root cause is that addObject sets the initial Label to the name hint ("Length") rather than the unique internal name ("Length001"). When updateData then sets Label to "Length: 10.000 mm", FreeCAD's duplicate label prevention appends the suffix to the end of the whole string.

Fix by falling back to getNameInDocument() when the current Label has not yet been formatted with a colon separator. Once the label contains a colon, the existing extraction logic preserves user renames.

Fixes #32420

Assisted-by: claude-opus-4-6

 [+] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.