### PR TITLE
CAM: SimpleCopy - Add task panel

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Utils.py
+++ b/src/Mod/CAM/Path/Dressup/Utils.py
@@ -1,25 +1,23 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2018 sliptonic <shopinthewoods@gmail.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
 
-# ***************************************************************************
-# *   Copyright (c) 2018 sliptonic <shopinthewoods@gmail.com>               *
-# *                                                                         *
-# *   This program is free software; you can redistribute it and/or modify  *
-# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
-# *   as published by the Free Software Foundation; either version 2 of     *
-# *   the License, or (at your option) any later version.                   *
-# *   for detail see the LICENCE text file.                                 *
-# *                                                                         *
-# *   This program is distributed in the hope that it will be useful,       *
-# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-# *   GNU Library General Public License for more details.                  *
-# *                                                                         *
-# *   You should have received a copy of the GNU Library General Public     *
-# *   License along with this program; if not, write to the Free Software   *
-# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-# *   USA                                                                   *
-# *                                                                         *
-# ***************************************************************************
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
 
 import FreeCAD
 import Path
@@ -63,11 +61,15 @@ def isOp(obj):
     return "Path.Op" in proxy or "Path.Dressup" in proxy
 
 
-def baseOp(path):
-    """baseOp(path) ... return the base operation underlying the given path"""
-    if hasattr(path, "Name") and "Dressup" in path.Name:
-        return baseOp(path.Base)
-    return path
+def baseOp(obj):
+    """baseOp(obj) ... return the base operation underlying the given path object"""
+    if (
+        getattr(obj, "Proxy", None)
+        and obj.Proxy.__module__.startswith("Path.Dressup")
+        and getattr(obj, "Base", None)
+    ):
+        return baseOp(obj.Base)
+    return obj
 
 
 def toolController(path, default=None):

--- a/src/Mod/CAM/Path/Op/Gui/SimpleCopy.py
+++ b/src/Mod/CAM/Path/Op/Gui/SimpleCopy.py
@@ -1,28 +1,27 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2015 Yorik van Havre <yorik@uncreated.net>
+# SPDX-FileNotice: Part of the FreeCAD project.
 
-# ***************************************************************************
-# *   Copyright (c) 2015 Yorik van Havre <yorik@uncreated.net>              *
-# *                                                                         *
-# *   This program is free software; you can redistribute it and/or modify  *
-# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
-# *   as published by the Free Software Foundation; either version 2 of     *
-# *   the License, or (at your option) any later version.                   *
-# *   for detail see the LICENCE text file.                                 *
-# *                                                                         *
-# *   This program is distributed in the hope that it will be useful,       *
-# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-# *   GNU Library General Public License for more details.                  *
-# *                                                                         *
-# *   You should have received a copy of the GNU Library General Public     *
-# *   License along with this program; if not, write to the Free Software   *
-# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-# *   USA                                                                   *
-# *                                                                         *
-# ***************************************************************************
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
 
 import FreeCAD
 import FreeCADGui
+import Path
 from Path.Base.Util import coolantModeForOp
 from Path.Base.Util import toolControllerForOp
 import Path.Dressup.Utils as PathDressup
@@ -33,30 +32,23 @@ __doc__ = """CAM SimpleCopy command"""
 translate = FreeCAD.Qt.translate
 
 
-class ViewProvider:
-
-    def __init__(self, vobj):
-        self.attach(vobj)
-        vobj.Proxy = self
-
-    def attach(self, vobj):
-        self.vobj = vobj
-        self.obj = vobj.Object
-
-    def dumps(self):
-        return None
+class ViewProvider(Path.Op.Gui.Base.ViewProvider):
+    """This class exists to replace ViewProvider of SimpleCopy objects in old documents
+    Should be removed in release 27.3"""
 
     def loads(self, state):
-        return None
+        """Overwrites base class because 'state' is None"""
+        self.OpName = "Custom"
+        self.OpIcon = ":/icons/CAM_Custom.svg"
+        self.OpPageModule = "Path.Op.Gui.Custom"
+        self.OpPageClass = "TaskPanelOpPage"
 
-    def onChanged(self, vobj, prop):
-        return
-
-    def getIcon(self):
-        if self.obj.Active:
-            return ":/icons/CAM_SimpleCopy.svg"
-        else:
-            return ":/icons/CAM_OpActive.svg"
+    def dumps(self):
+        """Overwrites base class
+        Changes ViewProvider and dumps correct 'state'"""
+        res = Path.Op.Gui.Custom.Command.res
+        self.Object.ViewObject.Proxy = Path.Op.Gui.Base.ViewProvider(self.Object.ViewObject, res)
+        return super().dumps()
 
 
 class CommandPathSimpleCopy:
@@ -83,33 +75,24 @@ class CommandPathSimpleCopy:
         if any(coolant != coolantModeForOp(op) for op in selection):
             return False
 
-        toolController = toolControllerForOp(selection[0])
-        if any(toolController != toolControllerForOp(op) for op in selection):
-            return False
-
-        return True
+        tc = toolControllerForOp(selection[0])
+        return all(tc == toolControllerForOp(op) for op in selection)
 
     def Activated(self):
         # check that the selection contains exactly what we want
         FreeCAD.ActiveDocument.openTransaction("Simple Copy")
-        FreeCADGui.doCommand("selection = FreeCADGui.Selection.getSelection()")
-        FreeCADGui.doCommand(
-            "name = selection[0].Name+'_SimpleCopy' if len(selection) == 1 else 'SimpleCopy'"
-        )
-        FreeCADGui.addModule("PathScripts.PathUtils")
-        FreeCADGui.doCommand("job = PathScripts.PathUtils.findParentJob(selection[0])")
-        FreeCADGui.doCommand(
-            "paths = [PathScripts.PathUtils.getPathWithPlacement(sel) for sel in selection]"
-        )
-        FreeCADGui.addModule("Path.Op.Custom")
+        FreeCADGui.doCommand("sel = FreeCADGui.Selection.getSelection()")
+        FreeCADGui.doCommand("name = sel[0].Name+'_SimpleCopy' if len(sel) == 1 else 'SimpleCopy'")
+        FreeCADGui.addModule("PathScripts.PathUtils as PathUtils")
+        FreeCADGui.doCommand("job = PathUtils.findParentJob(sel[0])")
         FreeCADGui.doCommand("obj = Path.Op.Custom.Create(name, parentJob=job)")
+        FreeCADGui.doCommand("res = Path.Op.Gui.Custom.Command.res")
         FreeCADGui.doCommand(
-            "obj.ToolController = Path.Base.Util.toolControllerForOp(selection[0])"
+            "obj.ViewObject.Proxy = Path.Op.Gui.Base.ViewProvider(obj.ViewObject, res)"
         )
-        FreeCADGui.doCommand("obj.CoolantMode = Path.Base.Util.coolantModeForOp(selection[0])")
-        FreeCADGui.doCommand(
-            "obj.ViewObject.Proxy = Path.Op.Gui.SimpleCopy.ViewProvider(obj.ViewObject)"
-        )
+        FreeCADGui.doCommand("obj.ToolController = Path.Base.Util.toolControllerForOp(sel[0])")
+        FreeCADGui.doCommand("obj.CoolantMode = Path.Base.Util.coolantModeForOp(sel[0])")
+        FreeCADGui.doCommand("paths = [PathUtils.getPathWithPlacement(s) for s in sel]")
         FreeCADGui.doCommand("obj.Gcode = [c.toGCode() for path in paths for c in path.Commands]")
         FreeCAD.ActiveDocument.commitTransaction()
         FreeCAD.ActiveDocument.recompute()


### PR DESCRIPTION
### Description

**SimpleCopy** creates **Custom** op, but uses own `ViewProvider`
In result user get behavior of **Custom** op, but without Task panel
Access to parameters and raw gcode only by Property view, which is not convenient

### Changes

- Suggested to create **Custom** op completely 
- `ViewProvider` of old **SimpleCopy** objects replaces while saving document
- make `Path.Dressup.Utils.baseOp()` more robust
  Check Proxy instead of name for dressup
  Needed because simple copy can contains `dressup` in object name

https://github.com/user-attachments/assets/05e4d67c-6b25-424a-996e-9e82cede3a8c