### PR TITLE
GH: skip triage label on typed PRs, add Mod labels, assign tbd milestone

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -40,6 +40,10 @@
 - changed-files:
   - any-glob-to-any-file:  ['src/Mod/Fem/**/*']
 
+"Mod: Inspection":
+- changed-files:
+  - any-glob-to-any-file:  ['src/Mod/Inspection/**/*']
+
 "Mod: Mesh":
 - changed-files:
   - any-glob-to-any-file: ['src/Mod/Mesh/**/*']
@@ -95,6 +99,30 @@
 "Mod: Test":
 - changed-files:
   - any-glob-to-any-file:  ['src/Mod/Test/**/*']
+
+"Mod: Import":
+- changed-files:
+  - any-glob-to-any-file:  ['src/Mod/Import/**/*']
+
+"Mod: Points":
+- changed-files:
+  - any-glob-to-any-file:  ['src/Mod/Points/**/*']
+
+"Mod: Robot":
+- changed-files:
+  - any-glob-to-any-file:  ['src/Mod/Robot/**/*']
+
+"Mod: Show":
+- changed-files:
+  - any-glob-to-any-file:  ['src/Mod/Show/**/*']
+
+"Mod: Web":
+- changed-files:
+  - any-glob-to-any-file:  ['src/Mod/Web/**/*']
+
+"Mod: Help":
+- changed-files:
+  - any-glob-to-any-file:  ['src/Mod/Help/**/*']
 
 # 'Packaging' related labels
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,6 +9,10 @@ on:
   pull_request_target:
     types: [opened, reopened]
 
+concurrency:
+  group: labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
- Status: Needs triage is no longer added when the pull request already carries Type: Bug, Type: Feature or Type: Other at creation time
- Added missing Mod Labels (e.g. Mod: Inspection) to.github/labels.yml 
- New step assigns the open milestone **tbd** to every pull request