### PR TITLE
Sketcher: Fix visibility on save bug when in edit of previous PD feature

### DIFF
--- a/src/Mod/Show/TVStack.py
+++ b/src/Mod/Show/TVStack.py
@@ -132,6 +132,10 @@ class TVStack(object):
                         details[detail.full_key] = detail
 
         self._rewind_tv = mTempoVis.TempoVis(self.document, None)
+        # Capture all values before applying any changes: showing a PartDesign
+        # feature can implicitly hide another feature in the same body.
+        for detail in details.values():
+            self._rewind_tv.save(detail)
         for key, detail in details.items():
             self._rewind_tv.modify(detail)
 


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/18347

Sketcher uses TempoVis to remember the normal visibility and temporarily show the earlier pad.

When you save during editing, the document should contain the normal model visibility, so reopening it won’t look like you are still editing a sketch. The save code therefore:

1. Remembers the current editing visibility.
2. Temporarily restores normal visibility.
3. Writes the file.
4. Restores the editing visibility.

The mistake was inside steps 1–2. Previously, each modify() call remembered one current value and immediately changed it:
- Remember Pad001 is hidden, then show it for saving.
- Showing Pad001 automatically hides Pad, because PartDesign allows only one visible solid feature in a body.
- Now process Pad: remember its current visibility—but it is already hidden!
- After saving, restore that incorrectly recorded “hidden” value.
That is why the underlying pad disappeared.

The added loop records every current value before changing anything