### PR TITLE
[Gui][Macros Dialog] Improve performance of file name and find in fil…

### DIFF
--- a/src/Gui/Dialogs/DlgMacroExecuteImp.cpp
+++ b/src/Gui/Dialogs/DlgMacroExecuteImp.cpp
@@ -141,6 +141,39 @@ DlgMacroExecuteImp::~DlgMacroExecuteImp() = default;
 void DlgMacroExecuteImp::setupConnections()
 {
     // clang-format off
+
+    /* improve performance of find file and find in files functions
+     * by not calling the fillup list function until the user
+     * is finished typing
+     */
+    auto findFileTimer = new QTimer(this);
+    findFileTimer->setSingleShot(true);
+    findFileTimer->setInterval(600);
+
+    //start timer when user types
+    connect(ui->LineEditFind, &QLineEdit::textChanged,
+            this, [findFileTimer] (const QString&) {
+                findFileTimer->start();
+    });
+
+    //call the handler only after the timer times out
+    connect(findFileTimer, &QTimer::timeout, this, [this]() {
+        this->onLineEditFindTextChanged(ui->LineEditFind->text());
+    });
+
+    auto findInFilesTimer = new QTimer(this);
+    findInFilesTimer->setSingleShot(true);
+    findInFilesTimer->setInterval(600);
+
+    connect(ui->LineEditFindInFiles, &QLineEdit::textChanged,
+            this, [findInFilesTimer] (const QString&) {
+                findInFilesTimer->start();
+    });
+    connect(findInFilesTimer, &QTimer::timeout, this, [this]() {
+        this->onLineEditFindInFilesTextChanged(ui->LineEditFindInFiles->text());
+    });
+
+
     connect(ui->fileChooser, &FileChooser::fileNameChanged,
             this, &DlgMacroExecuteImp::onFileChooserFileNameChanged);
     connect(ui->createButton, &QPushButton::clicked,
@@ -165,10 +198,6 @@ void DlgMacroExecuteImp::setupConnections()
             this, &DlgMacroExecuteImp::onSystemMacroListBoxCurrentItemChanged);
     connect(ui->tabMacroWidget, &QTabWidget::currentChanged,
             this, &DlgMacroExecuteImp::onTabMacroWidgetCurrentChanged);
-    connect(ui->LineEditFind, &QLineEdit::textChanged,
-            this, &DlgMacroExecuteImp::onLineEditFindTextChanged);
-    connect(ui->LineEditFindInFiles, &QLineEdit::textChanged,
-            this, &DlgMacroExecuteImp::onLineEditFindInFilesTextChanged);
     // clang-format on
 }
 


### PR DESCRIPTION
…e filters in macros dialog by not calling fill up list function until the user has finished typing

In the current state of FreeCAD the file list inside the Macros Dialog is refreshed every time the user types anything into the Find or Find in Files line edits.  If there aren't many macros in the macros folder this is negligible, but when there are many files it can add a considerable delay.  This speeds things up by waiting until the user has finished typing to refresh the file list.  A QTimer is used for this purpose with a 600 millisecond timeout.

Changes:  Instead of directly calling the on text changed handlers when the text changes the timer is started, and when the timer times out then the handler gets called, which then updates the list.  Conceptually, before the PR:

user types -> handler is called

After the PR:

user types -> timer gets started -> user types -> timer reset -> user ends typing -> timer times out -> calls handler.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.  I did get some AI assistance in getting the syntax correct for the lambdas used, but I fully understand the code and take full responsibility for it.

Assisted-by: GPT-5.6 Luna  


## Issues
I don't know of any open issues related to this PR, but it is possible one or more do exist.

## Before and After Images
There are no changes to the look of the Gui.

While it does not address a known github issue, it is an issue for me personally that it takes a long time to enter a find in files string.  It does affect the Gui to the extent that it makes the dialog more responsive.  There is no impact on the existing workflow for users and it does not impact any other part of FreeCAD outside the dialog itself.


