### PR TITLE
Gui: fix Initiate Dragging (T,D) for Tree View

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -3464,14 +3464,11 @@ StdTreeDrag::StdTreeDrag()
 
 void StdTreeDrag::activated(int)
 {
-    if (Gui::Selection().hasSelection()) {
-        const auto trees = getMainWindow()->findChildren<TreeWidget*>();
-        for (auto tree : trees) {
-            if (tree->isVisible()) {
-                tree->startDragging();
-                break;
-            }
-        }
+    if (!Gui::Selection().hasSelection()) {
+        return;
+    }
+    if (auto* tree = TreeWidget::getTreeForSelection()) {
+        tree->startDragging();
     }
 }
 

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -1395,6 +1395,7 @@ void TreeWidget::contextMenuEvent(QContextMenuEvent* e)
 
 void TreeWidget::hideEvent(QHideEvent* ev)
 {
+    clearKeyboardDragPending();
     QTreeWidget::hideEvent(ev);
 }
 
@@ -1944,6 +1945,11 @@ bool isTreeViewDragging()
 
 void TreeWidget::keyPressEvent(QKeyEvent* event)
 {
+    if (event->key() == Qt::Key_Escape && keyboardDragPending) {
+        clearKeyboardDragPending();
+        event->accept();
+        return;
+    }
     if (event->matches(QKeySequence::Find)) {
         event->accept();
         onSearchObjects();
@@ -2014,6 +2020,18 @@ void TreeWidget::keyPressEvent(QKeyEvent* event)
 
 void TreeWidget::mousePressEvent(QMouseEvent* event)
 {
+    if (keyboardDragPending && event->button() == Qt::LeftButton) {
+        clearKeyboardDragPending();
+        if (state() == NoState && !selectedItems().empty()) {
+            setState(DraggingState);
+            startDrag(model()->supportedDragActions());
+            setState(NoState);
+            stopAutoScroll();
+            event->accept();
+            return;
+        }
+    }
+
     expandIndicatorPressed = false;
     visibilityIconPressed = false;
     if (isVisibilityIconEnabled()) {
@@ -2186,12 +2204,29 @@ void TreeWidget::mouseDoubleClickEvent(QMouseEvent* event)
     }
 }
 
+void TreeWidget::clearKeyboardDragPending()
+{
+    if (!keyboardDragPending) {
+        return;
+    }
+    keyboardDragPending = false;
+    viewport()->unsetCursor();
+}
+
 void TreeWidget::startDragging()
 {
     if (state() != NoState) {
         return;
     }
     if (selectedItems().empty()) {
+        return;
+    }
+
+    // Native DnD (macOS/Windows) needs a real mouse-down. Arm on T,D and start on next LMB.
+    if (!(QApplication::mouseButtons() & Qt::LeftButton)) {
+        keyboardDragPending = true;
+        viewport()->setCursor(Qt::ClosedHandCursor);
+        setFocus(Qt::ShortcutFocusReason);
         return;
     }
 

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -131,6 +131,8 @@ public:
 
     void startDragging();
 
+    static TreeWidget* getTreeForSelection();
+
     void resetItemSearch();
     void startItemSearch(QLineEdit*);
     void itemSearch(const QString& text, bool select);
@@ -200,6 +202,7 @@ protected:
 
 private:
     void _updateStatus(bool delay = true);
+    void clearKeyboardDragPending();
 
     // Helpers for the two-stage "Select All" feature
     void selectGroupItems(const QTreeWidgetItem* group, bool recursive);
@@ -265,7 +268,6 @@ private:
 
     bool CheckForDependents();
     void addDependentToSelection(App::Document* doc, App::DocumentObject* docObject);
-    static TreeWidget* getTreeForSelection();
 
 private:
     QAction* createGroupAction;
@@ -300,6 +302,8 @@ private:
 
     bool expandIndicatorPressed = false;
     bool visibilityIconPressed = false;
+    // Armed by Std_TreeDrag (T,D) when no mouse button is down; real QDrag starts on next LMB.
+    bool keyboardDragPending = false;
 
     static std::unique_ptr<QPixmap> documentPixmap;
     static std::unique_ptr<QPixmap> documentPartialPixmap;


### PR DESCRIPTION
Fixes #32444

Problem was that Initiate Dragging (T,D) did nothing in the tree view manual mouse drag still worked action was enabled, cursor never changed, click just selected the target

Cause: Std_TreeDrag called QDrag right on the keypress native DnD on macOS/Windows needs a real mouse-down so exec() returned immediately and nothing happened same leftover as the old menu initiate dragging doesn’t work on windows wiki note

Arm a pending drag on T,D  then start QDrag on the next left click in the tree also route through getTreeForSelection() so tree selection stays in syncs normal click-drag path untouched

Took AI assistance: Cursor
Manually verified

https://github.com/user-attachments/assets/0b12a7c7-a673-481d-9cdb-6816e7f23680

