### PR TITLE
Sketcher: Fix sketch recompute does not honor configured Sketcher default solver

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -194,6 +194,19 @@ short SketchObject::mustExecute() const
     return Part2DObject::mustExecute();
 }
 
+namespace {
+GCS::Algorithm getDefaultSolver()
+{
+    auto preferences = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Sketcher/SolverAdvanced");
+    int solver = preferences->GetInt("DefaultSolver", GCS::DogLeg);
+    if (solver < GCS::BFGS || solver > GCS::DogLeg) {
+        throw Base::ValueError("Invalid Sketcher DefaultSolver preference: expected a value from 0 to 2");
+    }
+    return static_cast<GCS::Algorithm>(solver);
+}
+} // namespace
+
 App::DocumentObjectExecReturn* SketchObject::execute()
 {
     try {
@@ -219,11 +232,12 @@ App::DocumentObjectExecReturn* SketchObject::execute()
         //  delConstraintsToExternal();
     }
 
-    auto solverPreferences = App::GetApplication().GetParameterGroupByPath(
-        "User parameter:BaseApp/Preferences/Mod/Sketcher/SolverAdvanced");
-    int defaultSolver = solverPreferences->GetInt("DefaultSolver", GCS::DogLeg);
-    solvedSketch.defaultSolver = defaultSolver >= GCS::BFGS && defaultSolver <= GCS::DogLeg
-        ? static_cast<GCS::Algorithm>(defaultSolver) : GCS::DogLeg;
+    try {
+        solvedSketch.defaultSolver = getDefaultSolver();
+    }
+    catch (const Base::Exception& e) {
+        return new App::DocumentObjectExecReturn(e.what(), this);
+    }
 
     // This includes a regular solve including full geometry update, except when an error
     // ensues

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -219,6 +219,12 @@ App::DocumentObjectExecReturn* SketchObject::execute()
         //  delConstraintsToExternal();
     }
 
+    auto solverPreferences = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Sketcher/SolverAdvanced");
+    int defaultSolver = solverPreferences->GetInt("DefaultSolver", GCS::DogLeg);
+    solvedSketch.defaultSolver = defaultSolver >= GCS::BFGS && defaultSolver <= GCS::DogLeg
+        ? static_cast<GCS::Algorithm>(defaultSolver) : GCS::DogLeg;
+
     // This includes a regular solve including full geometry update, except when an error
     // ensues
     std::string msg;


### PR DESCRIPTION
Fix #6739

by applying the default solver before solving. This way if user changed it it will be picked up.