### PR TITLE
Gui: QuantitySpinbox : Fix order in openFormulaDialog

### DIFF
--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -761,6 +761,8 @@ void QuantitySpinBox::openFormulaDialog()
 {
     Q_ASSERT(isBound());
 
+    Q_EMIT showFormulaDialog(true);
+
     Q_D(const QuantitySpinBox);
     auto box = new Gui::Dialog::DlgExpressionInput(getPath(), getExpression(), d->unit, this);
     if (d->checkRangeInExpression) {
@@ -783,8 +785,6 @@ void QuantitySpinBox::openFormulaDialog()
     QPoint pos = mapToGlobal(QPoint(0, 0));
     box->move(pos - box->expressionPosition());
     Gui::adjustDialogPosition(box);
-
-    Q_EMIT showFormulaDialog(true);
 }
 
 void QuantitySpinBox::handlePendingEmit(bool updateUnit /* = true */)


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/11145

The problem was the order inside `QuantitySpinBox::openFormulaDialog()`:
1. Construct the expression dialog. Its constructor immediately validates the current value.
2. Emit showFormulaDialog(true).
3. Sketcher receives that signal and switches the reference constraint to driving.
Validation therefore ran while the constraint was still reference, producing the error. Changing it afterward didn’t refresh that initial result.
The fix emits the signal before constructing the dialog. Sketcher switches the constraint first, then validation succeeds.