### PR TITLE
Assembly: ignore Exploded View double-click while task is open (#32494)

### DIFF
--- a/src/Mod/Assembly/CommandCreateView.py
+++ b/src/Mod/Assembly/CommandCreateView.py
@@ -321,9 +321,10 @@ class ViewProviderExplodedView:
         return self.app_obj.Group
 
     def doubleClicked(self, vobj):
-        task = Gui.Control.activeTaskDialog()
-        if task:
-            task.reject()
+        # Issue #32494: re-opening while a task is live re-applies explosion moves
+        # and openCommand may commit the create/edit transaction into the assembly.
+        if Gui.Control.activeDialog():
+            return True
 
         assembly = vobj.Object.Proxy.getAssembly(vobj.Object)
 


### PR DESCRIPTION
Fixes #32494

Double clicking Exploded_View while the task was already open rebuilt TaskAssemblyCreateView that reapplied explosion moves and openCommand could commit the live create/edit transaction so translations got baked into the real assembly cancel only aborted the newest txn so earlier damage stuck

If a task dialog is already active doubleClicked now returns immediately (same idea as Snapshot) no change to apply/accept/reject placement logic

Manually verified: double click with task open does nothing after cancel double click opens edit normally again

Took AI assistance: Cursor

https://github.com/user-attachments/assets/6e30d116-82f8-485c-b9f2-3b5f1256beb5

