### PR TITLE
Sketcher: fix BSplineConvertToNURBS issues

### DIFF
--- a/src/Mod/Sketcher/App/SketchObjectOperations.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectOperations.cpp
@@ -2797,22 +2797,27 @@ bool SketchObject::convertToNURBS(int GeoId)
     // no need to check input data validity as this is an sketchobject managed operation.
     Base::StateLocker lock(managedoperation, true);
 
-    if (GeoId > getHighestCurveIndex()
-        || (GeoId < 0 && -GeoId > static_cast<int>(ExternalGeo.getSize())) || GeoId == -1
-        || GeoId == -2)
+    const Part::Geometry* geo = getGeometry(GeoId);
+    if (!geo || GeoId == -1 || GeoId == -2)
         return false;
 
-    const Part::Geometry* geo = getGeometry(GeoId);
+    // Replacing an existing spline would discard its constraints and detach its internal geometry.
+    // External geometry is still converted into a new internal copy.
+    if (GeoId >= 0 && geo->is<Part::GeomBSplineCurve>())
+        return true;
 
     if (geo->is<Part::GeomPoint>())
         return false;
 
     const auto* geo1 = static_cast<const Part::GeomCurve*>(geo);
 
-    Part::GeomBSplineCurve* bspline;
+    std::unique_ptr<Part::GeomBSplineCurve> bspline;
 
     try {
-        bspline = geo1->toNurbs(geo1->getFirstParameter(), geo1->getLastParameter());
+        bspline.reset(geo1->toNurbs(geo1->getFirstParameter(), geo1->getLastParameter()));
+
+        if (geo->is<Part::GeomCircle>() || geo->is<Part::GeomEllipse>())
+            bspline->setPeriodic();
 
         if (geo1->isDerivedFrom<Part::GeomArcOfConic>()) {
             const auto* geoaoc = static_cast<const Part::GeomArcOfConic*>(geo1);
@@ -2831,18 +2836,32 @@ bool SketchObject::convertToNURBS(int GeoId)
 
     std::vector<Part::Geometry*> newVals(vals);
 
+    std::set<int> internalGeometry;
+    if (GeoId >= 0) {
+        for (const auto* constraint : Constraints.getValues()) {
+            if (constraint->Type == InternalAlignment && constraint->Second == GeoId
+                && constraint->First >= 0 && constraint->First != GeoId)
+                internalGeometry.insert(constraint->First);
+        }
+        // Shared internal geometry still belongs to the other conic.
+        for (const auto* constraint : Constraints.getValues()) {
+            if (constraint->Type == InternalAlignment && constraint->Second != GeoId)
+                internalGeometry.erase(constraint->First);
+        }
+    }
+
     // Block checks and updates in OnChanged to avoid unnecessary checks and updates
     {
         Base::StateLocker preventUpdate(internaltransaction, true);
 
         if (GeoId < 0) {// external geometry
-            newVals.push_back(bspline);
-            generateId(bspline);
+            generateId(bspline.get());
+            newVals.push_back(bspline.release());
         }
         else {// normal geometry
 
-            newVals[GeoId] = bspline;
-            GeometryFacade::copyId(geo, bspline);
+            GeometryFacade::copyId(geo, bspline.get());
+            newVals[GeoId] = bspline.release();
 
             const std::vector<Sketcher::Constraint*>& cvals = Constraints.getValues();
 
@@ -2867,6 +2886,13 @@ bool SketchObject::convertToNURBS(int GeoId)
         }
 
         Geometry.setValues(std::move(newVals));
+
+        // Remove obsolete axes/foci along with their constraints, and remap surviving geometry.
+        if (!internalGeometry.empty()) {
+            delGeometriesExclusiveList(
+                std::vector<int>(internalGeometry.begin(), internalGeometry.end()),
+                DeleteOption::NoSolve);
+        }
     }
 
     // trigger update now

--- a/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
@@ -24,6 +24,7 @@
 
 #include <Inventor/SbString.h>
 #include <QApplication>
+#include <set>
 
 #include <App/Application.h>
 #include <Base/Console.h>
@@ -139,42 +140,77 @@ void CmdSketcherConvertToNURBS::activated(int iMsg)
     const std::vector<std::string>& SubNames = selection[0].getSubNames();
     Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
-    openCommand(QT_TRANSLATE_NOOP("Command", "Convert to NURBS"));
-
-    std::vector<int> GeoIdList;
+    // Internal indices can change when conversion removes a conic's auxiliary geometry.
+    std::vector<std::pair<int, long>> selectedGeometry;
 
     for (const auto& subName : SubNames) {
-        // only handle edges
+        int GeoId;
         if (subName.size() > 4 && subName.substr(0, 4) == "Edge") {
-            int GeoId = std::atoi(subName.substr(4, 4000).c_str()) - 1;
-            GeoIdList.push_back(GeoId);
+            GeoId = std::atoi(subName.substr(4, 4000).c_str()) - 1;
         }
         else if (subName.size() > 12 && subName.substr(0, 12) == "ExternalEdge") {
-            int GeoId = -(std::atoi(subName.substr(12, 4000).c_str()) + 2);
-            GeoIdList.push_back(GeoId);
+            GeoId = -(std::atoi(subName.substr(12, 4000).c_str()) + 2);
+        }
+        else {
+            continue;
+        }
+        const auto* geometry = Obj->getGeometry(GeoId);
+        if (!geometry || geometry->is<Part::GeomBSplineCurve>()) {
+            continue;
+        }
+        long id = 0;
+        if (GeoId >= 0) {
+            Obj->getGeometryId(GeoId, id);
+        }
+        selectedGeometry.emplace_back(GeoId, id);
+    }
+
+    if (selectedGeometry.empty()) {
+        return;
+    }
+
+    // A box selection can include both a conic and its axes. Convert only the parent.
+    std::set<int> selectedIds;
+    for (const auto& [geoId, id] : selectedGeometry) {
+        selectedIds.insert(geoId);
+    }
+    std::set<int> auxiliaryIds;
+    for (const auto* constraint : Obj->Constraints.getValues()) {
+        if (constraint->Type == InternalAlignment && selectedIds.contains(constraint->Second)) {
+            auxiliaryIds.insert(constraint->First);
         }
     }
+    std::erase_if(selectedGeometry, [&auxiliaryIds](const auto& entry) {
+        return auxiliaryIds.contains(entry.first);
+    });
 
-    // for creating the poles and knots
-    for (auto GeoId : GeoIdList) {
-        Gui::cmdAppObjectArgs(selection[0].getObject(), "convertToNURBS(%d) ", GeoId);
-    }
-    for (auto GeoId : GeoIdList) {
-        Gui::cmdAppObjectArgs(selection[0].getObject(), "exposeInternalGeometry(%d)", GeoId);
-    }
+    auto findGeometry = [Obj](long id) -> int {
+        for (int index = 0; index <= Obj->getHighestCurveIndex(); ++index) {
+            long currentId = 0;
+            Obj->getGeometryId(index, currentId);
+            if (currentId == id) {
+                return index;
+            }
+        }
+        return GeoEnum::GeoUndef;
+    };
 
-    if (GeoIdList.empty()) {
-        abortCommand();
-
-        Gui::TranslatedUserWarning(
-            Obj,
-            QObject::tr("Wrong selection"),
-            QObject::tr("None of the selected elements is an edge.")
-        );
+    openCommand(QT_TRANSLATE_NOOP("Command", "Convert to NURBS"));
+    for (const auto& [originalGeoId, id] : selectedGeometry) {
+        int GeoId = originalGeoId < 0 ? originalGeoId : findGeometry(id);
+        if (GeoId == GeoEnum::GeoUndef) {
+            continue; // An auxiliary element removed by an earlier conversion.
+        }
+        int previousSize = Obj->Geometry.getSize();
+        Gui::cmdAppObjectArgs(Obj, "convertToNURBS(%d)", GeoId);
+        GeoId = originalGeoId < 0 ? previousSize : findGeometry(id);
+        const auto* converted = Obj->getGeometry(GeoId);
+        if (converted && converted->is<Part::GeomBSplineCurve>()) {
+            Gui::cmdAppObjectArgs(Obj, "exposeInternalGeometry(%d)", GeoId);
+        }
     }
-    else {
-        commitCommand();
-    }
+    commitCommand();
+    getSelection().clearSelection();
     tryAutoRecomputeIfNotSolve(Obj);
 }
 

--- a/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
@@ -199,7 +199,7 @@ void CmdSketcherConvertToNURBS::activated(int iMsg)
     for (const auto& [originalGeoId, id] : selectedGeometry) {
         int GeoId = originalGeoId < 0 ? originalGeoId : findGeometry(id);
         if (GeoId == GeoEnum::GeoUndef) {
-            continue; // An auxiliary element removed by an earlier conversion.
+            continue;  // An auxiliary element removed by an earlier conversion.
         }
         int previousSize = Obj->Geometry.getSize();
         Gui::cmdAppObjectArgs(Obj, "convertToNURBS(%d)", GeoId);


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/13251

This fixes the three problems listed in https://github.com/FreeCAD/FreeCAD/issues/13251.

First, B-splines are now skipped: the command filters them out of the selection, and convertToNURBS() returns early for an internal B-spline. Before, reconverting one replaced it with a new spline and silently dropped its constraints and its internal geometry. External B-splines are still copied as a new internal spline, as before.

Second, circles and ellipses now come out as periodic B-splines (setPeriodic()), not open ones.

Third, when an ellipse, hyperbola or parabola is converted, its axes and foci are no longer left behind. These are the elements tied to it by InternalAlignment constraints. They're now removed with delGeometriesExclusiveList() along with their constraints, except for any that another conic also uses. Deleting that geometry shifts GeoIds, so the GUI command now tracks each selected edge by its geometry ID rather than its index, and looks up the current index before each conversion. It also ignores axes and foci picked up in a box selection together with their parent conic. On the code side, bspline is now held in a unique_ptr, so it no longer leaks if toNurbs() or the later steps throw.