### PR TITLE
BIM: Add IFC summary and use it for import dialog

### DIFF
--- a/src/Mod/BIM/CMakeLists.txt
+++ b/src/Mod/BIM/CMakeLists.txt
@@ -218,6 +218,7 @@ SET(nativeifc_SRCS
     nativeifc/ifc_psets.py
     nativeifc/ifc_selftest.py
     nativeifc/ifc_status.py
+    nativeifc/ifc_summary.py
     nativeifc/ifc_tools.py
     nativeifc/ifc_tree.py
     nativeifc/ifc_viewproviders.py

--- a/src/Mod/BIM/Resources/ui/dialogImport.ui
+++ b/src/Mod/BIM/Resources/ui/dialogImport.ui
@@ -6,14 +6,261 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>551</width>
-    <height>340</height>
+    <width>600</width>
+    <height>600</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>IFC Import Options</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="groupSummary">
+     <property name="title">
+      <string>IFC file content summary</string>
+     </property>
+     <layout class="QFormLayout" name="summaryLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelSummaryFile">
+        <property name="text">
+         <string>File:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="summaryFile">
+        <property name="text">
+         <string>—</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="labelSummarySize">
+        <property name="text">
+         <string>Size:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="summarySize">
+        <property name="text">
+         <string>—</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="labelSummaryCreated">
+        <property name="text">
+         <string>Created:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="summaryCreated">
+        <property name="text">
+         <string>—</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="labelSummaryModified">
+        <property name="text">
+         <string>Modified:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLabel" name="summaryModified">
+        <property name="text">
+         <string>—</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="labelSummarySchema">
+        <property name="text">
+         <string>Schema:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QLabel" name="summarySchema">
+        <property name="text">
+         <string>—</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="labelSummaryProjects">
+        <property name="text">
+         <string>Projects:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QLabel" name="summaryProjects">
+        <property name="text">
+         <string>—</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="labelSummarySites">
+        <property name="text">
+         <string>Sites:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QLabel" name="summarySites">
+        <property name="text">
+         <string>—</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="labelSummaryBuildings">
+        <property name="text">
+         <string>Buildings:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="QLabel" name="summaryBuildings">
+        <property name="text">
+         <string>—</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="labelSummaryStoreys">
+        <property name="text">
+         <string>Storeys:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <widget class="QLabel" name="summaryStoreys">
+        <property name="text">
+         <string>—</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0">
+       <widget class="QLabel" name="labelSummaryProducts">
+        <property name="text">
+         <string>Products:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="1">
+       <widget class="QLabel" name="summaryProducts">
+        <property name="text">
+         <string>—</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="0">
+       <widget class="QLabel" name="labelSummaryTypes">
+        <property name="text">
+         <string>Types:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="1">
+       <widget class="QLabel" name="summaryTypes">
+        <property name="text">
+         <string>—</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="11" column="0">
+       <widget class="QLabel" name="labelSummaryPropertySets">
+        <property name="text">
+         <string>Property sets:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="11" column="1">
+       <widget class="QLabel" name="summaryPropertySets">
+        <property name="text">
+         <string>—</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="0">
+       <widget class="QLabel" name="labelSummaryMaterials">
+        <property name="text">
+         <string>Materials:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="1">
+       <widget class="QLabel" name="summaryMaterials">
+        <property name="text">
+         <string>—</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="13" column="0">
+       <widget class="QLabel" name="labelSummaryLayers">
+        <property name="text">
+         <string>Layers:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="13" column="1">
+       <widget class="QLabel" name="summaryLayers">
+        <property name="text">
+         <string>—</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item>
     <layout class="QGridLayout" name="gridLayout">
      <item row="1" column="1">

--- a/src/Mod/BIM/Resources/ui/dialogImport.ui
+++ b/src/Mod/BIM/Resources/ui/dialogImport.ui
@@ -17,13 +17,13 @@
    <item>
     <widget class="QGroupBox" name="groupSummary">
      <property name="title">
-      <string>IFC file content summary</string>
+      <string>IFC File Content Summary</string>
      </property>
      <layout class="QFormLayout" name="summaryLayout">
       <item row="0" column="0">
        <widget class="QLabel" name="labelSummaryFile">
         <property name="text">
-         <string>File:</string>
+         <string>File</string>
         </property>
        </widget>
       </item>
@@ -40,7 +40,7 @@
       <item row="1" column="0">
        <widget class="QLabel" name="labelSummarySize">
         <property name="text">
-         <string>Size:</string>
+         <string>Size</string>
         </property>
        </widget>
       </item>
@@ -57,7 +57,7 @@
       <item row="2" column="0">
        <widget class="QLabel" name="labelSummaryCreated">
         <property name="text">
-         <string>Created:</string>
+         <string>Created</string>
         </property>
        </widget>
       </item>
@@ -74,7 +74,7 @@
       <item row="3" column="0">
        <widget class="QLabel" name="labelSummaryModified">
         <property name="text">
-         <string>Modified:</string>
+         <string>Modified</string>
         </property>
        </widget>
       </item>
@@ -91,7 +91,7 @@
       <item row="4" column="0">
        <widget class="QLabel" name="labelSummarySchema">
         <property name="text">
-         <string>Schema:</string>
+         <string>Schema</string>
         </property>
        </widget>
       </item>
@@ -108,7 +108,7 @@
       <item row="5" column="0">
        <widget class="QLabel" name="labelSummaryProjects">
         <property name="text">
-         <string>Projects:</string>
+         <string>Projects</string>
         </property>
        </widget>
       </item>
@@ -125,7 +125,7 @@
       <item row="6" column="0">
        <widget class="QLabel" name="labelSummarySites">
         <property name="text">
-         <string>Sites:</string>
+         <string>Sites</string>
         </property>
        </widget>
       </item>
@@ -142,7 +142,7 @@
       <item row="7" column="0">
        <widget class="QLabel" name="labelSummaryBuildings">
         <property name="text">
-         <string>Buildings:</string>
+         <string>Buildings</string>
         </property>
        </widget>
       </item>
@@ -159,7 +159,7 @@
       <item row="8" column="0">
        <widget class="QLabel" name="labelSummaryStoreys">
         <property name="text">
-         <string>Storeys:</string>
+         <string>Storeys</string>
         </property>
        </widget>
       </item>
@@ -176,7 +176,7 @@
       <item row="9" column="0">
        <widget class="QLabel" name="labelSummaryProducts">
         <property name="text">
-         <string>Products:</string>
+         <string>Products</string>
         </property>
        </widget>
       </item>
@@ -193,7 +193,7 @@
       <item row="10" column="0">
        <widget class="QLabel" name="labelSummaryTypes">
         <property name="text">
-         <string>Types:</string>
+         <string>Types</string>
         </property>
        </widget>
       </item>
@@ -210,7 +210,7 @@
       <item row="11" column="0">
        <widget class="QLabel" name="labelSummaryPropertySets">
         <property name="text">
-         <string>Property sets:</string>
+         <string>Property sets</string>
         </property>
        </widget>
       </item>
@@ -227,7 +227,7 @@
       <item row="12" column="0">
        <widget class="QLabel" name="labelSummaryMaterials">
         <property name="text">
-         <string>Materials:</string>
+         <string>Materials</string>
         </property>
        </widget>
       </item>
@@ -244,7 +244,7 @@
       <item row="13" column="0">
        <widget class="QLabel" name="labelSummaryLayers">
         <property name="text">
-         <string>Layers:</string>
+         <string>Layers</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/BIM/nativeifc/ifc_import.py
+++ b/src/Mod/BIM/nativeifc/ifc_import.py
@@ -24,6 +24,7 @@
 
 import os
 import time
+from datetime import datetime
 
 import FreeCAD
 
@@ -32,6 +33,7 @@ from . import ifc_psets
 from . import ifc_materials
 from . import ifc_layers
 from . import ifc_status
+from . import ifc_summary
 from . import ifc_types
 
 if FreeCAD.GuiUp:
@@ -40,6 +42,9 @@ if FreeCAD.GuiUp:
 
 
 PARAMS = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/NativeIFC")
+
+
+translate = FreeCAD.Qt.translate
 
 
 def open(filename):
@@ -75,7 +80,7 @@ def insert(
 
     from PySide import QtCore  # lazy loading
 
-    strategy, shapemode, switchwb = get_options(strategy, shapemode, switchwb, silent)
+    strategy, shapemode, switchwb = get_options(filename, strategy, shapemode, switchwb, silent)
     if strategy is None:
         print("Aborted.")
         return
@@ -122,15 +127,154 @@ def insert(
     return document
 
 
-def get_options(strategy=None, shapemode=None, switchwb=None, silent=False):
-    """Shows a dialog to get import options
+if FreeCAD.GuiUp:
+    from PySide import QtCore
 
-    shapemode: 0 = full shape
-               1 = coin only
-               2 = no representation
-    strategy:  0 = only root object
-               1 = only bbuilding structure,
-               2 = all children
+    _SUMMARY_WORKERS = set()
+
+    class _IfcSummaryWorker(QtCore.QThread):
+        """Background worker generating IFC summary."""
+
+        summary_metadata = QtCore.Signal(str, int, str, float)
+        summary_update = QtCore.Signal(str, object)
+        summary_failed = QtCore.Signal(str)
+
+        def __init__(self, filename):
+            super().__init__()
+            self.filename = filename
+
+        def run(self):
+            try:
+                ifc_summary.get_summary(
+                    self.filename,
+                    metadata=self.summary_metadata.emit,
+                    update=self.summary_update.emit,
+                    cancelled=self.isInterruptionRequested,
+                )
+            except InterruptedError:
+                return
+            except Exception as error:
+                if not self.isInterruptionRequested():
+                    self.summary_failed.emit(f"{type(error).__name__}: {error}")
+
+    class _IfcSummaryReceiver(QtCore.QObject):
+        """IFC summary receiver to update dialog."""
+
+        def __init__(self, dialog):
+            super().__init__(dialog)
+            self.dialog = dialog
+
+        @QtCore.Slot(str, int, str, float)
+        def metadata(self, filename, file_size, created, modified):
+            _summary_metadata(self.dialog, filename, file_size, created, modified)
+
+        @QtCore.Slot(str, object)
+        def update(self, name, value):
+            _summary_update(self.dialog, name, value)
+
+        @QtCore.Slot(str)
+        def failed(self, message):
+            _summary_failed(self.dialog, message)
+
+
+def _summary_metadata(dialog, filename, file_size, created, modified):
+    """IFC summary metadata on dialog."""
+
+    dialog.summaryFile.setText(filename or "—")
+    dialog.summarySize.setText(f"{file_size / (1024 * 1024):.1f} MB" if file_size else "—")
+    dialog.summaryCreated.setText(created.replace("T", " ") if created else "—")
+    dialog.summaryModified.setText(
+        datetime.fromtimestamp(modified).strftime("%Y-%m-%d %H:%M:%S") if modified else "—"
+    )
+
+
+def _summary_update(dialog, name, value):
+    """IFC summary fields displayed on dialog as they become available."""
+
+    labels = {
+        "schema": dialog.summarySchema,
+        "projects": dialog.summaryProjects,
+        "sites": dialog.summarySites,
+        "buildings": dialog.summaryBuildings,
+        "storeys": dialog.summaryStoreys,
+        "products": dialog.summaryProducts,
+        "types": dialog.summaryTypes,
+        "property_sets": dialog.summaryPropertySets,
+        "materials": dialog.summaryMaterials,
+        "layers": dialog.summaryLayers,
+    }
+
+    label = labels.get(name)
+
+    if label is None:
+        return
+
+    if name == "schema":
+        label.setText(str(value) if value else "—")
+    else:
+        label.setText(f"{int(value):,}")
+
+
+def _summary_failed(dialog, message):
+    """Non-blocking IFC summary failure."""
+
+    dialog.groupSummary.setTitle(translate("BIM", "IFC file content summary — Unable to read"))
+    dialog.groupSummary.setToolTip(message)
+
+    # Keep already available file metadata visible.
+    # Clear only incomplete content values.
+    for name in (
+        "summarySchema",
+        "summaryProjects",
+        "summarySites",
+        "summaryBuildings",
+        "summaryStoreys",
+        "summaryProducts",
+        "summaryTypes",
+        "summaryPropertySets",
+        "summaryMaterials",
+        "summaryLayers",
+    ):
+        getattr(dialog, name).setText("—")
+
+    FreeCAD.Console.PrintError(f"BIM IFC import summary failure: {message}\n")
+
+
+def _summary_finished(dialog):
+    """Mark summary as ready."""
+
+    if not getattr(dialog, "summary_worker", None):
+        return
+
+    dialog.groupSummary.setTitle(translate("BIM", "IFC file content summary"))
+
+
+def get_options(filename=None, strategy=None, shapemode=None, switchwb=None, silent=False):
+    """Show a dialog to get IFC import options.
+
+    Parameters
+    ----------
+    filename : str, optional
+        IFC file path used to display file content summary.
+    strategy : int, optional
+        Import strategy.
+            0 = only root object
+            1 = only building structure
+            2 = all children
+    shapemode : int, optional
+        Shape loading mode.
+            0 = full shape
+            1 = coin only
+            2 = no representation
+    switchwb : bool, optional
+        Whether to switch to BIM workbench after import.
+    silent : bool, optional
+        Skip the dialog.
+
+    Returns
+    -------
+    tuple
+        Import strategy, shape mode, and workbench switch setting.
     """
 
     psets = PARAMS.GetBool("LoadPsets", False)
@@ -149,6 +293,7 @@ def get_options(strategy=None, shapemode=None, switchwb=None, silent=False):
     ask = PARAMS.GetBool("AskAgain", True)
     if ask and FreeCAD.GuiUp:
         import FreeCADGui
+        from PySide import QtCore, QtGui
 
         dlg = FreeCADGui.PySideUic.loadUi(":/ui/dialogImport.ui")
         dlg.checkSwitchWB.hide()  # TODO see what to do with this...
@@ -162,10 +307,53 @@ def get_options(strategy=None, shapemode=None, switchwb=None, silent=False):
         dlg.checkLoadLayers.setChecked(layers)
         dlg.comboSingleDoc.setCurrentIndex(1 - int(singledoc))
 
-        from PySide import QtCore, QtGui
+        if filename:
+            dlg.groupSummary.setTitle(
+                translate("BIM", "IFC file content summary — Reading IFC file…")
+            )
+
+            summary_worker = _IfcSummaryWorker(filename)
+            summary_receiver = _IfcSummaryReceiver(dlg)
+
+            summary_worker.summary_metadata.connect(summary_receiver.metadata)
+            summary_worker.summary_update.connect(summary_receiver.update)
+            summary_worker.summary_failed.connect(summary_receiver.failed)
+
+            summary_worker.finished.connect(lambda: _summary_finished(dlg))
+
+            def _cleanup_worker():
+                _SUMMARY_WORKERS.discard(summary_worker)
+
+                if getattr(dlg, "summary_worker", None) is summary_worker:
+                    dlg.summary_worker = None
+
+                summary_worker.deleteLater()
+
+            summary_worker.finished.connect(_cleanup_worker)
+
+            _SUMMARY_WORKERS.add(summary_worker)
+
+            # Keep explicit references for dialog lifetime.
+            dlg.summary_worker = summary_worker
+            dlg.summary_receiver = summary_receiver
+
+            summary_worker.start()
+
+        else:
+            dlg.groupSummary.setTitle(
+                translate("BIM", "IFC file content summary — No IFC file selected")
+            )
+
+        def stop_summary_worker():
+            worker = getattr(dlg, "summary_worker", None)
+
+            if worker is not None and worker.isRunning():
+                worker.requestInterruption()
+                dlg.summary_worker = None
 
         QtGui.QApplication.setOverrideCursor(QtCore.Qt.ArrowCursor)
         result = dlg.exec_()
+        stop_summary_worker()
         QtGui.QApplication.restoreOverrideCursor()
 
         if not result:

--- a/src/Mod/BIM/nativeifc/ifc_import.py
+++ b/src/Mod/BIM/nativeifc/ifc_import.py
@@ -218,7 +218,9 @@ def _summary_update(dialog, name, value):
 def _summary_failed(dialog, message):
     """Non-blocking IFC summary failure."""
 
-    dialog.groupSummary.setTitle(translate("BIM", "IFC file content summary — Unable to read"))
+    dialog.groupSummary.setTitle(
+        translate("BIM", "IFC File Content Summary (unable to read file)")
+    )
     dialog.groupSummary.setToolTip(message)
 
     # Keep already available file metadata visible.
@@ -246,7 +248,7 @@ def _summary_finished(dialog):
     if not getattr(dialog, "summary_worker", None):
         return
 
-    dialog.groupSummary.setTitle(translate("BIM", "IFC file content summary"))
+    dialog.groupSummary.setTitle(translate("BIM", "IFC File Content Summary"))
 
 
 def get_options(filename=None, strategy=None, shapemode=None, switchwb=None, silent=False):
@@ -309,7 +311,7 @@ def get_options(filename=None, strategy=None, shapemode=None, switchwb=None, sil
 
         if filename:
             dlg.groupSummary.setTitle(
-                translate("BIM", "IFC file content summary — Reading IFC file…")
+                translate("BIM", "IFC File Content Summary (reading file…)")
             )
 
             summary_worker = _IfcSummaryWorker(filename)
@@ -341,7 +343,7 @@ def get_options(filename=None, strategy=None, shapemode=None, switchwb=None, sil
 
         else:
             dlg.groupSummary.setTitle(
-                translate("BIM", "IFC file content summary — No IFC file selected")
+                translate("BIM", "IFC File Content Summary (no file selected)")
             )
 
         def stop_summary_worker():

--- a/src/Mod/BIM/nativeifc/ifc_import.py
+++ b/src/Mod/BIM/nativeifc/ifc_import.py
@@ -218,9 +218,7 @@ def _summary_update(dialog, name, value):
 def _summary_failed(dialog, message):
     """Non-blocking IFC summary failure."""
 
-    dialog.groupSummary.setTitle(
-        translate("BIM", "IFC File Content Summary (unable to read file)")
-    )
+    dialog.groupSummary.setTitle(translate("BIM", "IFC File Content Summary (unable to read file)"))
     dialog.groupSummary.setToolTip(message)
 
     # Keep already available file metadata visible.
@@ -310,9 +308,7 @@ def get_options(filename=None, strategy=None, shapemode=None, switchwb=None, sil
         dlg.comboSingleDoc.setCurrentIndex(1 - int(singledoc))
 
         if filename:
-            dlg.groupSummary.setTitle(
-                translate("BIM", "IFC File Content Summary (reading file…)")
-            )
+            dlg.groupSummary.setTitle(translate("BIM", "IFC File Content Summary (reading file…)"))
 
             summary_worker = _IfcSummaryWorker(filename)
             summary_receiver = _IfcSummaryReceiver(dlg)

--- a/src/Mod/BIM/nativeifc/ifc_summary.py
+++ b/src/Mod/BIM/nativeifc/ifc_summary.py
@@ -1,0 +1,260 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 FreeCAD contributors
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+
+"""IFC file content summary utility.
+
+Extracts basic metadata and entity counts from IFC files
+without loading geometry or traversing object relationships.
+Intended for quick overview of IFC file content in UI such as import/export dialogs.
+"""
+
+from __future__ import annotations
+
+import os
+import time  # TODO: remove before merge
+
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+@dataclass(frozen=True)
+class _SummaryField:
+    """IFC summary field definition."""
+
+    name: str
+    entity: str | None = None
+
+
+_SUMMARY_FIELDS: tuple[_SummaryField, ...] = (
+    _SummaryField("schema"),
+    _SummaryField("projects", "IfcProject"),
+    _SummaryField("sites", "IfcSite"),
+    _SummaryField("buildings", "IfcBuilding"),
+    _SummaryField("storeys", "IfcBuildingStorey"),
+    _SummaryField("products", "IfcProduct"),
+    _SummaryField("types", "IfcTypeObject"),
+    _SummaryField("property_sets", "IfcPropertySet"),
+    _SummaryField("materials", "IfcMaterial"),
+    _SummaryField("layers", "IfcPresentationLayerAssignment"),
+)
+
+# Keep the process-wide cache size small.
+_MAX_CACHE_SIZE = 16
+
+# Summaries cache keyed by IFC file absolute path, file size, and modification time.
+# Useful when same unchanged IFC file is summarized again, e.g. inexpensive import dialog reopen.
+_SUMMARY_CACHE: OrderedDict[tuple[str, int, int], IfcSummary] = OrderedDict()
+
+
+@dataclass(frozen=True)
+class IfcSummary:
+    """Summary of IFC file content.
+
+    `created` is creation timestamp stored in IFC FILE_NAME header.
+    `modified` is filesystem modification timestamp of IFC file.
+    `schema` is IFC schema identifier, e.g. `IFC2X3` or `IFC4`.
+    Counts are IFC entities and do not necessarily correspond to number of FreeCAD objects.
+    """
+
+    filename: str
+    file_size: int
+    created: str
+    modified: float
+
+    schema: str
+    projects: int
+    sites: int
+    buildings: int
+    storeys: int
+    products: int
+    types: int
+    property_sets: int
+    materials: int
+    layers: int
+
+
+def _get_created(ifc_file: Any) -> str:
+    """IFC file creation timestamp from header."""
+
+    file_name = ifc_file.header.file_name
+    timestamp = getattr(file_name, "time_stamp", None)
+
+    return timestamp or ""
+
+
+def _count_type_entities(
+    ifc_file: Any,
+    entity_name: str,
+    cancelled: Callable[[], bool] | None = None,
+) -> int:
+    """Number of IFC entities of given type."""
+
+    if cancelled is not None and cancelled():
+        raise InterruptedError("IFC summary generation cancelled")
+
+    return len(ifc_file.by_type(entity_name))
+
+
+def _cache_key(
+    filename: str | os.PathLike[str],
+) -> tuple[tuple[str, int, int], os.stat_result]:
+    """Summary cache key from IFC file absolute path, size, and modification time."""
+
+    path: str = os.path.abspath(os.fspath(filename))
+    stat: os.stat_result = os.stat(path)
+    return (path, stat.st_size, stat.st_mtime_ns), stat
+
+
+def _emit_cached_summary(
+    summary: IfcSummary,
+    metadata: Callable[[str, int, str, float], None] | None,
+    update: Callable[[str, str | int], None] | None,
+) -> None:
+    """Cached summary sent to callback."""
+
+    if metadata is not None:
+        metadata(
+            summary.filename,
+            summary.file_size,
+            summary.created,
+            summary.modified,
+        )
+
+    if update is not None:
+        for field in _SUMMARY_FIELDS:
+            update(field.name, getattr(summary, field.name))
+
+
+def _get_cached_summary(
+    cache_key: tuple[str, int, int],
+) -> IfcSummary | None:
+    """Cached summary marked as used."""
+
+    summary: IfcSummary | None = _SUMMARY_CACHE.get(cache_key)
+
+    if summary is not None:
+        _SUMMARY_CACHE.move_to_end(cache_key)
+
+    return summary
+
+
+def _cache_summary(
+    cache_key: tuple[str, int, int],
+    summary: IfcSummary,
+) -> None:
+    """Store summary in cache."""
+
+    _SUMMARY_CACHE[cache_key] = summary
+    _SUMMARY_CACHE.move_to_end(cache_key)
+
+    if len(_SUMMARY_CACHE) > _MAX_CACHE_SIZE:
+        _SUMMARY_CACHE.popitem(last=False)
+
+
+def get_summary(
+    source: str | os.PathLike[str] | Any,
+    metadata: Callable[[str, int, str, float], None] | None = None,
+    update: Callable[[str, str | int], None] | None = None,
+    cancelled: Callable[[], bool] | None = None,
+) -> IfcSummary:
+    """Summary of IFC file with basic metadata and IFC entities counts.
+
+    `source` is either filename/path or already-open IFC object.
+    Open file objects are not cached as no reliable filesystem stats can be used.
+
+    Summaries are cached using absolute path, file size, and filesystem modification time.
+    Repeated requests for same unchanged file directly return cached summary.
+    Cancellation is checked before each entity count.
+    But it cannot interrupt individual IfcOpenShell operation already in progress.
+    """
+
+    time_0 = time.perf_counter()  # TODO: remove before merge
+
+    filename: str = ""
+    file_size: int = 0
+    modified: float = 0.0
+    cache_key: tuple[str, int, int] | None = None
+
+    if hasattr(source, "by_type"):
+        ifc_file = source  # Already open IFC file object.
+
+    else:
+        cache_key, stat = _cache_key(source)
+        cached_summary: IfcSummary | None = _get_cached_summary(cache_key)
+
+        if cached_summary is not None:
+            _emit_cached_summary(cached_summary, metadata, update)
+            return cached_summary
+
+        if cancelled is not None and cancelled():
+            raise InterruptedError("IFC summary generation cancelled")
+
+        abspath: str = cache_key[0]
+        filename = os.path.basename(abspath)
+        file_size = cache_key[1]
+        modified = stat.st_mtime
+
+        # Update IFC file metadata immediately before expensive IFC parsing completes.
+        if metadata is not None:
+            metadata(filename, file_size, "", modified)
+
+        import ifcopenshell
+
+        ifc_file = ifcopenshell.open(abspath)
+
+    time_1 = time.perf_counter()  # TODO: remove before merge
+
+    # Info from already open IFC file object.
+    if not filename:
+        path: str = getattr(ifc_file, "filename", "")
+        if path:
+            filename = os.path.basename(path)
+            if os.path.isfile(path):
+                stat = os.stat(path)
+                file_size = stat.st_size
+                modified = stat.st_mtime
+
+    created: str = _get_created(ifc_file)
+    schema: str = str(getattr(ifc_file, "schema", "") or "Unknown")
+
+    if metadata is not None:
+        metadata(filename, file_size, created, modified)
+
+    if update is not None:
+        update("schema", schema)
+
+    values: dict[str, int] = {}
+
+    for field in _SUMMARY_FIELDS:
+        if field.entity is None:
+            continue
+
+        count = _count_type_entities(ifc_file, field.entity, cancelled)
+        values[field.name] = count
+
+        if update is not None:
+            update(field.name, count)
+
+    time_2 = time.perf_counter()  # TODO: remove before merge
+
+    summary = IfcSummary(
+        filename=filename,
+        file_size=file_size,
+        created=created,
+        modified=modified,
+        schema=schema,
+        **values,
+    )
+
+    if cache_key is not None:
+        _cache_summary(cache_key, summary)
+
+    time_3 = time.perf_counter()  # TODO: remove before merge
+    print(
+        f"IFC Summary timing for {filename}: open={time_1-time_0:.3f}s count={time_2-time_1:.3f}s store={time_3-time_2:.3f}s total={time_3-time_0:.3f}s"
+    )
+
+    return summary


### PR DESCRIPTION
### What

Before doing a long opening or import of someone else's IFC files, it's pretty handy to know their basic content structure.
Here comes IFC summary! 😁

Basically, this PR adds a `IFC summary` utility that only relies on standard Python and IfcOpenShell (i.e. no FreeCAD and no GUI stuff), and then use it for the import dialog in order to show some basic info (metadata, IFC schema, and IFC entities counts) about the selected IFC file, before importing or loading it fully.

### How

`ifc_summary.py` utility is quite simple: it extracts basic metadata like filename, file size, creation datetime, last modification datetime, and then uses IfcOpenShell to get the IFC schema and the entities counts (e.g. `IfcBuildingStorey`, `IfcProduct`, etc).
The public `get_summary()` provides this data incrementally as soon as possible, instead of only at the end, so it's a bit nicer UX.
It also makes use of a cache so subsequent summary requests for the same *unchanged* IFC file are quick.
Oh, I know we don't do typing yet in the BIM module, but hey, just slightly anticipating the addition of type hinting very soon anyway 😋

`ifc_import.py` is a bit more complex. Instead of blocking the GUI while the summary data is generated, a separate thread is used and the data is displayed on the dialog in steps as soon as available. So summaries for large IFC files that take several seconds are not causing problems and the users can still interact with the dropdowns or checkboxes.
This is honestly way more code than I would have liked but it works fairly well and was a nice exercise 😆

### After

https://github.com/user-attachments/assets/294e0d14-3018-4a2a-9641-e7f9894741d1


### Testing

To test, grab some IFC files [here](https://github.com/buildingSMART/Certification-datasets) and [there](https://github.com/buildingsmart-community/Community-Sample-Test-Files).

Then, with the BIM workbench opened, do `File` > `Import` (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd>) and select the IFC file to import.

Performance: the local debug build on my old laptop requires for the summary to fully show up between some milliseconds for small IFC files up to about 10-15 seconds for larger ones (>100MB). Hopefully it's a bit quicker on your side. Full import is not impacted and still can take several minutes in most cases.

### TODOs

- Remove debug timings after testing and review is complete.

### Later PRs

- Refactor and cleanup the whole `ifc_import` stuff.
- Reuse the `ifc_summary` in other places, e.g. export dialog.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
