### PR TITLE
Gui: Stop overlay callbacks before destruction

### DIFF
--- a/src/Gui/OverlayWidgets.cpp
+++ b/src/Gui/OverlayWidgets.cpp
@@ -476,6 +476,22 @@ OverlayTabWidget::OverlayTabWidget(QWidget* parent, Qt::DockWidgetArea pos)
     connect(_animator, &QAbstractAnimation::stateChanged, this, &OverlayTabWidget::onAnimationStateChanged);
 }
 
+OverlayTabWidget::~OverlayTabWidget()
+{
+    // Member and child QObjects can emit signals while they are torn down,
+    // after the OverlayTabWidget portion of this object has been destroyed.
+    // Disconnect first so those signals cannot invoke our slots during base
+    // class destruction.
+    QObject::disconnect(&timer, nullptr, this, nullptr);
+    QObject::disconnect(&repaintTimer, nullptr, this, nullptr);
+    timer.stop();
+    repaintTimer.stop();
+    if (_animator) {
+        QObject::disconnect(_animator, nullptr, this, nullptr);
+        _animator->stop();
+    }
+}
+
 void OverlayTabWidget::refreshIcons()
 {
     auto curStyleSheet = App::GetApplication()

--- a/src/Gui/OverlayWidgets.h
+++ b/src/Gui/OverlayWidgets.h
@@ -88,6 +88,7 @@ public:
      * @param pos: docking position
      */
     OverlayTabWidget(QWidget* parent, Qt::DockWidgetArea pos);
+    ~OverlayTabWidget() override;
 
     /// Enable/disable overlay mode for this tab widget
     void setOverlayMode(bool enable);


### PR DESCRIPTION
While testing GUI code in a standalone headless FreeCAD process, shutdown could trigger this Qt assertion:

    ASSERT failure in Gui::OverlayTabWidget:
    "Called object is not of the correct type (class destructor may have already run)"

`OverlayTabWidget` has timers and a property animation connected to its own slots. These objects may emit signals while the widget is being torn down, after the derived portion of the receiver has already been destroyed.

This was discovered while developing the end-to-end tests for #30424, but the issue is in the generic GUI overlay lifecycle and is independent of that PR.

## Solution

Add an `OverlayTabWidget` destructor that disconnects and stops its timers and property animation before base-class and member destruction begins.
