### PR TITLE
Sketcher: Fix updating a spreadsheet dimension does not update in sketch

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3887,15 +3887,8 @@ void ViewProviderSketch::slotSolverUpdate()
             + getSketchObject()->getHighestCurveIndex() + 1
         == getSolvedSketch().getGeometrySize()) {
 
-        auto editDoc = Gui::Application::Instance->editDocument([this](Gui::Document* editdoc) {
-            return editdoc->getEditViewProvider() == this;
-        });
-
-        Gui::MDIView* mdi = nullptr;
-
-        if (editDoc) {
-            mdi = editDoc->getActiveView();
-        }
+        Gui::MDIView* mdi =
+            Gui::Application::Instance->editViewOfNode(editCoinManager->getRootEditNode());
         if (mdi && mdi->isDerivedFrom<Gui::View3DInventor>()) {
             draw(false, true);
         }


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/17036

The refresh checked the active view, which was the spreadsheet, and skipped redrawing. It now finds the 3D view containing the edited sketch.
Verified a spreadsheet change from 40 to 60 mm updates both the dimension and displayed geometry without closing the sketch or manually recomputing.