### PR TITLE
Sketcher: Recursive groups implementation

### DIFF
--- a/src/Mod/Sketcher/App/CMakeLists.txt
+++ b/src/Mod/Sketcher/App/CMakeLists.txt
@@ -85,6 +85,7 @@ SET(Datatypes_SRCS
     Constraint.h
     Sketch.cpp
     Sketch.h
+    GroupHierarchy.h
     GeoList.h
     GeoList.cpp
     GeometryFacade.cpp

--- a/src/Mod/Sketcher/App/Constraint.cpp
+++ b/src/Mod/Sketcher/App/Constraint.cpp
@@ -178,12 +178,12 @@ void Constraint::Save(Writer& writer) const
     // Save elements
     {
         // Ensure backwards compatibility with old versions
-        writer.Stream() << "First=\"" << getElement(0).GeoId << "\" "
-                        << "FirstPos=\"" << getElement(0).posIdAsInt() << "\" "
-                        << "Second=\"" << getElement(1).GeoId << "\" "
-                        << "SecondPos=\"" << getElement(1).posIdAsInt() << "\" "
-                        << "Third=\"" << getElement(2).GeoId << "\" "
-                        << "ThirdPos=\"" << getElement(2).posIdAsInt() << "\" ";
+        writer.Stream() << "First=\"" << getGeoId(0) << "\" "
+                        << "FirstPos=\"" << getPosIdAsInt(0) << "\" "
+                        << "Second=\"" << getGeoId(1) << "\" "
+                        << "SecondPos=\"" << getPosIdAsInt(1) << "\" "
+                        << "Third=\"" << getGeoId(2) << "\" "
+                        << "ThirdPos=\"" << getPosIdAsInt(2) << "\" ";
 #if SKETCHER_CONSTRAINT_USE_LEGACY_ELEMENTS
         auto elements = std::views::iota(size_t {0}, this->elements.size())
             | std::views::transform([&](size_t i) { return getElement(i); });

--- a/src/Mod/Sketcher/App/GroupHierarchy.h
+++ b/src/Mod/Sketcher/App/GroupHierarchy.h
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <map>
+#include <set>
+#include <vector>
+
+#include "Constraint.h"
+
+namespace Sketcher
+{
+
+/// Groups form a forest: a member has one parent, and a child group is represented by its handle.
+class GroupHierarchy
+{
+public:
+    explicit GroupHierarchy(const std::vector<Constraint*>& constraints, bool activeOnly = true)
+    {
+        for (const auto* c : constraints) {
+            if ((activeOnly && !c->isActive) || (c->Type != Group && c->Type != Text)) {
+                continue;
+            }
+            const int handle = c->getGeoId(0);
+            if (handle < 0 || !children.emplace(handle, std::vector<int>()).second) {
+                valid = false;
+                continue;
+            }
+            for (int i = 1; c->hasElement(i); ++i) {
+                const int member = c->getGeoId(i);
+                // Older constraint records pad the first three slots with GeoUndef.
+                if (member == GeoEnum::GeoUndef) {
+                    continue;
+                }
+                if (member < 0 || !parents.emplace(member, handle).second) {
+                    valid = false;
+                }
+                children[handle].push_back(member);
+            }
+        }
+        std::set<int> complete;
+        for (const auto& [handle, members] : children) {
+            std::set<int> visited;
+            int current = handle;
+            while (parents.contains(current) && !complete.contains(current)) {
+                if (!visited.insert(current).second) {
+                    valid = false;
+                    break;
+                }
+                current = parents.at(current);
+            }
+            complete.insert(visited.begin(), visited.end());
+        }
+    }
+
+    std::set<int> descendants(int handle) const
+    {
+        std::set<int> result;
+        std::vector<int> pending {handle};
+        while (!pending.empty()) {
+            const int current = pending.back();
+            pending.pop_back();
+            if (auto it = children.find(current); it != children.end()) {
+                for (int member : it->second) {
+                    if (member != handle && result.insert(member).second) {
+                        pending.push_back(member);
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    bool valid = true;
+    std::map<int, int> parents;
+    std::map<int, std::vector<int>> children;
+};
+
+}  // namespace Sketcher

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -2615,8 +2615,7 @@ int Sketch::addConstraint(const Constraint* constraint)
                 if (member == GeoEnum::GeoUndef) {
                     continue;
                 }
-                if (member < 0 || member >= static_cast<int>(Geoms.size())
-                    || Geoms[member].external) {
+                if (member < 0 || member >= static_cast<int>(Geoms.size()) || Geoms[member].external) {
                     return -1;
                 }
             }
@@ -5831,8 +5830,10 @@ void Sketch::applyGroupTransformations()
         Base::Matrix4D R;  // Identity
         if (preLen > Precision::Confusion()) {
             // Signed planar angle also handles a 180-degree turn (zero cross product).
-            const double angle = std::atan2(preVec.x * postVec.y - preVec.y * postVec.x,
-                                            preVec.x * postVec.x + preVec.y * postVec.y);
+            const double angle = std::atan2(
+                preVec.x * postVec.y - preVec.y * postVec.x,
+                preVec.x * postVec.x + preVec.y * postVec.y
+            );
             R.rotZ(angle);
         }
 

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -53,6 +53,7 @@
 
 #include "Constraint.h"
 #include "GeometryFacade.h"
+#include "GroupHierarchy.h"
 #include "Sketch.h"
 #include "SolverGeometryExtension.h"
 
@@ -263,14 +264,18 @@ int Sketch::setUpSketch(
     clear();
 
     // The geometries that are in groups are going to be ignored by the solver.
-    std::set<int> inGroupGeoIds;
-    for (const auto& c : ConstraintList) {
-        if (c->Type == Group || c->Type == Text) {
-            // Start from index 1, as 0 is the frame.
-            for (int i = 1; c->hasElement(i); ++i) {
-                inGroupGeoIds.insert(c->getGeoId(i));
+    const GroupHierarchy hierarchy(ConstraintList);
+    if (!hierarchy.valid) {
+        for (size_t i = 0; i < ConstraintList.size(); ++i) {
+            if (ConstraintList[i]->Type == Group || ConstraintList[i]->Type == Text) {
+                MalformedConstraints.push_back(static_cast<int>(i) + 1);
             }
         }
+        return 0;
+    }
+    std::set<int> inGroupGeoIds;
+    for (const auto& [member, parent] : hierarchy.parents) {
+        inGroupGeoIds.insert(member);
     }
 
     std::vector<Part::Geometry*> intGeoList, extGeoList;
@@ -2599,8 +2604,21 @@ int Sketch::addConstraint(const Constraint* constraint)
                 return -1;
             }
             // Check that the first element is correctly the group construction line
-            if (Geoms[checkGeoId(constraint->getGeoId(0))].type != Line) {
+            const int handle = constraint->getGeoId(0);
+            if (handle < 0 || handle >= static_cast<int>(Geoms.size())
+                || !Geoms[handle].geo->is<Part::GeomLineSegment>()) {
                 return -1;
+            }
+
+            for (int i = 1; constraint->hasElement(i); ++i) {
+                const int member = constraint->getGeoId(i);
+                if (member == GeoEnum::GeoUndef) {
+                    continue;
+                }
+                if (member < 0 || member >= static_cast<int>(Geoms.size())
+                    || Geoms[member].external) {
+                    return -1;
+                }
             }
 
             rtn = ++ConstraintsCounter;
@@ -5738,8 +5756,11 @@ void Sketch::captureGroupStates()
 {
     preSolveGroupStates.clear();
 
-    // A set to keep track of which parameters we've already moved.
-    std::set<double*> movedParams;
+    std::vector<Constraint*> constraints;
+    for (const auto& def : Constrs) {
+        constraints.push_back(def.constr);
+    }
+    const GroupHierarchy hierarchy(constraints);
 
     for (const auto& constrDef : Constrs) {
         const Constraint* c = constrDef.constr;
@@ -5750,6 +5771,9 @@ void Sketch::captureGroupStates()
 
         // --- Capture Frame State ---
         int frameGeoId = c->getGeoId(0);
+        if (hierarchy.parents.contains(frameGeoId)) {
+            continue;
+        }
         preSolveGroupStates[frameGeoId] = getGroupLineState(frameGeoId);
     }
 }
@@ -5760,6 +5784,12 @@ void Sketch::applyGroupTransformations()
         return;
     }
 
+    std::vector<Constraint*> constraints;
+    for (const auto& def : Constrs) {
+        constraints.push_back(def.constr);
+    }
+    const GroupHierarchy hierarchy(constraints);
+
     for (const auto& constrDef : Constrs) {
         const Constraint* c = constrDef.constr;
         if ((c->Type != Group && c->Type != Text) || !c->hasElement(1)) {
@@ -5767,6 +5797,9 @@ void Sketch::applyGroupTransformations()
         }
 
         int frameGeoId = c->getGeoId(0);
+        if (!preSolveGroupStates.contains(frameGeoId)) {
+            continue;
+        }
 
         // Get the "before" and "after" states of the frame line
         GroupLineState preSolveFrame = preSolveGroupStates.at(frameGeoId);
@@ -5797,13 +5830,10 @@ void Sketch::applyGroupTransformations()
         // 3. R: Matrix for rotation
         Base::Matrix4D R;  // Identity
         if (preLen > Precision::Confusion()) {
-            // We can get the axis and angle from the two vectors and use rotLine
-            Base::Vector3d rotationAxis = preVec.Cross(postVec);
-            double rotationAngle = preVec.GetAngle(postVec);
-            // Only apply rotation if the vectors are not collinear
-            if (rotationAxis.Length() > Precision::Confusion()) {
-                R.rotLine(rotationAxis, rotationAngle);
-            }
+            // Signed planar angle also handles a 180-degree turn (zero cross product).
+            const double angle = std::atan2(preVec.x * postVec.y - preVec.y * postVec.x,
+                                            preVec.x * postVec.x + preVec.y * postVec.y);
+            R.rotZ(angle);
         }
 
         // 4. T2: Matrix to translate the group to its new final position
@@ -5816,12 +5846,7 @@ void Sketch::applyGroupTransformations()
         Base::Matrix4D transform = T2 * R * S * T1;
 
         // --- Loop through grouped elements and apply the transform ---
-        for (int i = 1; c->hasElement(i); ++i) {
-            int groupedGeoId = c->getGeoId(i);
-            if (groupedGeoId == GeoEnum::GeoUndef) {
-                continue;
-            }
-
+        for (int groupedGeoId : hierarchy.descendants(frameGeoId)) {
             // Get the slave's current (pre-solve) state
             Part::Geometry* groupedGeo = Geoms[checkGeoId(groupedGeoId)].geo;
 

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -58,6 +58,7 @@
 #include <memory>
 
 #include "GeoEnum.h"
+#include "GroupHierarchy.h"
 #include "SketchObject.h"
 #include "Constraint.h"
 #include "SketchObjectPy.h"
@@ -829,10 +830,13 @@ bool SketchObject::evaluateSupport()
 
 bool SketchObject::isInGroup(int geoId, bool includeHandle) const
 {
+    if (geoId == GeoEnum::GeoUndef) {
+        return false;
+    }
     const std::vector<Sketcher::Constraint*>& vals = Constraints.getValues();
 
     for (const auto& constr : vals) {
-        if (constr->Type == Group || constr->Type == Text) {
+        if (constr->isActive && (constr->Type == Group || constr->Type == Text)) {
             // First is the group construction line. We include it or not in our search.
             int iStart = includeHandle ? 0 : 1;
             for (int i = iStart; constr->hasElement(i); ++i) {
@@ -861,39 +865,36 @@ bool SketchObject::isGroupHandle(int geoId) const
 
 int SketchObject::getGroupHandleIfInGroup(int geoId)
 {
-    const std::vector<Sketcher::Constraint*>& vals = Constraints.getValues();
-
-    for (const auto& constr : vals) {
-        if (constr->Type == Group || constr->Type == Text) {
-            // First is the group construction line.
-            int groupHandleGeoId = -1;
-            for (int i = 0; constr->hasElement(i); ++i) {
-                if (i == 0) {
-                    groupHandleGeoId = constr->getGeoId(i);
+    if (geoId < 0) {
+        return geoId;
+    }
+    const auto& constraints = Constraints.getValues();
+    std::set<int> visited;
+    while (visited.insert(geoId).second) {
+        const int current = geoId;
+        for (const auto* c : constraints) {
+            if (c->isActive && (c->Type == Group || c->Type == Text)) {
+                for (int i = 1; c->hasElement(i); ++i) {
+                    if (c->getGeoId(i) == current) {
+                        geoId = c->getGeoId(0);
+                        break;
+                    }
                 }
-                else if (constr->getGeoId(i) == geoId) {
-                    return groupHandleGeoId;
+                if (geoId != current) {
+                    break;
                 }
             }
         }
+        if (geoId == current) {
+            return geoId;
+        }
     }
-    return geoId;
+    return geoId;  // A malformed cycle must not hang selection or drawing.
 }
 
 std::set<int> SketchObject::getGroupGeometries(int handleGeoId) const
 {
-    std::set<int> geoIds;
-    const std::vector<Sketcher::Constraint*>& vals = Constraints.getValues();
-    for (const auto& constr : vals) {
-        if (constr->Type == Group || constr->Type == Text) {
-            if (constr->getGeoId(0) == handleGeoId) {
-                for (int i = 1; constr->hasElement(i); ++i) {
-                    geoIds.insert(constr->getElement(i).GeoId);
-                }
-            }
-        }
-    }
-    return geoIds;
+    return GroupHierarchy(Constraints.getValues(), false).descendants(handleGeoId);
 }
 
 PyObject* SketchObject::getPyObject()

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -153,9 +153,10 @@ public:
      */
     bool isInGroup(int geoId, bool includeHandle = true) const;
     bool isGroupHandle(int geoId) const;
+    /// All descendants, including handles and members of nested groups.
     std::set<int> getGroupGeometries(int handleGeoId) const;
     /*!
-     \brief Returns geoId if it's not in a group. Or the group handle if it is in a group.
+     \brief Returns the outermost active group handle, or geoId if it is not grouped.
      \param geoId - the geometry id in the sketch
      */
     int getGroupHandleIfInGroup(int geoId);

--- a/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
@@ -988,7 +988,7 @@ int SketchObject::delConstraints(std::vector<int> ConstrIds, DeleteOptions optio
     const std::set<int> removedIndices(ConstrIds.begin(), ConstrIds.end());
     for (int id : removedIndices) {
         const auto* c = vals[id];
-        if (c->isActive && (c->Type == Group || c->Type == Text)) {
+        if (c->Type == Group || c->Type == Text) {
             removedGroups.emplace(c->getGeoId(0), c);
         }
     }
@@ -1005,12 +1005,13 @@ int SketchObject::delConstraints(std::vector<int> ConstrIds, DeleteOptions optio
                 members.push_back(member);
             }
         }
-        const size_t originalSize = members.size();
+        bool expanded = false;
         for (size_t i = 0; i < members.size(); ++i) {
             auto group = removedGroups.find(members[i]);
             if (group == removedGroups.end()) {
                 continue;
             }
+            expanded = true;
             for (int j = 1; group->second->hasElement(j); ++j) {
                 const int member = group->second->getGeoId(j);
                 if (member != GeoEnum::GeoUndef && visited.insert(member).second) {
@@ -1018,11 +1019,13 @@ int SketchObject::delConstraints(std::vector<int> ConstrIds, DeleteOptions optio
                 }
             }
         }
-        if (members.size() != originalSize) {
+        if (expanded) {
             auto* replacement = c->clone();
             replacement->truncateElements(1);
             for (int member : members) {
-                replacement->addElement(GeoElementId(member));
+                if (!removedGroups.contains(member)) {
+                    replacement->addElement(GeoElementId(member));
+                }
             }
             newVals[id] = replacement;
         }
@@ -1035,6 +1038,17 @@ int SketchObject::delConstraints(std::vector<int> ConstrIds, DeleteOptions optio
     }
 
     this->Constraints.setValues(std::move(newVals));
+
+    // Ungrouping releases the members, but the group-owned handle is no longer geometry.
+    std::vector<int> removedHandles;
+    for (const auto& [handle, group] : removedGroups) {
+        if (handle >= 0 && handle <= getHighestCurveIndex() && !isGroupHandle(handle)) {
+            removedHandles.push_back(handle);
+        }
+    }
+    if (!removedHandles.empty()) {
+        delGeometriesExclusiveList(removedHandles, DeleteOption::NoSolve);
+    }
 
     // if we do not have a recompute, the sketch must be solved to update the DoF of the solver
     if (noRecomputes && !options.testFlag(DeleteOption::NoSolve)) {

--- a/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
@@ -963,26 +963,7 @@ int SketchObject::addConstraint(std::unique_ptr<Constraint> constraint)
 
 int SketchObject::delConstraint(int ConstrId, DeleteOptions options)
 {
-    // no need to check input data validity as this is an sketchobject managed operation.
-    Base::StateLocker lock(managedoperation, true);
-
-    const std::vector<Constraint*>& vals = this->Constraints.getValues();
-    if (ConstrId < 0 || ConstrId >= int(vals.size())) {
-        return -1;
-    }
-
-    std::vector<Constraint*> newVals(vals);
-    auto ctriter = newVals.begin() + ConstrId;
-    removeGeometryState(*ctriter);
-    newVals.erase(ctriter);
-    this->Constraints.setValues(std::move(newVals));
-
-    // if we do not have a recompute, the sketch must be solved to update the DoF of the solver
-    if (noRecomputes && !options.testFlag(DeleteOption::NoSolve)) {
-        solve(options.testFlag(DeleteOption::UpdateGeometry));
-    }
-
-    return 0;
+    return delConstraints({ConstrId}, options);
 }
 
 int SketchObject::delConstraints(std::vector<int> ConstrIds, DeleteOptions options)
@@ -1001,6 +982,51 @@ int SketchObject::delConstraints(std::vector<int> ConstrIds, DeleteOptions optio
 
     if (ConstrIds.front() < 0 || ConstrIds.back() >= int(vals.size()))
         return -1;
+
+    // Ungrouping a nested group must leave its members inside the surviving parent.
+    std::map<int, const Constraint*> removedGroups;
+    const std::set<int> removedIndices(ConstrIds.begin(), ConstrIds.end());
+    for (int id : removedIndices) {
+        const auto* c = vals[id];
+        if (c->isActive && (c->Type == Group || c->Type == Text)) {
+            removedGroups.emplace(c->getGeoId(0), c);
+        }
+    }
+    for (size_t id = 0; id < newVals.size() && !removedGroups.empty(); ++id) {
+        const auto* c = newVals[id];
+        if (removedIndices.contains(static_cast<int>(id)) || c->Type != Group) {
+            continue;
+        }
+        std::vector<int> members;
+        std::set<int> visited {c->getGeoId(0)};
+        for (int i = 1; c->hasElement(i); ++i) {
+            const int member = c->getGeoId(i);
+            if (member != GeoEnum::GeoUndef && visited.insert(member).second) {
+                members.push_back(member);
+            }
+        }
+        const size_t originalSize = members.size();
+        for (size_t i = 0; i < members.size(); ++i) {
+            auto group = removedGroups.find(members[i]);
+            if (group == removedGroups.end()) {
+                continue;
+            }
+            for (int j = 1; group->second->hasElement(j); ++j) {
+                const int member = group->second->getGeoId(j);
+                if (member != GeoEnum::GeoUndef && visited.insert(member).second) {
+                    members.push_back(member);
+                }
+            }
+        }
+        if (members.size() != originalSize) {
+            auto* replacement = c->clone();
+            replacement->truncateElements(1);
+            for (int member : members) {
+                replacement->addElement(GeoElementId(member));
+            }
+            newVals[id] = replacement;
+        }
+    }
 
     for (auto rit = ConstrIds.rbegin(); rit != ConstrIds.rend(); rit++) {
         auto ctriter = newVals.begin() + *rit;

--- a/src/Mod/Sketcher/CMakeLists.txt
+++ b/src/Mod/Sketcher/CMakeLists.txt
@@ -22,6 +22,7 @@ set(Sketcher_TestScripts
     SketcherTests/TestSketchValidateCoincidents.py
     SketcherTests/TestSketchCarbonCopyReverseMapping.py
     SketcherTests/TestSketchCarbonCopyReverseMapping.FCStd
+    SketcherTests/TestSketchGroups.py
     SketcherTests/TestSketchInternalFaces.py
     SketcherTests/TestSketcherEllipse.py
 )
@@ -34,6 +35,7 @@ if(BUILD_GUI)
     list (APPEND Sketcher_TestScripts
           SketcherTests/TestConstraintPreselectionGui.py
           SketcherTests/GuiTestCase.py
+          SketcherTests/TestSketchGroupsGui.py
           SketcherTests/TestPlacementUpdate.py
           SketcherTests/TestOnViewParameterGui.py
           SketcherTests/TestExternalFacePreselection.py

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -11422,6 +11422,9 @@ void CmdSketcherConstrainGroup::activated(int iMsg)
         Sketcher::PointPos posId;
         getIdsFromName(subName, Obj, geoId, posId);
 
+        // A selected member represents its whole outermost group.
+        geoId = Obj->getGroupHandleIfInGroup(geoId);
+
         bool alreadyAdded = std::any_of(elts.begin(), elts.end(),
                                 [geoId](const Sketcher::GeoElementId& elem) {
                                     return elem.GeoId == geoId;

--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -126,7 +126,7 @@ int getConstraintId(std::string_view name)
     return std::atoi(name.substr(constr.size(), maxlen).data()) - 1;
 }
 
-std::vector<int> getListOfSelectedGeoIds(bool forceInternalSelection)
+std::vector<int> getListOfSelectedGeoIds(bool forceInternalSelection, bool expandGroups = false)
 {
     std::vector<int> listOfGeoIds = {};
 
@@ -169,6 +169,25 @@ std::vector<int> getListOfSelectedGeoIds(bool forceInternalSelection)
                 }
             }
         }
+    }
+
+    if (expandGroups) {
+        std::vector<int> expanded;
+        std::set<int> seen;
+        for (int geoId : listOfGeoIds) {
+            const int root = Obj->getGroupHandleIfInGroup(geoId);
+            if (seen.insert(root).second) {
+                expanded.push_back(root);
+            }
+            if (Obj->isGroupHandle(root)) {
+                for (int member : Obj->getGroupGeometries(root)) {
+                    if (seen.insert(member).second) {
+                        expanded.push_back(member);
+                    }
+                }
+            }
+        }
+        listOfGeoIds = std::move(expanded);
     }
 
     if (forceInternalSelection) {
@@ -2527,7 +2546,7 @@ CmdSketcherRotate::CmdSketcherRotate()
 void CmdSketcherRotate::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    std::vector<int> listOfGeoIds = getListOfSelectedGeoIds(true);
+    std::vector<int> listOfGeoIds = getListOfSelectedGeoIds(true, true);
 
     if (!listOfGeoIds.empty()) {
         ActivateHandler(getActiveGuiDocument(), std::make_unique<DrawSketchHandlerRotate>(listOfGeoIds));
@@ -2561,7 +2580,7 @@ CmdSketcherScale::CmdSketcherScale()
 void CmdSketcherScale::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    std::vector<int> listOfGeoIds = getListOfSelectedGeoIds(true);
+    std::vector<int> listOfGeoIds = getListOfSelectedGeoIds(true, true);
 
     if (!listOfGeoIds.empty()) {
         ActivateHandler(getActiveGuiDocument(), std::make_unique<DrawSketchHandlerScale>(listOfGeoIds));
@@ -2595,7 +2614,7 @@ CmdSketcherTranslate::CmdSketcherTranslate()
 void CmdSketcherTranslate::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    std::vector<int> listOfGeoIds = getListOfSelectedGeoIds(true);
+    std::vector<int> listOfGeoIds = getListOfSelectedGeoIds(true, true);
 
     if (!listOfGeoIds.empty()) {
         ActivateHandler(getActiveGuiDocument(), std::make_unique<DrawSketchHandlerTranslate>(listOfGeoIds));

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
@@ -426,6 +426,15 @@ private:
                     int secondIndexi = firstCurveCreated + secondIndex + static_cast<int>(size * i);
                     int thirdIndexi = firstCurveCreated + thirdIndex + static_cast<int>(size * i);
 
+                    if (cstr->Type == Group || cstr->Type == Text) {
+                        auto group = copyTransformedGroup(*cstr, listOfGeoIds,
+                                                          firstCurveCreated + static_cast<int>(size * i));
+                        if (group) {
+                            ShapeConstraints.push_back(std::move(group));
+                        }
+                        continue;
+                    }
+
                     auto newConstr = std::unique_ptr<Constraint>(cstr->copy());
                     newConstr->First = firstIndexi;
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
@@ -427,8 +427,11 @@ private:
                     int thirdIndexi = firstCurveCreated + thirdIndex + static_cast<int>(size * i);
 
                     if (cstr->Type == Group || cstr->Type == Text) {
-                        auto group = copyTransformedGroup(*cstr, listOfGeoIds,
-                                                          firstCurveCreated + static_cast<int>(size * i));
+                        auto group = copyTransformedGroup(
+                            *cstr,
+                            listOfGeoIds,
+                            firstCurveCreated + static_cast<int>(size * i)
+                        );
                         if (group) {
                             ShapeConstraints.push_back(std::move(group));
                         }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerScale.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerScale.h
@@ -498,6 +498,14 @@ private:
             const std::vector<Constraint*>& vals = Obj->Constraints.getValues();
             int cstrIndex = 0;
             for (auto cstr : vals) {
+                if (cstr->Type == Group || cstr->Type == Text) {
+                    auto group = copyTransformedGroup(*cstr, listOfGeoIds, firstCurveCreated);
+                    if (group) {
+                        ShapeConstraints.push_back(std::move(group));
+                        cstrIndex++;
+                    }
+                    continue;
+                }
                 if (skipConstraint(cstr)) {
                     continue;
                 }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTranslate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTranslate.h
@@ -438,8 +438,11 @@ private:
                         + size * static_cast<int>(copyIndex);
 
                     if (cstr->Type == Group || cstr->Type == Text) {
-                        auto group = copyTransformedGroup(*cstr, listOfGeoIds,
-                                                          firstCurveCreated + size * static_cast<int>(copyIndex));
+                        auto group = copyTransformedGroup(
+                            *cstr,
+                            listOfGeoIds,
+                            firstCurveCreated + size * static_cast<int>(copyIndex)
+                        );
                         if (group) {
                             ShapeConstraints.push_back(std::move(group));
                         }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTranslate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTranslate.h
@@ -437,6 +437,15 @@ private:
                     int thirdIndexi = firstCurveCreated + thirdIndex
                         + size * static_cast<int>(copyIndex);
 
+                    if (cstr->Type == Group || cstr->Type == Text) {
+                        auto group = copyTransformedGroup(*cstr, listOfGeoIds,
+                                                          firstCurveCreated + size * static_cast<int>(copyIndex));
+                        if (group) {
+                            ShapeConstraints.push_back(std::move(group));
+                        }
+                        continue;
+                    }
+
                     auto newConstr = std::unique_ptr<Constraint>(cstr->copy());
                     newConstr->First = firstIndexi;
 

--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -53,6 +53,24 @@ bool Sketcher::isCircle(const Part::Geometry& geom)
     return geom.is<Part::GeomCircle>();
 }
 
+std::unique_ptr<Sketcher::Constraint> SketcherGui::copyTransformedGroup(
+    const Sketcher::Constraint& constraint, const std::vector<int>& geometry, int firstGeometry)
+{
+    auto result = std::unique_ptr<Sketcher::Constraint>(constraint.copy());
+    for (int index = 0; constraint.hasElement(index); ++index) {
+        const int geoId = constraint.getGeoId(index);
+        if (geoId == Sketcher::GeoEnum::GeoUndef) {
+            continue;
+        }
+        auto member = std::ranges::find(geometry, geoId);
+        if (member == geometry.end()) {
+            return nullptr;
+        }
+        result->setGeoId(index, firstGeometry + static_cast<int>(member - geometry.begin()));
+    }
+    return result;
+}
+
 bool Sketcher::isArcOfCircle(const Part::Geometry& geom)
 {
     return geom.is<Part::GeomArcOfCircle>();

--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -54,7 +54,10 @@ bool Sketcher::isCircle(const Part::Geometry& geom)
 }
 
 std::unique_ptr<Sketcher::Constraint> SketcherGui::copyTransformedGroup(
-    const Sketcher::Constraint& constraint, const std::vector<int>& geometry, int firstGeometry)
+    const Sketcher::Constraint& constraint,
+    const std::vector<int>& geometry,
+    int firstGeometry
+)
 {
     auto result = std::unique_ptr<Sketcher::Constraint>(constraint.copy());
     for (int index = 0; constraint.hasElement(index); ++index) {

--- a/src/Mod/Sketcher/Gui/Utils.h
+++ b/src/Mod/Sketcher/Gui/Utils.h
@@ -83,7 +83,10 @@ class ViewProviderSketch;
 
 /// Copy a complete Group/Text constraint, remapping every member into a transformed copy.
 std::unique_ptr<Sketcher::Constraint> copyTransformedGroup(
-    const Sketcher::Constraint& constraint, const std::vector<int>& geometry, int firstGeometry);
+    const Sketcher::Constraint& constraint,
+    const std::vector<int>& geometry,
+    int firstGeometry
+);
 
 enum OffsetMode : bool
 {

--- a/src/Mod/Sketcher/Gui/Utils.h
+++ b/src/Mod/Sketcher/Gui/Utils.h
@@ -24,6 +24,9 @@
 
 #pragma once
 
+#include <memory>
+#include <vector>
+
 #include <Base/Exception.h>
 #include <Base/Tools.h>
 #include <Base/Tools2D.h>
@@ -54,6 +57,7 @@ namespace Sketcher
 {
 enum class PointPos : int;
 class SketchObject;
+class Constraint;
 
 bool isCircle(const Part::Geometry&);
 bool isArcOfCircle(const Part::Geometry&);
@@ -76,6 +80,10 @@ namespace SketcherGui
 {
 class DrawSketchHandler;
 class ViewProviderSketch;
+
+/// Copy a complete Group/Text constraint, remapping every member into a transformed copy.
+std::unique_ptr<Sketcher::Constraint> copyTransformedGroup(
+    const Sketcher::Constraint& constraint, const std::vector<int>& geometry, int firstGeometry);
 
 enum OffsetMode : bool
 {

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -4845,8 +4845,6 @@ bool ViewProviderSketch::onDelete(const std::vector<std::string>& subList)
         Gui::Selection().clearSelection();
         resetPreselectPoint();
 
-        const auto& constraints = getSketchObject()->Constraints.getValues();
-
         std::set<int> delInternalGeometries, delExternalGeometries, delCoincidents, delConstraints;
         // go through the selected subelements
         for (std::vector<std::string>::const_iterator it = SubNames.begin(); it != SubNames.end();
@@ -4856,17 +4854,8 @@ bool ViewProviderSketch::onDelete(const std::vector<std::string>& subList)
                 if (GeoId >= 0) {
                     delInternalGeometries.insert(GeoId);
 
-                    // Handle group deletion
-                    for (const auto* c : constraints) {
-                        if ((c->Type == Sketcher::Text || c->Type == Sketcher::Group)
-                            && c->hasElement(0) && c->getGeoId(0) == GeoId) {
-                            // This is a group handle. Add all members to the delete list.
-                            for (int j = 1; c->hasElement(j); ++j) {
-                                delInternalGeometries.insert(c->getGeoId(j));
-                            }
-                            break; // A geo can only be a handle for one constraint.
-                        }
-                    }
+                    const auto members = getSketchObject()->getGroupGeometries(GeoId);
+                    delInternalGeometries.insert(members.begin(), members.end());
                 }
                 else
                     delExternalGeometries.insert(Sketcher::GeoEnum::RefExt - GeoId);

--- a/src/Mod/Sketcher/SketcherTests/TestSketchGroups.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketchGroups.py
@@ -79,9 +79,10 @@ class TestSketchGroups(unittest.TestCase):
         s.delConstraint(2)
         self.assertEqual(s.solve(), 0)
         self.assertEqual(sum(c.Type == "Group" for c in s.Constraints), 2)
+        self.assertEqual(s.GeometryCount, 4)
         s.addConstraint(Sketcher.Constraint("Distance", self.handles[1], 20.0))
         self.assertEqual(s.solve(), 0)
-        self.assertAlmostEqual(s.Geometry[self.circle].Radius, 4)
+        self.assertAlmostEqual(s.Geometry[self.circle - 1].Radius, 4)
 
     def testSaveRestore(self):
         self.nested()
@@ -129,7 +130,8 @@ class TestSketchGroups(unittest.TestCase):
         self.doc.commitTransaction()
         self.assertEqual(s.solve(), 0)
         s.setDatum(self.length - 2, 20.0)
-        self.assertAlmostEqual(s.Geometry[self.circle].Radius, 4)
+        self.assertEqual(s.GeometryCount, 3)
+        self.assertAlmostEqual(s.Geometry[self.circle - 2].Radius, 4)
         self.doc.undo()
         self.assertEqual(s.solve(), 0)
         self.assertEqual(sum(c.Type == "Group" for c in s.Constraints), 3)

--- a/src/Mod/Sketcher/SketcherTests/TestSketchGroups.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketchGroups.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import math
+import os
+import tempfile
+import unittest
+
+import FreeCAD as App
+import Part
+import Sketcher
+
+
+class TestSketchGroups(unittest.TestCase):
+    def setUp(self):
+        self.doc = App.newDocument("NestedGroupsTest")
+        self.sketch = self.doc.addObject("Sketcher::SketchObject", "Sketch")
+
+    def tearDown(self):
+        App.closeDocument(self.doc.Name)
+
+    def line(self, x, y=0):
+        return self.sketch.addGeometry(
+            Part.LineSegment(App.Vector(x, y, 0), App.Vector(x, y + 10, 0)), True
+        )
+
+    def group(self, handle, members):
+        elements = [handle, 0]
+        for member in members:
+            elements.extend([member, 0])
+        return Sketcher.Constraint("Group", elements)
+
+    def nested(self, reverse=False):
+        s = self.sketch
+        self.handles = [self.line(x) for x in (10, 20, 30)]
+        self.circle = s.addGeometry(Part.Circle(App.Vector(12, 4, 0), App.Vector(0, 0, 1), 2))
+        self.other = s.addGeometry(Part.LineSegment(App.Vector(23, 2, 0), App.Vector(27, 5, 0)))
+        groups = [self.group(self.handles[0], [self.circle]),
+                  self.group(self.handles[1], [self.handles[0], self.other]),
+                  self.group(self.handles[2], [self.handles[1]])]
+        s.addConstraint(list(reversed(groups)) if reverse else groups)
+        self.assertEqual(s.solve(), 0)
+        root = self.handles[2]
+        self.x = s.addConstraint(Sketcher.Constraint("DistanceX", root, 1, 30.0))
+        self.y = s.addConstraint(Sketcher.Constraint("DistanceY", root, 1, 1.0))
+        self.angle = s.addConstraint(Sketcher.Constraint("Angle", root, math.pi / 2))
+        self.length = s.addConstraint(Sketcher.Constraint("Distance", root, 10.0))
+        self.assertEqual(s.solve(), 0)
+
+    def assertVector(self, actual, expected):
+        self.assertLess((actual - expected).Length, 1e-6)
+
+    def testTransformAndRepeatedSolve(self):
+        for reverse in (False, True):
+            if reverse:
+                self.sketch = self.doc.addObject("Sketcher::SketchObject", "ReverseOrder")
+            self.nested(reverse)
+            s = self.sketch
+            before = s.Geometry
+            origin = before[self.handles[2]].StartPoint
+            s.setDatum(self.length, 20.0)
+            s.setDatum(self.angle, 3 * math.pi / 2)
+            s.setDatum(self.x, 50.0)
+            s.setDatum(self.y, 11.0)
+            target = App.Vector(50, 11, 0)
+            for _ in range(3):
+                self.assertEqual(s.solve(), 0)
+                for geo in self.handles[:2] + [self.other]:
+                    self.assertVector(s.Geometry[geo].StartPoint,
+                                      target - 2 * (before[geo].StartPoint - origin))
+                    self.assertVector(s.Geometry[geo].EndPoint,
+                                      target - 2 * (before[geo].EndPoint - origin))
+                self.assertVector(s.Geometry[self.circle].Center,
+                                  target - 2 * (before[self.circle].Center - origin))
+                self.assertAlmostEqual(s.Geometry[self.circle].Radius, 4)
+
+    def testUngroupOuterPreservesInner(self):
+        self.nested()
+        s = self.sketch
+        s.delConstraint(2)
+        self.assertEqual(s.solve(), 0)
+        self.assertEqual(sum(c.Type == "Group" for c in s.Constraints), 2)
+        s.addConstraint(Sketcher.Constraint("Distance", self.handles[1], 20.0))
+        self.assertEqual(s.solve(), 0)
+        self.assertAlmostEqual(s.Geometry[self.circle].Radius, 4)
+
+    def testSaveRestore(self):
+        self.nested()
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "Nested.FCStd")
+            self.doc.recompute()
+            self.doc.saveAs(path)
+            App.closeDocument(self.doc.Name)
+            self.doc = App.openDocument(path)
+            self.sketch = self.doc.getObject("Sketch")
+            self.assertEqual(self.sketch.solve(), 0)
+            self.sketch.setDatum(self.length, 20.0)
+            self.assertEqual(self.sketch.solve(), 0)
+            self.assertAlmostEqual(self.sketch.Geometry[self.circle].Radius, 4)
+
+    def testInvalidHierarchy(self):
+        for case in ("self", "cycle", "shared", "duplicate_handle", "duplicate_member"):
+            s = self.doc.addObject("Sketcher::SketchObject", case)
+            self.sketch = s
+            a, b, c = [self.line(x) for x in (0, 20, 40)]
+            definitions = {
+                "self": [self.group(a, [a])],
+                "cycle": [self.group(a, [b]), self.group(b, [a])],
+                "shared": [self.group(a, [c]), self.group(b, [c])],
+                "duplicate_handle": [self.group(a, [b]), self.group(a, [c])],
+                "duplicate_member": [self.group(a, [b, b])],
+            }
+            s.addConstraint(definitions[case])
+            self.assertEqual(s.solve(), -5, case)
+
+    def testDeactivateOuter(self):
+        self.nested()
+        s = self.sketch
+        s.toggleActive(2)
+        self.assertEqual(s.solve(), 0)
+        before = s.Geometry[self.circle].Center
+        s.setDatum(self.length, 20.0)
+        self.assertVector(s.Geometry[self.circle].Center, before)
+
+    def testUngroupInnerAndUndo(self):
+        self.nested()
+        s = self.sketch
+        self.doc.openTransaction("Ungroup inner levels")
+        s.delConstraints([0, 1])
+        self.doc.commitTransaction()
+        self.assertEqual(s.solve(), 0)
+        s.setDatum(self.length - 2, 20.0)
+        self.assertAlmostEqual(s.Geometry[self.circle].Radius, 4)
+        self.doc.undo()
+        self.assertEqual(s.solve(), 0)
+        self.assertEqual(sum(c.Type == "Group" for c in s.Constraints), 3)
+
+    def testExpressionAndQuarterTurn(self):
+        self.nested()
+        s = self.sketch
+        before = s.Geometry[self.circle].Center
+        origin = s.Geometry[self.handles[2]].StartPoint
+        s.addProperty("App::PropertyLength", "GroupLength")
+        s.GroupLength = 15
+        s.setExpression("Constraints[{}]".format(self.length), "GroupLength")
+        self.doc.recompute()
+        s.setDatum(self.angle, math.pi)
+        delta = before - origin
+        self.assertVector(s.Geometry[self.circle].Center,
+                          origin + 1.5 * App.Vector(-delta.y, delta.x, 0))
+        self.assertAlmostEqual(s.Geometry[self.circle].Radius, 3)
+
+    def testChildDimensionsAreDormant(self):
+        self.nested()
+        s = self.sketch
+        child_length = s.addConstraint(Sketcher.Constraint("Distance", self.handles[0], 10.0))
+        self.assertEqual(s.solve(), 0)
+        s.setDatum(self.length, 20.0)
+        self.assertAlmostEqual(s.Geometry[self.handles[0]].length(), 20)
+        self.assertAlmostEqual(s.Constraints[child_length].Value, 10)
+        s.delConstraints([1, 2])
+        self.assertEqual(s.solve(), 0)
+        self.assertAlmostEqual(s.Geometry[self.handles[0]].length(), 10)
+
+    def testDragOuterHandle(self):
+        self.nested()
+        s = self.sketch
+        s.delConstraints([self.x, self.y])
+        self.assertEqual(s.solve(), 0)
+        root = self.handles[2]
+        before = s.Geometry[self.circle].Center
+        origin = s.Geometry[root].StartPoint
+        for delta in (App.Vector(15, 15, 0), App.Vector(-10, -10, 0)):
+            s.moveGeometry(root, 1, origin + delta, 0)
+            self.assertEqual(s.solve(), 0)
+            self.assertVector(s.Geometry[self.circle].Center, before + delta)
+
+    def testDeepHierarchy(self):
+        s = self.sketch
+        circle = s.addGeometry(Part.Circle(App.Vector(1, 2, 0), App.Vector(0, 0, 1), 2))
+        child = circle
+        constraints = []
+        for i in range(100):
+            handle = self.line(10 + i)
+            constraints.append(self.group(handle, [child]))
+            child = handle
+        s.addConstraint(list(reversed(constraints)))
+        self.assertEqual(s.solve(), 0)
+        s.addConstraint(Sketcher.Constraint("Distance", handle, 20.0))
+        self.assertEqual(s.solve(), 0)
+        self.assertAlmostEqual(s.Geometry[circle].Radius, 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/Sketcher/SketcherTests/TestSketchGroups.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketchGroups.py
@@ -34,9 +34,11 @@ class TestSketchGroups(unittest.TestCase):
         self.handles = [self.line(x) for x in (10, 20, 30)]
         self.circle = s.addGeometry(Part.Circle(App.Vector(12, 4, 0), App.Vector(0, 0, 1), 2))
         self.other = s.addGeometry(Part.LineSegment(App.Vector(23, 2, 0), App.Vector(27, 5, 0)))
-        groups = [self.group(self.handles[0], [self.circle]),
-                  self.group(self.handles[1], [self.handles[0], self.other]),
-                  self.group(self.handles[2], [self.handles[1]])]
+        groups = [
+            self.group(self.handles[0], [self.circle]),
+            self.group(self.handles[1], [self.handles[0], self.other]),
+            self.group(self.handles[2], [self.handles[1]]),
+        ]
         s.addConstraint(list(reversed(groups)) if reverse else groups)
         self.assertEqual(s.solve(), 0)
         root = self.handles[2]
@@ -65,12 +67,16 @@ class TestSketchGroups(unittest.TestCase):
             for _ in range(3):
                 self.assertEqual(s.solve(), 0)
                 for geo in self.handles[:2] + [self.other]:
-                    self.assertVector(s.Geometry[geo].StartPoint,
-                                      target - 2 * (before[geo].StartPoint - origin))
-                    self.assertVector(s.Geometry[geo].EndPoint,
-                                      target - 2 * (before[geo].EndPoint - origin))
-                self.assertVector(s.Geometry[self.circle].Center,
-                                  target - 2 * (before[self.circle].Center - origin))
+                    self.assertVector(
+                        s.Geometry[geo].StartPoint, target - 2 * (before[geo].StartPoint - origin)
+                    )
+                    self.assertVector(
+                        s.Geometry[geo].EndPoint, target - 2 * (before[geo].EndPoint - origin)
+                    )
+                self.assertVector(
+                    s.Geometry[self.circle].Center,
+                    target - 2 * (before[self.circle].Center - origin),
+                )
                 self.assertAlmostEqual(s.Geometry[self.circle].Radius, 4)
 
     def testUngroupOuterPreservesInner(self):
@@ -147,8 +153,9 @@ class TestSketchGroups(unittest.TestCase):
         self.doc.recompute()
         s.setDatum(self.angle, math.pi)
         delta = before - origin
-        self.assertVector(s.Geometry[self.circle].Center,
-                          origin + 1.5 * App.Vector(-delta.y, delta.x, 0))
+        self.assertVector(
+            s.Geometry[self.circle].Center, origin + 1.5 * App.Vector(-delta.y, delta.x, 0)
+        )
         self.assertAlmostEqual(s.Geometry[self.circle].Radius, 3)
 
     def testChildDimensionsAreDormant(self):

--- a/src/Mod/Sketcher/SketcherTests/TestSketchGroupsGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketchGroupsGui.py
@@ -10,6 +10,92 @@ from SketcherTests.GuiTestCase import FreeCADGui as Gui, SketcherGuiTestCase
 
 
 class TestSketchGroupsGui(SketcherGuiTestCase):
+    def testGroupOnlySelectedGeometry(self):
+        Gui.activateWorkbench("SketcherWorkbench")
+        self.doc = App.newDocument("GroupSelection")
+        s = self.doc.addObject("Sketcher::SketchObject", "Sketch")
+        for x in (0, 10, 20):
+            s.addGeometry(Part.Circle(App.Vector(x, 0, 0), App.Vector(0, 0, 1), 2))
+        self.doc.recompute()
+        Gui.activeDocument().setEdit(s.Name)
+        Gui.Selection.clearSelection()
+        for edge in ("Edge1", "Edge2"):
+            Gui.Selection.addSelection(s, edge)
+        Gui.runCommand("Sketcher_ConstrainGroup")
+        self.assertEqual((s.GeometryCount, s.ConstraintCount), (4, 1))
+        untouched = s.Geometry[2].Content
+        s.addConstraint(Sketcher.Constraint("Distance", 3, 8.0))
+        self.assertEqual(s.solve(), 0)
+        self.assertAlmostEqual(s.Geometry[0].Radius, 4)
+        self.assertAlmostEqual(s.Geometry[1].Radius, 4)
+        self.assertEqual(s.Geometry[2].Content, untouched)
+
+    def testGroupTransforms(self):
+        Gui.activateWorkbench("SketcherWorkbench")
+        for command in ("Rotate", "Translate", "Scale"):
+            for pattern in (False, True):
+                with self.subTest(command=command, pattern=pattern):
+                    self.doc = App.newDocument("GroupTransform")
+                    s = self.doc.addObject("Sketcher::SketchObject", "Sketch")
+                    s.addGeometry(Part.Circle(App.Vector(12, 14, 0), App.Vector(0, 0, 1), 2))
+                    s.addGeometry(Part.Point(App.Vector(16, 18, 0)))
+                    for x in (10, 20):
+                        s.addGeometry(Part.LineSegment(App.Vector(x, 10, 0), App.Vector(x, 20, 0)), True)
+                    s.addConstraint(Sketcher.Constraint("Group", [2, 0, 0, 0, 1, 0]))
+                    s.addConstraint(Sketcher.Constraint("Group", [3, 0, 2, 0]))
+                    self.doc.recompute()
+                    Gui.activeDocument().setEdit(s.Name)
+                    view = Gui.activeDocument().activeView()
+                    view.setCamera('#Inventor V2.1 ascii\nOrthographicCamera { position 0 0 100 '
+                                   'orientation 0 0 1 0 focalDistance 100 height 100 }')
+                    self.flush_gui(150)
+                    viewport = view.graphicsView().viewport()
+                    # Selecting a leaf must transform its entire outer group, including points.
+                    Gui.Selection.clearSelection()
+                    Gui.Selection.addSelection(s, "Edge1")
+                    Gui.runCommand("Sketcher_" + command)
+                    self.flush_gui(150)
+                    points = [(0, 0), (20, 0)]
+                    if command == "Rotate":
+                        points.append((0, 20))
+                    elif command == "Scale":
+                        points.append((40, 0))
+                    for index, (x, y) in enumerate(points):
+                        pos = self.viewport_to_qpoint(view, viewport,
+                                                     view.getPointOnScreen(App.Vector(x, y, 0)))
+                        self.move(viewport, pos)
+                        self.click(viewport, pos)
+                        if index == 0 and pattern:
+                            self.key_click(viewport, QtCore.Qt.Key_U, "u")
+                    self.assertEqual(s.GeometryCount, 8 if pattern else 4)
+                    self.assertEqual(sum(c.Type == "Group" for c in s.Constraints), 4 if pattern else 2)
+                    self.assertEqual(s.solve(), 0)
+                    first = 4 if pattern else 0
+                    root, circle, point, child = s.Geometry[first:first + 4]
+                    # Derive the transformation from the outer handle: every member must
+                    # follow it exactly, independently of mouse pixel rounding or snapping.
+                    y_axis = (root.EndPoint - root.StartPoint) / 10
+                    x_axis = App.Vector(y_axis.y, -y_axis.x, 0)
+                    def transformed_point(x, y):
+                        return root.StartPoint + x_axis * (x - 20) + y_axis * (y - 10)
+                    for actual, expected in (
+                        (circle.Center, transformed_point(12, 14)),
+                        (point.toShape().Point, transformed_point(16, 18)),
+                        (child.StartPoint, transformed_point(10, 10)),
+                        (child.EndPoint, transformed_point(10, 20)),
+                    ):
+                        self.assertLess((actual - expected).Length, 1e-6)
+                    self.assertAlmostEqual(circle.Radius, 2 * y_axis.Length)
+                    self.assertGreater((root.StartPoint - App.Vector(20, 10, 0)).Length, 10)
+                    transformed = [g.Content for g in s.Geometry]
+                    self.doc.undo()
+                    self.assertEqual(s.GeometryCount, 4)
+                    self.assertEqual(sum(c.Type == "Group" for c in s.Constraints), 2)
+                    self.doc.redo()
+                    self.assertEqual([g.Content for g in s.Geometry], transformed)
+                    self.cleanup_gui_document(self.doc)
+                    self.doc = None
+
     def testNestedTextGroup(self):
         font = os.path.join(App.getResourceDir(), "examples", "osifont-lgpl3fe.ttf")
         if not os.path.isfile(font):
@@ -37,6 +123,16 @@ class TestSketchGroupsGui(SketcherGuiTestCase):
         self.assertEqual(s.solve(), 0)
         self.assertEqual((s.GeometryCount, s.ConstraintCount), (before + 1, 3))
 
+        # Ungrouping two text objects must remove only the outer group's handle.
+        Gui.Selection.clearSelection()
+        Gui.Selection.addSelection(s, "Constraint3")
+        Gui.runCommand("Std_Delete", 0)
+        self.assertEqual((s.GeometryCount, s.ConstraintCount), (before, 2))
+        self.assertEqual(sum(c.Type == "Text" for c in s.Constraints), 2)
+        self.assertEqual(s.solve(), 0)
+        self.doc.undo()
+        self.assertEqual((s.GeometryCount, s.ConstraintCount), (before + 1, 3))
+
         circle = s.addGeometry(Part.Circle(App.Vector(60, 5, 0), App.Vector(0, 0, 1), 2))
         select([0, circle])  # Selecting a text member must select its outer group.
         Gui.runCommand("Sketcher_ConstrainGroup", 0)
@@ -53,6 +149,34 @@ class TestSketchGroupsGui(SketcherGuiTestCase):
         self.assertEqual(len(groups), 2)
         root = groups[-1].First
         counts = (s.GeometryCount, s.ConstraintCount)
+
+        # Pattern copies must retain both levels of groups and editable text constraints.
+        for command in ("Rotate", "Translate", "Scale"):
+            select([root])
+            view = Gui.activeDocument().activeView()
+            view.setCamera('#Inventor V2.1 ascii\nOrthographicCamera { position 0 0 100 '
+                           'orientation 0 0 1 0 focalDistance 100 height 100 }')
+            Gui.runCommand("Sketcher_" + command)
+            self.flush_gui(150)
+            viewport = view.graphicsView().viewport()
+            points = [(0, 0), (20, 0)]
+            if command == "Rotate":
+                points.append((0, 20))
+            elif command == "Scale":
+                points.append((40, 0))
+            for index, (x, y) in enumerate(points):
+                pos = self.viewport_to_qpoint(view, viewport,
+                                             view.getPointOnScreen(App.Vector(x, y, 0)))
+                self.move(viewport, pos)
+                self.click(viewport, pos)
+                if index == 0:
+                    self.key_click(viewport, QtCore.Qt.Key_U, "u")
+            self.assertEqual(s.solve(), 0, command)
+            self.assertEqual(s.GeometryCount, 2 * counts[0], command)
+            self.assertEqual(sum(c.Type == "Group" for c in s.Constraints), 4, command)
+            self.assertEqual(sum(c.Type == "Text" for c in s.Constraints), 4, command)
+            self.doc.undo()
+            self.assertEqual((s.GeometryCount, s.ConstraintCount), counts)
 
         clipboard = QtGui.QApplication.clipboard()
         original = clipboard.mimeData()

--- a/src/Mod/Sketcher/SketcherTests/TestSketchGroupsGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketchGroupsGui.py
@@ -40,14 +40,18 @@ class TestSketchGroupsGui(SketcherGuiTestCase):
                     s.addGeometry(Part.Circle(App.Vector(12, 14, 0), App.Vector(0, 0, 1), 2))
                     s.addGeometry(Part.Point(App.Vector(16, 18, 0)))
                     for x in (10, 20):
-                        s.addGeometry(Part.LineSegment(App.Vector(x, 10, 0), App.Vector(x, 20, 0)), True)
+                        s.addGeometry(
+                            Part.LineSegment(App.Vector(x, 10, 0), App.Vector(x, 20, 0)), True
+                        )
                     s.addConstraint(Sketcher.Constraint("Group", [2, 0, 0, 0, 1, 0]))
                     s.addConstraint(Sketcher.Constraint("Group", [3, 0, 2, 0]))
                     self.doc.recompute()
                     Gui.activeDocument().setEdit(s.Name)
                     view = Gui.activeDocument().activeView()
-                    view.setCamera('#Inventor V2.1 ascii\nOrthographicCamera { position 0 0 100 '
-                                   'orientation 0 0 1 0 focalDistance 100 height 100 }')
+                    view.setCamera(
+                        "#Inventor V2.1 ascii\nOrthographicCamera { position 0 0 100 "
+                        "orientation 0 0 1 0 focalDistance 100 height 100 }"
+                    )
                     self.flush_gui(150)
                     viewport = view.graphicsView().viewport()
                     # Selecting a leaf must transform its entire outer group, including points.
@@ -61,23 +65,28 @@ class TestSketchGroupsGui(SketcherGuiTestCase):
                     elif command == "Scale":
                         points.append((40, 0))
                     for index, (x, y) in enumerate(points):
-                        pos = self.viewport_to_qpoint(view, viewport,
-                                                     view.getPointOnScreen(App.Vector(x, y, 0)))
+                        pos = self.viewport_to_qpoint(
+                            view, viewport, view.getPointOnScreen(App.Vector(x, y, 0))
+                        )
                         self.move(viewport, pos)
                         self.click(viewport, pos)
                         if index == 0 and pattern:
                             self.key_click(viewport, QtCore.Qt.Key_U, "u")
                     self.assertEqual(s.GeometryCount, 8 if pattern else 4)
-                    self.assertEqual(sum(c.Type == "Group" for c in s.Constraints), 4 if pattern else 2)
+                    self.assertEqual(
+                        sum(c.Type == "Group" for c in s.Constraints), 4 if pattern else 2
+                    )
                     self.assertEqual(s.solve(), 0)
                     first = 4 if pattern else 0
-                    root, circle, point, child = s.Geometry[first:first + 4]
+                    root, circle, point, child = s.Geometry[first : first + 4]
                     # Derive the transformation from the outer handle: every member must
                     # follow it exactly, independently of mouse pixel rounding or snapping.
                     y_axis = (root.EndPoint - root.StartPoint) / 10
                     x_axis = App.Vector(y_axis.y, -y_axis.x, 0)
+
                     def transformed_point(x, y):
                         return root.StartPoint + x_axis * (x - 20) + y_axis * (y - 10)
+
                     for actual, expected in (
                         (circle.Center, transformed_point(12, 14)),
                         (point.toShape().Point, transformed_point(16, 18)),
@@ -154,8 +163,10 @@ class TestSketchGroupsGui(SketcherGuiTestCase):
         for command in ("Rotate", "Translate", "Scale"):
             select([root])
             view = Gui.activeDocument().activeView()
-            view.setCamera('#Inventor V2.1 ascii\nOrthographicCamera { position 0 0 100 '
-                           'orientation 0 0 1 0 focalDistance 100 height 100 }')
+            view.setCamera(
+                "#Inventor V2.1 ascii\nOrthographicCamera { position 0 0 100 "
+                "orientation 0 0 1 0 focalDistance 100 height 100 }"
+            )
             Gui.runCommand("Sketcher_" + command)
             self.flush_gui(150)
             viewport = view.graphicsView().viewport()
@@ -165,8 +176,9 @@ class TestSketchGroupsGui(SketcherGuiTestCase):
             elif command == "Scale":
                 points.append((40, 0))
             for index, (x, y) in enumerate(points):
-                pos = self.viewport_to_qpoint(view, viewport,
-                                             view.getPointOnScreen(App.Vector(x, y, 0)))
+                pos = self.viewport_to_qpoint(
+                    view, viewport, view.getPointOnScreen(App.Vector(x, y, 0))
+                )
                 self.move(viewport, pos)
                 self.click(viewport, pos)
                 if index == 0:

--- a/src/Mod/Sketcher/SketcherTests/TestSketchGroupsGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketchGroupsGui.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+
+import FreeCAD as App
+import Part
+import Sketcher
+from PySide import QtCore, QtGui
+from SketcherTests.GuiTestCase import FreeCADGui as Gui, SketcherGuiTestCase
+
+
+class TestSketchGroupsGui(SketcherGuiTestCase):
+    def testNestedTextGroup(self):
+        font = os.path.join(App.getResourceDir(), "examples", "osifont-lgpl3fe.ttf")
+        if not os.path.isfile(font):
+            self.skipTest("Bundled osifont not found")
+        Gui.activateWorkbench("SketcherWorkbench")
+        self.doc = App.newDocument("NestedTextGroupTest")
+        s = self.doc.addObject("Sketcher::SketchObject", "Sketch")
+        for x, text in [(0, "A"), (30, "B")]:
+            handle = s.addGeometry(
+                Part.LineSegment(App.Vector(x, 0, 0), App.Vector(x, 10, 0)), True
+            )
+            c = s.addConstraint(Sketcher.Constraint("Text", [handle, 0], text, font, True))
+            s.setTextAndFont(c, text, font, True, False)
+        self.doc.recompute()
+        Gui.activeDocument().setEdit(s.Name)
+
+        def select(ids):
+            Gui.Selection.clearSelection()
+            for geo in ids:
+                Gui.Selection.addSelection(self.doc.Name, s.Name, "Edge{}".format(geo + 1))
+
+        before = s.GeometryCount
+        select(range(before))
+        Gui.runCommand("Sketcher_ConstrainGroup", 0)
+        self.assertEqual(s.solve(), 0)
+        self.assertEqual((s.GeometryCount, s.ConstraintCount), (before + 1, 3))
+
+        circle = s.addGeometry(Part.Circle(App.Vector(60, 5, 0), App.Vector(0, 0, 1), 2))
+        select([0, circle])  # Selecting a text member must select its outer group.
+        Gui.runCommand("Sketcher_ConstrainGroup", 0)
+        root = s.GeometryCount - 1
+        s.addConstraint(Sketcher.Constraint("Distance", root, 20.0))
+        self.assertEqual(s.solve(), 0)
+        self.assertAlmostEqual(s.Geometry[circle].Radius, 4)
+
+        # Regeneration changes geometry indices and the order of the text constraints.
+        s.setTextAndFont(0, "ABC", font, True, False)
+        self.assertEqual(s.solve(), 0)
+        self.assertEqual(sum(c.Type == "Text" for c in s.Constraints), 2)
+        groups = [c for c in s.Constraints if c.Type == "Group"]
+        self.assertEqual(len(groups), 2)
+        root = groups[-1].First
+        counts = (s.GeometryCount, s.ConstraintCount)
+
+        clipboard = QtGui.QApplication.clipboard()
+        original = clipboard.mimeData()
+        saved = {fmt: original.data(fmt) for fmt in original.formats()} if original else {}
+        try:
+            select([root])
+            Gui.runCommand("Sketcher_CopyClipboard", 0)
+            Gui.runCommand("Sketcher_Paste", 0)
+            self.assertEqual(s.solve(), 0)
+            self.assertEqual((s.GeometryCount, s.ConstraintCount), tuple(2 * n for n in counts))
+            self.doc.undo()
+            self.assertEqual((s.GeometryCount, s.ConstraintCount), counts)
+        finally:
+            restored = QtCore.QMimeData()
+            for fmt, data in saved.items():
+                restored.setData(fmt, data)
+            clipboard.setMimeData(restored)
+
+        select([root])
+        Gui.runCommand("Std_Delete", 0)
+        self.assertEqual((s.GeometryCount, s.ConstraintCount), (0, 0))
+        self.doc.undo()
+        self.assertEqual(s.solve(), 0)
+        self.assertEqual((s.GeometryCount, s.ConstraintCount), counts)

--- a/src/Mod/Sketcher/TestSketcherApp.py
+++ b/src/Mod/Sketcher/TestSketcherApp.py
@@ -25,6 +25,7 @@
 
 # Broken-out test modules
 from SketcherTests.TestSketcherSolver import TestSketcherSolver
+from SketcherTests.TestSketchGroups import TestSketchGroups
 from SketcherTests.TestSketchFillet import TestSketchFillet
 from SketcherTests.TestSketchExpression import TestSketchExpression
 from SketcherTests.TestSketchValidateCoincidents import TestSketchValidateCoincidents

--- a/src/Mod/Sketcher/TestSketcherGui.py
+++ b/src/Mod/Sketcher/TestSketcherGui.py
@@ -3,6 +3,7 @@ from SketcherTests.TestConstraintPreselectionGui import SketcherGuiTestCases
 from SketcherTests.TestOnViewParameterGui import TestOnViewParameterGui
 from SketcherTests.TestPlacementUpdate import TestSketchPlacementUpdate
 from SketcherTests.TestExternalFacePreselection import TestExternalFacePreselection
+from SketcherTests.TestSketchGroupsGui import TestSketchGroupsGui
 
 # Use the module so that code checkers don't complain (flake8)
 (
@@ -11,5 +12,6 @@ from SketcherTests.TestExternalFacePreselection import TestExternalFacePreselect
     and TestSketchPlacementUpdate
     and TestOnViewParameterGui
     and TestExternalFacePreselection
+    and TestSketchGroupsGui
     else False
 )


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/28276
Fix https://github.com/FreeCAD/FreeCAD/issues/28765
Fix https://github.com/FreeCAD/FreeCAD/issues/32374
Fix https://github.com/FreeCAD/FreeCAD/issues/32118

By implementing recursive group constraints support. And transform tools support for group.