### PR TITLE
Sketcher: Fix Cancelling Sketcher B-spline creation tools leaves behind

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -407,7 +407,8 @@ void DrawSketchHandler::deactivate()
 {
     // Some tools (bspline for instance) may get exited while a transaction is still opened.
     // Exiting should abort any opened transaction.
-    // The following recompute is needed else we have acces violation because preselection still referenced the removed bspline points.
+    // The following recompute is needed else we have acces violation because preselection still
+    // referenced the removed bspline points.
     abortCommand();
     tryAutoRecomputeIfNotSolve(sketchgui->getSketchObject());
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -405,6 +405,12 @@ void DrawSketchHandler::setSketchGui(ViewProviderSketch* vp)
 
 void DrawSketchHandler::deactivate()
 {
+    // Some tools (bspline for instance) may get exited while a transaction is still opened.
+    // Exiting should abort any opened transaction.
+    // The following recompute is needed else we have acces violation because preselection still referenced the removed bspline points.
+    abortCommand();
+    tryAutoRecomputeIfNotSolve(sketchgui->getSketchObject());
+
     Gui::ToolHandler::deactivate();
     ViewProviderSketchDrawSketchHandlerAttorney::setOriginPointMarker(*sketchgui, false);
     ViewProviderSketchDrawSketchHandlerAttorney::setConstraintSelectability(*sketchgui, true);


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/12473

Bspline is the only tool that has a pending transaction. So when the tool got dismissed in the middle of a bspline creation, the added circles were left over.

To fix that, we make sure to close any opened unfinished transaction when the tool is deactivated.