### PR TITLE
Spreadsheet: preserve numeric precision on save

### DIFF
--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -1315,17 +1315,14 @@ void NumberExpression::negate()
     setQuantity(-getQuantity());
 }
 
-void NumberExpression::_toString(std::ostream &ss, bool,int) const
+void NumberExpression::_toString(std::ostream &ss, bool persistent, int) const
 {
-    // Restore the old implementation because using digits10 + 2 causes
-    // undesired side-effects:
-    // https://forum.freecad.org/viewtopic.php?f=3&t=44057&p=375882#p375882
-    // See also:
-    // https://en.cppreference.com/w/cpp/types/numeric_limits/digits10
-    // https://en.cppreference.com/w/cpp/types/numeric_limits/max_digits10
-    // https://www.boost.org/doc/libs/1_63_0/libs/multiprecision/doc/html/boost_multiprecision/tut/limits/constants.html
+    // Keep the displayed form compact, but preserve the exact value when
+    // serializing expressions so parsing it restores the same double.
     boost::io::ios_flags_saver ifs(ss);
-    ss << std::setprecision(std::numeric_limits<double>::digits10) << getValue();
+    const int precision = persistent ? std::numeric_limits<double>::max_digits10
+                                     : std::numeric_limits<double>::digits10;
+    ss << std::setprecision(precision) << getValue();
 
     /* Trim of any extra spaces */
     //while (s.size() > 0 && s[s.size() - 1] == ' ')

--- a/src/Mod/Spreadsheet/App/Cell.cpp
+++ b/src/Mod/Spreadsheet/App/Cell.cpp
@@ -260,7 +260,7 @@ bool Cell::getStringContent(std::string& s, bool persistent) const
             s = "=" + expression->toString();
         }
         else if (freecad_cast<App::NumberExpression*>(expression.get())) {
-            s = expression->toString();
+            s = expression->toString(persistent);
         }
         else {
             s = "=" + expression->toString(persistent);

--- a/src/Mod/Spreadsheet/TestSpreadsheet.py
+++ b/src/Mod/Spreadsheet/TestSpreadsheet.py
@@ -719,6 +719,48 @@ class SpreadsheetCases(unittest.TestCase):
     def tearDown(self):
         FreeCAD.closeDocument(self.doc.Name)
 
+    def testNumericLiteralIsStableAcrossSaveRestore(self):
+        """Numeric literals retain their value and type across save and restore."""
+        sheet = self.doc.addObject("Spreadsheet::Sheet", "Spreadsheet")
+        values = {
+            "A1": "9030000.000000002",
+            "A2": "1.23456789e-9",
+            "A3": "1.234567891234567",
+            "A4": "42",
+        }
+        for address, value in values.items():
+            sheet.set(address, value)
+        self.doc.recompute()
+
+        contents_before = {address: sheet.getContents(address) for address in values}
+        values_before = {address: sheet.get(address) for address in values}
+        types_before = {address: sheet.getTypeIdOfProperty(address) for address in values}
+        self.assertEqual(values_before["A1"], float(values["A1"]))
+        self.assertEqual(types_before["A1"], "App::PropertyFloat")
+        self.assertEqual(types_before["A2"], "App::PropertyFloat")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = os.path.join(temp_dir, "numeric-literals.FCStd")
+            self.doc.saveAs(path)
+            FreeCAD.closeDocument(self.doc.Name)
+            self.doc = FreeCAD.openDocument(path)
+
+        sheet = self.doc.getObject("Spreadsheet")
+        self.assertEqual(
+            {address: sheet.getContents(address) for address in values},
+            contents_before,
+        )
+        self.assertEqual(
+            {address: sheet.get(address) for address in values},
+            values_before,
+        )
+        self.assertEqual(
+            {address: sheet.getTypeIdOfProperty(address) for address in values},
+            types_before,
+        )
+        self.assertEqual(sheet.getContents("A1"), "9030000")
+        self.assertEqual(sheet.getContents("A2"), "1.23456789e-09")
+
     def testRelationalOperators(self):
         """Test relational operators"""
         sheet = self.doc.addObject("Spreadsheet::Sheet", "Spreadsheet")

--- a/tests/src/App/Expression.cpp
+++ b/tests/src/App/Expression.cpp
@@ -313,6 +313,14 @@ TEST_F(Expression, toString)
     EXPECT_EQ(expr.toString(), "pi rad");
 }
 
+TEST_F(Expression, numberToStringUsesRoundTripPrecisionForPersistence)
+{
+    App::NumberExpression expr{nullptr, Base::Quantity{9030000.000000002}};
+
+    EXPECT_EQ(expr.toString(), "9030000");
+    EXPECT_EQ(std::stod(expr.toString(true)), expr.getValue());
+}
+
 TEST_F(Expression, test_pi_rad)
 {
     auto constant = std::make_unique<App::ConstantExpression>(nullptr, "pi");


### PR DESCRIPTION
Fixes #32097

This fixes Spreadsheet numeric values changing after saving and reopening a document.

Numeric expressions now use enough precision to restore the exact same `double` when written to a document. The normal displayed value remains compact, so this does not bring the extra floating-point digits into the Spreadsheet UI.

The Spreadsheet serialization path now also passes through the persistent formatting flag for plain numeric cells.

## Why

The earlier approach discussed in https://github.com/FreeCAD/FreeCAD/pull/32113 made the in-memory value match the shortened serialized value. That prevented it from changing after reopening, but it also meant precision was discarded as soon as a value was entered.

This keeps the original value instead and fixes the serialization side of the problem.

For example, `9030000.000000002` remains a floating-point value before and after saving, while its normal displayed form remains `9030000`.

## Tests

Added tests covering:

- Exact numeric round trips through persistent expression formatting
- Compact display formatting
- Spreadsheet values, contents, and property types across save and reopen

