### PR TITLE
Sketcher: Fix constraint text cutoff 21269

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -2868,7 +2868,15 @@ QImage EditModeConstraintCoinManager::renderConstrIcon(
     font.setBold(true);
     QFontMetrics qfm = QFontMetrics(font);
 
-    int labelWidth = qfm.boundingRect(labels.join(joinStr)).width();
+    // Measure the right edge at the same positions used to draw each label.
+    // Bounding-box widths omit the left bearing, and advances are rounded per label.
+    int labelWidth = 0;
+    int labelOffset = 0;
+    for (auto it = labels.begin(); it != labels.end(); ++it) {
+        const QString text = (it + 1 == labels.end()) ? *it : *it + joinStr;
+        labelWidth = std::max(labelWidth, labelOffset + qfm.boundingRect(text).right() + 1);
+        labelOffset += Gui::QtTools::horizontalAdvance(qfm, text);
+    }
     // See Qt docs on qRect::bottom() for explanation of the +1
     int pxBelowBase = qfm.boundingRect(labels.join(joinStr)).bottom() + 1;
 


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/21269

This fixes a coordinate-calculation error; it doesn’t depend on a particular font or screen scale.

The old code confused the width of the drawn text with how far its right edge lies from the drawing position.

For example, suppose Qt says a character occupies pixels 1 through 6, relative to where we draw it:
- Its bounding-box width is 6.
- But the image must accommodate 7 pixels, positions 0 through 6.
- Allocating only 6 clips the last column.

That is exactly what happened with several digits in our reproduction.

Tested an confirm the clipping is gone. For me at least. But this shouldn't be platform specific.