### PR TITLE
Sketcher: Offset fully constraint the construction lines

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
@@ -705,9 +705,9 @@ private:
                                         << getHighestCurveIndex() + newCurveCounter << ", "
                                         << curve[j] << "))\n";
                                     newLinesStream
-                                        << "conList2.append(Sketcher.Constraint('PointOnObject',"
+                                        << "conList2.append(Sketcher.Constraint('Coincident',"
                                         << getHighestCurveIndex() + newCurveCounter << ",1, "
-                                        << curve[j] << "))\n";
+                                        << curve[j] << ",1))\n";
                                     newLinesStream
                                         << "conList2.append(Sketcher.Constraint('PointOnObject',"
                                         << getHighestCurveIndex() + newCurveCounter << ",2, "


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/17930

by replacing one of the 'point on object' constraint of the construction line by a 'coincidence'.