### PR TITLE
Mesh: include .3mf in Import Mesh file filter (#32475)

### DIFF
--- a/src/Mod/Mesh/Gui/Command.cpp
+++ b/src/Mod/Mesh/Gui/Command.cpp
@@ -355,7 +355,7 @@ void CmdMeshImport::activated(int)
 
     const Gui::FileDialog::FilterList filter {
         {QObject::tr("All Mesh Files"),
-         {"*.stl", "*.ast", "*.bms", "*.obj", "*.off", "*.iv", "*.ply", "*.nas", "*.bdf"}},
+         {"*.stl", "*.ast", "*.bms", "*.obj", "*.off", "*.iv", "*.ply", "*.nas", "*.bdf", "*.3mf"}},
         {QObject::tr("Binary STL"), {"*.stl"}},
         {QObject::tr("ASCII STL"), {"*.ast"}},
         {QObject::tr("Binary Mesh"), {"*.bms"}},
@@ -363,6 +363,7 @@ void CmdMeshImport::activated(int)
         {QObject::tr("Object File Format"), {"*.off"}},
         {QObject::tr("Inventor V2.1 ASCII"), {"*.iv"}},
         {QObject::tr("Stanford Polygon"), {"*.ply"}},
+        {QObject::tr("3D Manufacturing Format"), {"*.3mf"}},
         {QStringLiteral("NASTRAN"), {"*.nas", "*.bdf"}},
         Gui::FileDialog::Filter::AllFiles(),
     };


### PR DESCRIPTION
Fixes #32475

Import Mesh default "all mesh files" filter never listed *.3mf even though 3mf import already works (All Files / File→Open / export already had it) just a stale filter list in CmdMeshImport

Added *.3mf to all mesh files and a dedicated 3D manufacturing format row matching export no I/O changes.

Manually verified: .3mf shows under default All Mesh Files and imports.

Took AI assistance: Cursor

https://github.com/user-attachments/assets/b01f279e-a549-496d-8d00-c1f060c40032

<img width="1710" height="1107" alt="image" src="https://github.com/user-attachments/assets/c69d35dc-5d93-40dd-a8a6-7f09cf0e1918" />
