### PR TITLE
Gui: Make thumbnails transparent and uniform

### DIFF
--- a/src/Gui/Camera.cpp
+++ b/src/Gui/Camera.cpp
@@ -26,7 +26,13 @@
 
 #include <App/Application.h>
 
+#include <algorithm>
 #include <cmath>
+
+#include <Inventor/SbBox3f.h>
+#include <Inventor/SbMatrix.h>
+#include <Inventor/SbVec3f.h>
+#include <Inventor/nodes/SoOrthographicCamera.h>
 
 using namespace Gui;
 
@@ -191,6 +197,35 @@ bool Camera::rotationsMatch(const SbRotation& lhs, const SbRotation& rhs, float 
     // against the closer sign.
     const float squaredDistance = 2.0F * (1.0F - absDot);
     return squaredDistance <= squaredTolerance;
+}
+
+void Camera::fitToBox(SoOrthographicCamera& camera, const SbBox3f& box, float aspect)
+{
+    if (box.isEmpty()) {
+        return;
+    }
+
+    SbMatrix intoCameraSpace;
+    intoCameraSpace.setRotate(camera.orientation.getValue().inverse());
+
+    // Only the rotated size matters here; viewBoundingBox below places the camera.
+    SbBox3f projected = box;
+    projected.transform(intoCameraSpace);
+    const SbVec3f half = projected.getSize() * 0.5F;
+
+    const float halfExtent = std::max(half[1], half[0] / aspect);
+    if (halfExtent <= 0.0F) {
+        // A box that projects to a point would leave the view volume degenerate.
+        return;
+    }
+
+    // Geometry outside the bounding box is still rendered - a sketch's edit-mode cross axes,
+    // for one - so the planes Coin puts tangent to the bounding sphere at a slack of 1 would
+    // clip it. Orthographic projection is happy with the negative near distance a slack of 2 gives.
+    camera.viewBoundingBox(box, aspect, 2.0F);
+
+    // Coin sizes the frame from the circumscribing sphere, which leaves the image mostly empty.
+    camera.height = 2.0F * halfExtent * fitMargin;
 }
 
 Base::Rotation Camera::convert(Camera::Orientation view)

--- a/src/Gui/Camera.h
+++ b/src/Gui/Camera.h
@@ -29,6 +29,9 @@
 
 #include <string>
 
+class SbBox3f;
+class SoOrthographicCamera;
+
 namespace Gui
 {
 
@@ -68,6 +71,11 @@ public:
         const SbRotation& rhs,
         float squaredTolerance = 1e-6F
     );
+
+    /// How much larger a fitted frame is than the content it holds.
+    static constexpr float fitMargin = 1.1F;
+
+    static void fitToBox(SoOrthographicCamera& camera, const SbBox3f& box, float aspect);
     static Base::Rotation convert(Orientation view);
     static Base::Rotation convert(const SbRotation&);
     static SbRotation convert(const Base::Rotation&);

--- a/src/Gui/Thumbnail.cpp
+++ b/src/Gui/Thumbnail.cpp
@@ -37,9 +37,14 @@
 #endif
 #include <zipios++/zipfile.h>
 
+#include <Inventor/SbBox3f.h>
+#include <Inventor/nodes/SoOrthographicCamera.h>
+
 #include "Thumbnail.h"
 #include "BitmapFactory.h"
+#include "Camera.h"
 #include "View3DInventorViewer.h"
+#include "ViewProvider.h"
 
 
 using namespace Gui;
@@ -95,11 +100,25 @@ void Thumbnail::SaveDocFile(Base::Writer& writer) const
             qWarning("Cannot create a thumbnail from non-GUI thread");
         }
         else {
-            View3DInventorViewer::RenderImageOptions options;
-            options.width = this->size;
-            options.height = this->size;
-            options.samples = 4;
-            options.intent = View3DInventorViewer::RenderIntent::RasterCapture;
+            // An empty document frames nothing, so it yields a blank thumbnail rather than a
+            // stale one of geometry that has since been deleted.
+            SbBox3f box;
+            this->viewer->getSceneBoundBox(box);
+
+            CoinPtr<SoOrthographicCamera> camera(new SoOrthographicCamera);
+            camera->orientation.setValue(Camera::defaultOrientation());
+            Camera::fitToBox(*camera, box, 1.0F);
+
+            const View3DInventorViewer::RenderImageOptions options {
+                .width = this->size,
+                .height = this->size,
+                .samples = 4,
+                .background = QColor(0, 0, 0, 0),
+                .alphaMode = View3DInventorViewer::AlphaMode::PerPixel,
+                .intent = View3DInventorViewer::RenderIntent::RasterCapture,
+                .includeViewerLighting = true,
+                .camera = camera.get(),
+            };
             img = this->viewer->renderToImage(options);
             created = !img.isNull();
         }

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -3060,7 +3060,11 @@ QImage View3DInventorViewer::renderToImage(const RenderImageOptions& options)
     // is to use a certain background color using GL_RGB as texture
     // format and in the output image search for the above color and
     // replaces it with the color requested by the user.
-    fboFormat.setInternalTextureFormat(getInternalTextureFormat());
+    const bool perPixelAlpha = options.alphaMode == AlphaMode::PerPixel;
+    // The InternalTextureFormat preference cannot express "must carry alpha".
+    fboFormat.setInternalTextureFormat(
+        perPixelAlpha ? static_cast<GLenum>(GL_RGBA8) : getInternalTextureFormat()
+    );
 
     QOpenGLFramebufferObject fbo(width, height, fboFormat);
     if (!fbo.isValid()) {
@@ -3074,9 +3078,10 @@ QImage View3DInventorViewer::renderToImage(const RenderImageOptions& options)
     }
 
     constexpr const int maxAlpha = 255;
-    int alpha = maxAlpha;
     QColor opaqueBackground = options.background;
     const bool overrideBackground = opaqueBackground.isValid();
+    const bool keyOutBackground = overrideBackground && opaqueBackground.alpha() < maxAlpha
+        && !perPixelAlpha;
     const QColor previousBackground = backgroundColor();
     const Background previousGradient = getGradientBackground();
     auto restoreBackground = qScopeGuard(
@@ -3089,16 +3094,15 @@ QImage View3DInventorViewer::renderToImage(const RenderImageOptions& options)
     );
 
     if (overrideBackground) {
-        // force an opaque background color
-        alpha = opaqueBackground.alpha();
-        if (alpha < maxAlpha) {
+        if (keyOutBackground) {
+            // force an opaque background color for the keying pass to match against
             opaqueBackground.setRgb(maxAlpha, maxAlpha, maxAlpha);
         }
         setBackgroundColor(opaqueBackground);
         setGradientBackground(Background::NoGradient);
     }
 
-    if (!renderToFramebuffer(&fbo, options.includeViewerLighting)) {
+    if (!renderToFramebuffer(&fbo, options)) {
         return {};
     }
     img = fbo.toImage();
@@ -3107,8 +3111,12 @@ QImage View3DInventorViewer::renderToImage(const RenderImageOptions& options)
         return {};
     }
 
-    // if background color isn't opaque manipulate the image
-    if (alpha < maxAlpha) {
+    if (perPixelAlpha) {
+        // The framebuffer already carries per-pixel alpha, so neither post-pass applies.
+        return img;
+    }
+
+    if (keyOutBackground) {
         QImage image(img.constBits(), img.width(), img.height(), QImage::Format_ARGB32);
         img = image.copy();
         QRgb rgba = options.background.rgba();
@@ -3123,7 +3131,7 @@ QImage View3DInventorViewer::renderToImage(const RenderImageOptions& options)
             }
         }
     }
-    else if (alpha == maxAlpha) {
+    else {
         QImage image(img.width(), img.height(), QImage::Format_RGB32);
         QPainter painter(&image);
         painter.fillRect(image.rect(), Qt::black);
@@ -3135,7 +3143,34 @@ QImage View3DInventorViewer::renderToImage(const RenderImageOptions& options)
     return img;
 }
 
-bool View3DInventorViewer::renderToFramebuffer(QOpenGLFramebufferObject* fbo, bool includeViewerLighting)
+SoSeparator* View3DInventorViewer::buildCaptureRoot(const RenderImageOptions& options) const
+{
+    // Skipping the render manager's scene graph leaves the placement indicator, the rotation
+    // center and the viewer's own camera out of the capture.
+    auto root = new SoSeparator;
+
+    if (options.includeViewerLighting) {
+        root->addChild(getHeadlight());
+        root->addChild(getBacklight());
+        root->addChild(getFillLight());
+        root->addChild(environment);
+    }
+
+    root->addChild(options.camera);
+    root->addChild(pcViewProviderRoot);
+
+    return root;
+}
+
+bool View3DInventorViewer::renderToFramebuffer(QOpenGLFramebufferObject* fbo)
+{
+    return renderToFramebuffer(fbo, RenderImageOptions {});
+}
+
+bool View3DInventorViewer::renderToFramebuffer(
+    QOpenGLFramebufferObject* fbo,
+    const RenderImageOptions& options
+)
 {
     static_cast<QOpenGLWidget*>(this->viewport())->makeCurrent();  // NOLINT
     if (!fbo->bind()) {
@@ -3171,7 +3206,11 @@ bool View3DInventorViewer::renderToFramebuffer(QOpenGLFramebufferObject* fbo, bo
     // while creating a new render action has it set to GL_LEQUAL. So, in order to get
     // the exact same result set it explicitly to GL_LESS.
     glDepthFunc(GL_LESS);
-    if (includeViewerLighting) {
+    if (options.camera) {
+        const CoinPtr<SoSeparator> captureRoot(buildCaptureRoot(options));
+        gl.apply(captureRoot);
+    }
+    else if (options.includeViewerLighting) {
         gl.apply(this->getSoRenderManager()->getSceneGraph());
     }
     else {

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -156,6 +156,16 @@ public:
         VectorExport
     };
 
+    /// Declares how a captured image carries transparency.
+    enum class AlphaMode
+    {
+        /// Derive from the background colour: a translucent one is rendered opaque and keyed out.
+        FromBackground,
+        /// Keep the framebuffer's own per-pixel alpha: cleaner edges, but no sorted-transparency
+        /// workaround.
+        PerPixel
+    };
+
     /** @name Render mode
      */
     //@{
@@ -241,8 +251,12 @@ public:
         int height = 0;
         int samples = -1;
         QColor background;
+        AlphaMode alphaMode = AlphaMode::FromBackground;
         RenderIntent intent = RenderIntent::RasterCapture;
         bool includeViewerLighting = true;
+        /// Render through this camera instead of the viewer's own, which is left untouched.
+        /// Must arrive already referenced; the render neither takes nor releases ownership.
+        SoCamera* camera = nullptr;
     };
 
     /** Render the scene into a new image using the requested capture policy. */
@@ -637,7 +651,11 @@ private:
     void recoverFromRenderMemoryException();
     void renderDelayedAnnotations(SoGLRenderAction* glra);
     void renderGLActionScene(const QColor& backgroundColor, SoGLRenderAction* glra);
-    bool renderToFramebuffer(QOpenGLFramebufferObject*, bool includeViewerLighting = true);
+    bool renderToFramebuffer(QOpenGLFramebufferObject*);
+    bool renderToFramebuffer(QOpenGLFramebufferObject*, const RenderImageOptions& options);
+    /// Assemble a scene root that renders the options' camera over the geometry alone.
+    /// The returned node is unreferenced; the caller owns it.
+    SoSeparator* buildCaptureRoot(const RenderImageOptions& options) const;
     void setCursorRepresentation(int mode);
     void aboutToDestroyGLContext();
     void createStandardCursors();

--- a/tests/src/Gui/Camera.cpp
+++ b/tests/src/Gui/Camera.cpp
@@ -2,16 +2,22 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 
+#include <Inventor/SbBox3f.h>
 #include <Inventor/SbMatrix.h>
 #include <Inventor/SbRotation.h>
+#include <Inventor/SbSphere.h>
 #include <Inventor/SbViewVolume.h>
+#include <Inventor/SoDB.h>
+#include <Inventor/nodes/SoOrthographicCamera.h>
 #include <Base/Converter.h>
 #include <Base/Tools.h>
 #include <Gui/Camera.h>
 #include <Gui/Utilities.h>
+#include <Gui/ViewProvider.h>
 
 #include <src/App/InitApplication.h>
 
@@ -137,6 +143,48 @@ std::array<double, 3> getProjectedLengths(const SbRotation& rot)
     return {(vx - vo).length(), (vy - vo).length(), (vz - vo).length()};
 }
 
+SbVec3f furthestNormalizedCorner(const SoOrthographicCamera& camera, const SbBox3f& box, float aspect)
+{
+    SbBox3f normalized = box;
+    normalized.transform(camera.getViewVolume(aspect).getMatrix());
+
+    const SbVec3f low = normalized.getMin();
+    const SbVec3f high = normalized.getMax();
+    return {
+        std::max(std::abs(low[0]), std::abs(high[0])),
+        std::max(std::abs(low[1]), std::abs(high[1])),
+        std::max(std::abs(low[2]), std::abs(high[2])),
+    };
+}
+
+float largestNormalizedExtent(const SoOrthographicCamera& camera, const SbBox3f& box, float aspect)
+{
+    const SbVec3f furthest = furthestNormalizedCorner(camera, box, aspect);
+    return std::max(furthest[0], furthest[1]);
+}
+
+float largestNormalizedDepth(const SoOrthographicCamera& camera, const SbBox3f& box, float aspect)
+{
+    return furthestNormalizedCorner(camera, box, aspect)[2];
+}
+
+/// Expect the fit to decline @p box, leaving a known starting pose untouched.
+void expectFitDeclines(SoOrthographicCamera& camera, const SbBox3f& box)
+{
+    camera.orientation.setValue(Gui::Camera::rotation(Gui::Camera::Isometric));
+    camera.position.setValue(7.0F, 8.0F, 9.0F);
+    camera.height.setValue(42.0F);
+
+    Gui::Camera::fitToBox(camera, box, 1.0F);
+
+    EXPECT_FLOAT_EQ(camera.height.getValue(), 42.0F);
+
+    const SbVec3f position = camera.position.getValue();
+    EXPECT_FLOAT_EQ(position[0], 7.0F);
+    EXPECT_FLOAT_EQ(position[1], 8.0F);
+    EXPECT_FLOAT_EQ(position[2], 9.0F);
+}
+
 }  // namespace
 
 class CameraPrecalculatedQuaternions: public ::testing::Test
@@ -236,4 +284,132 @@ TEST_F(CameraRotation, testTrimetricProjection)
     EXPECT_GT(std::abs(lengths[0] - lengths[1]), 1e-3);
     EXPECT_GT(std::abs(lengths[1] - lengths[2]), 1e-3);
     EXPECT_GT(std::abs(lengths[0] - lengths[2]), 1e-3);
+}
+
+
+class CameraFitToBox: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+        SoDB::init();  // idempotent; constructing a Coin node needs the type database
+    }
+
+    void SetUp() override
+    {
+        camera.reset(new SoOrthographicCamera);
+    }
+
+    Gui::CoinPtr<SoOrthographicCamera> camera;
+};
+
+TEST_F(CameraFitToBox, aCubeIsFramedWithTheMargin)
+{
+    // The default orientation looks down -Z, so camera space is world space.
+    const SbBox3f box(-1.0F, -1.0F, -1.0F, 1.0F, 1.0F, 1.0F);
+
+    Gui::Camera::fitToBox(*camera, box, 1.0F);
+
+    EXPECT_FLOAT_EQ(camera->height.getValue(), 2.0F * Gui::Camera::fitMargin);
+
+    const SbVec3f position = camera->position.getValue();
+    EXPECT_FLOAT_EQ(position[0], 0.0F);
+    EXPECT_FLOAT_EQ(position[1], 0.0F);
+    EXPECT_FLOAT_EQ(position[2], std::sqrt(3.0F));
+}
+
+TEST_F(CameraFitToBox, noCornerIsClipped)
+{
+    // A different orientation and a non-square frame from theContentReachesTheMargin below.
+    camera->orientation.setValue(Gui::Camera::rotation(Gui::Camera::Dimetric));
+    const SbBox3f box(-30.0F, -8.0F, -12.0F, 70.0F, 22.0F, 5.0F);
+
+    Gui::Camera::fitToBox(*camera, box, 1.6F);
+
+    EXPECT_LE(largestNormalizedExtent(*camera, box, 1.6F), 1.0F);
+}
+
+TEST_F(CameraFitToBox, theClippingPlanesClearTheScene)
+{
+    // The isometric direction runs along a cube's body diagonal, so a cubic box puts its nearest
+    // and farthest corners hard against tangent clipping planes.
+    camera->orientation.setValue(Gui::Camera::rotation(Gui::Camera::Isometric));
+    const SbBox3f box(-1.0F, -1.0F, -1.0F, 1.0F, 1.0F, 1.0F);
+
+    Gui::Camera::fitToBox(*camera, box, 1.0F);
+
+    EXPECT_LT(largestNormalizedDepth(*camera, box, 1.0F), 1.0F);
+}
+
+TEST_F(CameraFitToBox, theContentReachesTheMargin)
+{
+    camera->orientation.setValue(Gui::Camera::rotation(Gui::Camera::Isometric));
+    const SbBox3f box(-30.0F, -8.0F, -12.0F, 70.0F, 22.0F, 5.0F);
+
+    Gui::Camera::fitToBox(*camera, box, 1.0F);
+
+    // A circumscribing-sphere fit leaves this well short of the margin.
+    EXPECT_NEAR(largestNormalizedExtent(*camera, box, 1.0F), 1.0F / Gui::Camera::fitMargin, 1e-4F);
+}
+
+TEST_F(CameraFitToBox, aTranslatedBoxFramesIdentically)
+{
+    camera->orientation.setValue(Gui::Camera::rotation(Gui::Camera::Isometric));
+    const SbBox3f box(-1.0F, -2.0F, -3.0F, 4.0F, 5.0F, 6.0F);
+    const SbVec3f offset(100.0F, -50.0F, 25.0F);
+    const SbBox3f moved(box.getMin() + offset, box.getMax() + offset);
+
+    Gui::Camera::fitToBox(*camera, box, 1.0F);
+    const float heightAtOrigin = camera->height.getValue();
+    const SbVec3f positionAtOrigin = camera->position.getValue();
+
+    Gui::Camera::fitToBox(*camera, moved, 1.0F);
+    const SbVec3f movedPosition = camera->position.getValue();
+
+    EXPECT_FLOAT_EQ(camera->height.getValue(), heightAtOrigin);
+    EXPECT_NEAR(movedPosition[0], positionAtOrigin[0] + offset[0], 1e-3F);
+    EXPECT_NEAR(movedPosition[1], positionAtOrigin[1] + offset[1], 1e-3F);
+    EXPECT_NEAR(movedPosition[2], positionAtOrigin[2] + offset[2], 1e-3F);
+}
+
+TEST_F(CameraFitToBox, anElongatedRodBeatsTheSphereFit)
+{
+    camera->orientation.setValue(Gui::Camera::rotation(Gui::Camera::Isometric));
+    const SbBox3f rod(-0.5F, -0.5F, -50.0F, 0.5F, 0.5F, 50.0F);
+
+    Gui::Camera::fitToBox(*camera, rod, 1.0F);
+
+    SbSphere circumscribed;
+    circumscribed.circumscribe(rod);
+
+    // Coin's viewBoundingBox would hand the rod a frame of 2 * radius and leave it swimming.
+    EXPECT_LT(camera->height.getValue(), 2.0F * circumscribed.getRadius());
+    EXPECT_NEAR(largestNormalizedExtent(*camera, rod, 1.0F), 1.0F / Gui::Camera::fitMargin, 1e-4F);
+}
+
+TEST_F(CameraFitToBox, theAspectRatioDecidesWhichExtentConstrains)
+{
+    // Half extents are 2 across and 1 up in camera space.
+    const SbBox3f box(-2.0F, -1.0F, -1.0F, 2.0F, 1.0F, 1.0F);
+
+    Gui::Camera::fitToBox(*camera, box, 1.0F);
+    EXPECT_FLOAT_EQ(camera->height.getValue(), 4.0F * Gui::Camera::fitMargin);
+
+    Gui::Camera::fitToBox(*camera, box, 2.0F);
+    EXPECT_FLOAT_EQ(camera->height.getValue(), 2.0F * Gui::Camera::fitMargin);
+
+    Gui::Camera::fitToBox(*camera, box, 0.5F);
+    EXPECT_FLOAT_EQ(camera->height.getValue(), 8.0F * Gui::Camera::fitMargin);
+}
+
+TEST_F(CameraFitToBox, anEmptyBoxLeavesTheCameraAlone)
+{
+    expectFitDeclines(*camera, SbBox3f());
+}
+
+TEST_F(CameraFitToBox, aPointBoxLeavesTheCameraAlone)
+{
+    // A single-point scene is a valid bounding box, not an empty one, so it reaches the fit.
+    expectFitDeclines(*camera, SbBox3f(3.0F, 4.0F, 5.0F, 3.0F, 4.0F, 5.0F));
 }


### PR DESCRIPTION
Thumbnails in FreeCAD are captured based on the current camera - if you save files randomly and often they usually contain everything but not what they should.

This PR uses dedicated camera for the thumbnails that is automatically computed to fit all object in the scene and uses default (home) view. For better effect it also uses true alpha rendering (not keyed out like the save image tool) so the thumbnails look actually nice. 

One problem with this implementation is that users no longer have control over what is in the thumbnail. For most models it should not be a problem, but if needed I can implement a way to store and set either static thumbnail or camera angle.

Part of: https://github.com/FreeCAD/FPA-grant-proposals/issues/58

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Tests and implementation cleanup assisted by: claude opus 5

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
| Before | After |
|--------|--------|
| <img width="513" height="233" alt="image" src="https://github.com/user-attachments/assets/ce29b27a-9c01-43b3-99ae-55386e568089" /> | <img width="511" height="226" alt="image" src="https://github.com/user-attachments/assets/589c5f05-76c0-4bb1-be3e-6c817062ab41" />| 
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
