### PR TITLE
Sketcher: Fix Constraint coincident tool gives error

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -5159,12 +5159,26 @@ bool CmdSketcherConstrainCoincidentUnified::isCoincidentSelectionValid(SketchObj
 {
     // check if this coincidence is already enforced (even indirectly)
     bool constraintExists = obj->arePointsCoincident(GeoId1, PosId1, GeoId2, PosId2);
-    bool sameGeo = GeoId1 == GeoId2;
+    if (constraintExists) {
+        return false;
+    }
 
-    const Part::Geometry* geo = obj->getGeometry(GeoId1);
-    bool isBSpline = geo && geo->is<Part::GeomBSplineCurve>();
+    auto firstPoints = obj->getAllCoincidentPoints(GeoId1, PosId1);
+    auto secondPoints = obj->getAllCoincidentPoints(GeoId2, PosId2);
+    firstPoints.emplace(GeoId1, PosId1);
+    secondPoints.emplace(GeoId2, PosId2);
 
-    return !constraintExists && (!sameGeo || isBSpline);
+    // Joining the groups must not collapse an element, even when its endpoints
+    // are selected through coincident points belonging to other elements.
+    for (const auto& [geoId, posId] : firstPoints) {
+        if (secondPoints.contains(geoId)) {
+            const Part::Geometry* geo = obj->getGeometry(geoId);
+            if (!geo || !geo->is<Part::GeomBSplineCurve>()) {
+                return false;
+            }
+        }
+    }
+    return true;
 }
 
 // ======================================================================================


### PR DESCRIPTION
Fix #20771

https://github.com/FreeCAD/FreeCAD/pull/25304 made such a shield, but it worked only if the selected points where of the same line.
But in the given example in 20771 the user used a rectangle. In that case selecting the rectangle corners may not be on the same line.

So the fix is to make the guard check coincident groups.