### PR TITLE
CI: Update the score_prs script to use a custom token

### DIFF
--- a/.github/workflows/score_prs.yml
+++ b/.github/workflows/score_prs.yml
@@ -48,7 +48,7 @@ jobs:
         env:
           # The CI token needs write access to FreeCAD's organization project #40.
           # The repository-scoped GITHUB_TOKEN cannot update organization projects.
-          GH_TOKEN: ${{ secrets.GH_TOKEN_FOR_CI_RUNNERS }}
+          GH_TOKEN: ${{ secrets.PR_TRIAGE_PROJECT_TOKEN }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
           SKIP_LABELS: ${{ github.event.inputs.skip_labels }}


### PR DESCRIPTION
The normal CI token doesn't have write permissions on the project, so can't change the scores. I've created a separate token with the appropriate permissions.