### PR TITLE
Sketcher: typographic references and guide lines for text

### DIFF
--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -131,6 +131,7 @@
 #include FT_FREETYPE_H
 #include FT_GLYPH_H
 #include FT_OUTLINE_H
+#include FT_TRUETYPE_TABLES_H
 
 #include <hb.h>
 
@@ -7483,6 +7484,22 @@ int cubic_cb(const FT_Vector* pt0, const FT_Vector* pt1, const FT_Vector* pt2, v
 }
 
 
+double referenceHeight(const TextMetrics& metrics, TextReference reference)
+{
+    switch (reference) {
+        case TextReference::CapHeight:
+            return metrics.capHeight;
+        case TextReference::XHeight:
+            return metrics.xHeight;
+        case TextReference::Ascender:
+            return metrics.ascender;
+        case TextReference::EmBox:
+            return metrics.emSize;
+        default:
+            return 0.0;
+    }
+}
+
 }  // end anonymous namespace
 
 /**
@@ -7497,13 +7514,25 @@ int cubic_cb(const FT_Vector* pt0, const FT_Vector* pt1, const FT_Vector* pt2, v
  * @param p2                The end point, which defines the size and orientation.
  * @param height            If true, the distance p1-p2 defines the height.
  *                          If false, it defines the width.
+ * @param reference         Typographic line the placement and the size are taken from.
+ * @param metrics           Metrics of the run, required by every reference but BoundingBox.
+ * @param guideLines        When given, receives the guide lines of the run.
+ * @param typographicLines  Emits a line per typographic level.
+ * @param letterLines       Emits a line at every glyph boundary.
+ * @param letterEdgeLines   Emits a line along both edges of the ink of every letter.
  */
 void transformAndConvertToGeometry(
     std::vector<std::unique_ptr<Part::Geometry>>& geos,
     const std::vector<TopoDS_Shape>& baseShapes,
     const Base::Vector3d& p1,
     const Base::Vector3d& p2,
-    bool height
+    bool height,
+    TextReference reference,
+    const TextMetrics* metrics,
+    std::vector<std::unique_ptr<Part::Geometry>>* guideLines,
+    bool typographicLines,
+    bool letterLines,
+    bool letterEdgeLines
 )
 {
     if (baseShapes.empty()) {
@@ -7516,28 +7545,44 @@ void transformAndConvertToGeometry(
         return;
     }
 
-    // 1. Calculate the bounding box of the base shapes
-    Bnd_Box bndBox;
-    for (const auto& shape : baseShapes) {
-        if (!shape.IsNull()) {
-            BRepBndLib::Add(shape, bndBox);
+    const bool useMetrics = reference != TextReference::BoundingBox && metrics && metrics->isValid;
+
+    double baseWidth = 0.0;
+    double baseHeight = 0.0;
+    // Translation bringing the reference point of the base shapes onto the origin.
+    gp_Vec initialTranslationVec(0.0, 0.0, 0.0);
+
+    if (useMetrics) {
+        // 1. Anchor on the pen origin of the baseline and take the size from a font metric.
+        // Neither depends on which glyphs the string happens to contain. The shapes are already
+        // built on that origin, so there is nothing to translate.
+        baseWidth = metrics->advance;
+        baseHeight = referenceHeight(*metrics, reference);
+    }
+    else {
+        // 1. Calculate the bounding box of the base shapes
+        Bnd_Box bndBox;
+        for (const auto& shape : baseShapes) {
+            if (!shape.IsNull()) {
+                BRepBndLib::Add(shape, bndBox);
+            }
         }
+
+        if (bndBox.IsVoid()) {
+            Base::Console().warning(
+                "transformAndConvertToGeometry: Could not determine bounds of generated geometry.\n"
+            );
+            return;
+        }
+
+        Standard_Real xmin, ymin, zmin, xmax, ymax, zmax;
+        bndBox.Get(xmin, ymin, zmin, xmax, ymax, zmax);
+        baseWidth = xmax - xmin;
+        baseHeight = ymax - ymin;
+
+        // This transform will move the geometry's bottom-left corner to the origin (0,0,0)
+        initialTranslationVec.SetCoord(-xmin, -ymin, 0.0);
     }
-
-    if (bndBox.IsVoid()) {
-        Base::Console().warning(
-            "transformAndConvertToGeometry: Could not determine bounds of generated geometry.\n"
-        );
-        return;
-    }
-
-    Standard_Real xmin, ymin, zmin, xmax, ymax, zmax;
-    bndBox.Get(xmin, ymin, zmin, xmax, ymax, zmax);
-    double baseWidth = xmax - xmin;
-    double baseHeight = ymax - ymin;
-
-    // This transform will move the geometry's bottom-left corner to the origin (0,0,0)
-    gp_Vec initialTranslationVec(-xmin, -ymin, 0.0);
 
     // 2. Determine scale and rotation
     double angle;
@@ -7569,7 +7614,66 @@ void transformAndConvertToGeometry(
     finalTranslate.SetTranslation(gp_Vec(p1.x, p1.y, 0.0));
     gp_Trsf finalTrsf = finalTranslate * rotateTrsf * scaleTrsf * initialTranslate;
 
-    // 4. Apply transformation and convert to Sketcher geometry
+    // 4. Emit the guide lines, spanning the run at the typographic levels. The levels come from
+    // the metrics and are already deduplicated, so all that is left here is to place them. This
+    // runs on every mouse move while dragging, which is why it avoids building an OCC transform.
+    if (guideLines && metrics && metrics->isValid && metrics->advance > Precision::Confusion()) {
+        // The same output carries both kinds of line, so an empty set of levels means only the
+        // letter lines were asked for.
+        static const std::vector<double> noLevels;
+        const std::vector<double>& levels = typographicLines ? metrics->guideLevels : noLevels;
+
+        // Scaled base axes, equivalent to finalTrsf applied to (0, 0), (1, 0) and (0, 1).
+        Base::Vector3d dirX(std::cos(angle) * scale, std::sin(angle) * scale, 0.0);
+        Base::Vector3d dirY(-dirX.y, dirX.x, 0.0);
+        Base::Vector3d origin = Base::Vector3d(p1.x, p1.y, 0.0)
+            + dirX * initialTranslationVec.X() + dirY * initialTranslationVec.Y();
+        Base::Vector3d run = dirX * metrics->advance;
+
+        guideLines->reserve(guideLines->size() + metrics->guideLevels.size());
+        for (double level : levels) {
+            Base::Vector3d start = origin + dirY * level;
+            auto segment = std::make_unique<Part::GeomLineSegment>();
+            segment->setPoints(start, start + run);
+            guideLines->push_back(std::move(segment));
+        }
+
+        // Lines across the text, so that a single letter can be referred to rather than the
+        // whole run. They span the full body of the text, from descender to ascender.
+        if ((letterLines || letterEdgeLines) && metrics->descender < metrics->ascender) {
+            Base::Vector3d bottom = dirY * metrics->descender;
+            Base::Vector3d top = dirY * metrics->ascender;
+
+            auto emitAt = [&](const std::vector<double>& positions) {
+                double previous = 0.0;
+                for (std::size_t i = 0; i < positions.size(); ++i) {
+                    // A glyph that does not advance the pen, a combining mark for instance, or
+                    // one whose ink starts where the previous ended, would put a second line on
+                    // top of the one before it.
+                    if (i > 0 && std::fabs(positions[i] - previous) < Precision::Confusion()) {
+                        continue;
+                    }
+                    previous = positions[i];
+
+                    Base::Vector3d at = origin + dirX * positions[i];
+                    auto segment = std::make_unique<Part::GeomLineSegment>();
+                    segment->setPoints(at + bottom, at + top);
+                    guideLines->push_back(std::move(segment));
+                }
+            };
+
+            // Where the pen stands between the letters, side bearings included.
+            if (letterLines) {
+                emitAt(metrics->glyphOffsets);
+            }
+            // Where the ink of each letter actually begins and ends.
+            if (letterEdgeLines) {
+                emitAt(metrics->glyphInkBounds);
+            }
+        }
+    }
+
+    // 5. Apply transformation and convert to Sketcher geometry
     for (const auto& shape : baseShapes) {
         BRepBuilderAPI_Transform performer(shape, finalTrsf, true);
         if (!performer.IsDone()) {
@@ -7629,7 +7733,8 @@ std::vector<TopoDS_Shape> makeTextWires(
     std::string& text,
     std::string& fontFile,
     double height,
-    double tracking
+    double tracking,
+    TextMetrics* metrics
 )
 {
     if (text.empty()) {
@@ -7689,6 +7794,62 @@ std::vector<TopoDS_Shape> makeTextWires(
     FT_Outline_Funcs ftCallbacks = {move_cb, line_cb, quad_cb, cubic_cb, 0, 0};
     FT_UInt ftLoadFlags = FT_LOAD_NO_SCALE | FT_LOAD_NO_BITMAP;
 
+    // Typographic metrics of the face, in font design units. They let the caller place and scale
+    // the text on a reference line rather than on its ink bounding box.
+    double ascender = 0.0;
+    double descender = 0.0;
+    double capHeight = 0.0;
+    double xHeight = 0.0;
+    if (metrics) {
+        metrics->glyphOffsets.clear();
+        metrics->glyphInkBounds.clear();
+
+        auto* os2 = static_cast<TT_OS2*>(FT_Get_Sfnt_Table(ftFace, FT_SFNT_OS2));
+        if (os2 && os2->version != 0xFFFFU) {
+            ascender = static_cast<double>(os2->sTypoAscender);
+            descender = static_cast<double>(os2->sTypoDescender);
+            if (os2->version >= 2) {
+                capHeight = static_cast<double>(os2->sCapHeight);
+                xHeight = static_cast<double>(os2->sxHeight);
+            }
+        }
+
+        // Not every face has an OS/2 table, and the entries in it are often left empty. Measure
+        // a representative glyph before falling back to the usual proportions.
+        auto glyphTop = [&ftFace, ftLoadFlags](FT_ULong charCode) -> double {
+            FT_UInt index = FT_Get_Char_Index(ftFace, charCode);
+            if (index == 0 || FT_Load_Glyph(ftFace, index, ftLoadFlags) != 0) {
+                return 0.0;
+            }
+            return static_cast<double>(ftFace->glyph->metrics.horiBearingY);
+        };
+
+        if (ascender <= 0.0) {
+            ascender = static_cast<double>(ftFace->ascender);
+        }
+        if (descender >= 0.0) {
+            descender = static_cast<double>(ftFace->descender);
+        }
+        if (capHeight <= 0.0) {
+            capHeight = glyphTop('H');
+        }
+        if (xHeight <= 0.0) {
+            xHeight = glyphTop('x');
+        }
+        if (ascender <= 0.0) {
+            ascender = 0.8 * unitsPerEM;
+        }
+        if (descender >= 0.0) {
+            descender = -0.2 * unitsPerEM;
+        }
+        if (capHeight <= 0.0) {
+            capHeight = 0.7 * unitsPerEM;
+        }
+        if (xHeight <= 0.0) {
+            xHeight = 0.5 * unitsPerEM;
+        }
+    }
+
     // Use HarfBuzz for text shaping. Positions are in font design units (upem),
     // matching our FT_LOAD_NO_SCALE outline decomposition.
     auto* hbBlob = hb_blob_create(
@@ -7719,10 +7880,26 @@ std::vector<TopoDS_Shape> makeTextWires(
         double xOffset = glyphPositions[i].x_offset;
         double xAdvance = glyphPositions[i].x_advance;
 
+        if (metrics) {
+            // Where the pen stands before this glyph is drawn. Whitespace counts, so the
+            // boundaries of a word can be referred to as well.
+            metrics->glyphOffsets.push_back(penPos * scaleFactor + currentTracking);
+        }
+
         if (FT_Load_Glyph(ftFace, glyphIndex, ftLoadFlags) != 0) {
             penPos += xAdvance;
             currentTracking += tracking;
             continue;
+        }
+
+        if (metrics && ftFace->glyph->metrics.width > 0) {
+            // The ink of this glyph, taken from the face rather than from the wires: the same
+            // numbers, without walking the outline a second time.
+            double placement = (penPos + xOffset) * scaleFactor + currentTracking;
+            double bearing = static_cast<double>(ftFace->glyph->metrics.horiBearingX) * scaleFactor;
+            double inkWidth = static_cast<double>(ftFace->glyph->metrics.width) * scaleFactor;
+            metrics->glyphInkBounds.push_back(placement + bearing);
+            metrics->glyphInkBounds.push_back(placement + bearing + inkWidth);
         }
 
         if (ftFace->glyph->format == FT_GLYPH_FORMAT_OUTLINE
@@ -7751,6 +7928,42 @@ std::vector<TopoDS_Shape> makeTextWires(
 
         penPos += xAdvance;
         currentTracking += tracking;
+    }
+
+    if (metrics) {
+        metrics->ascender = ascender * scaleFactor;
+        metrics->descender = descender * scaleFactor;
+        metrics->capHeight = capHeight * scaleFactor;
+        metrics->xHeight = xHeight * scaleFactor;
+        metrics->emSize = unitsPerEM * scaleFactor;
+        metrics->advance = penPos * scaleFactor
+            + (glyphCount > 0 ? static_cast<double>(glyphCount - 1) * tracking : 0.0);
+
+        // Close the last glyph off, so that consecutive offsets always bracket one glyph.
+        metrics->glyphOffsets.push_back(metrics->advance);
+
+        // Some fonts give the same value to two of these levels. Drop the duplicates here so
+        // that the guide lines never come out coincident.
+        metrics->guideLevels.clear();
+        metrics->guideLevels.reserve(5);
+        for (double level : {metrics->descender,
+                             0.0,  // baseline
+                             metrics->xHeight,
+                             metrics->capHeight,
+                             metrics->ascender}) {
+            bool duplicate = false;
+            for (double done : metrics->guideLevels) {
+                if (std::fabs(done - level) < Precision::Confusion()) {
+                    duplicate = true;
+                    break;
+                }
+            }
+            if (!duplicate) {
+                metrics->guideLevels.push_back(level);
+            }
+        }
+
+        metrics->isValid = true;
     }
 
     hb_buffer_destroy(hbBuf);

--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -7626,8 +7626,8 @@ void transformAndConvertToGeometry(
         // Scaled base axes, equivalent to finalTrsf applied to (0, 0), (1, 0) and (0, 1).
         Base::Vector3d dirX(std::cos(angle) * scale, std::sin(angle) * scale, 0.0);
         Base::Vector3d dirY(-dirX.y, dirX.x, 0.0);
-        Base::Vector3d origin = Base::Vector3d(p1.x, p1.y, 0.0)
-            + dirX * initialTranslationVec.X() + dirY * initialTranslationVec.Y();
+        Base::Vector3d origin = Base::Vector3d(p1.x, p1.y, 0.0) + dirX * initialTranslationVec.X()
+            + dirY * initialTranslationVec.Y();
         Base::Vector3d run = dirX * metrics->advance;
 
         guideLines->reserve(guideLines->size() + metrics->guideLevels.size());
@@ -7946,11 +7946,12 @@ std::vector<TopoDS_Shape> makeTextWires(
         // that the guide lines never come out coincident.
         metrics->guideLevels.clear();
         metrics->guideLevels.reserve(5);
-        for (double level : {metrics->descender,
-                             0.0,  // baseline
-                             metrics->xHeight,
-                             metrics->capHeight,
-                             metrics->ascender}) {
+        for (double level :
+             {metrics->descender,
+              0.0,  // baseline
+              metrics->xHeight,
+              metrics->capHeight,
+              metrics->ascender}) {
             bool duplicate = false;
             for (double done : metrics->guideLevels) {
                 if (std::fabs(done - level) < Precision::Confusion()) {

--- a/src/Mod/Part/App/Geometry.h
+++ b/src/Mod/Part/App/Geometry.h
@@ -1424,6 +1424,48 @@ PartExport std::unique_ptr<GeomCurve> makeFromTrimmedCurve(
 PartExport std::unique_ptr<GeomCurve> makeFromCurveAdaptor(const Adaptor3d_Curve&, bool silent = false);
 
 /**
+ * @brief Typographic line a text is anchored on and sized from.
+ *
+ * BoundingBox is the historical behaviour: the ink bounding box of the glyphs is used, so both
+ * position and size depend on which characters the string happens to contain. The other values
+ * anchor the text on the pen origin of the baseline and take the size from a font metric.
+ */
+enum class TextReference
+{
+    BoundingBox,
+    CapHeight,
+    XHeight,
+    Ascender,
+    EmBox
+};
+
+/**
+ * @brief Typographic metrics of a shaped text run.
+ *
+ * Values are expressed in the same units as the shapes returned by makeTextWires and are measured
+ * from the baseline, so the descender is negative.
+ */
+struct TextMetrics
+{
+    double ascender {0.0};
+    double descender {0.0};
+    double capHeight {0.0};
+    double xHeight {0.0};
+    double emSize {0.0};
+    double advance {0.0};
+    /// The distinct levels a guide line can sit on, from the descender upwards. Computed with
+    /// the rest of the metrics so that redrawing only has to place them.
+    std::vector<double> guideLevels;
+    /// Pen position at each glyph boundary, from the start of the run to its advance. One more
+    /// entry than there are glyphs, so consecutive entries bracket a single glyph.
+    std::vector<double> glyphOffsets;
+    /// Left and right edge of the ink of every glyph that has any, as consecutive pairs. Unlike
+    /// glyphOffsets these touch the letter, the side bearings being left out.
+    std::vector<double> glyphInkBounds;
+    bool isValid {false};
+};
+
+/**
  * @brief Creates a series of edges representing a text string.
  *
  * This function generates geometric edges for a given text string using a specified font file.
@@ -1437,19 +1479,35 @@ PartExport std::unique_ptr<GeomCurve> makeFromCurveAdaptor(const Adaptor3d_Curve
  * @param plainText The string to be rendered.
  * @param fontFile The absolute path to the TTF, OTF, etc., font file.
  * @param tracking Additional spacing between characters.
+ * @param reference Typographic line the placement and the size are taken from.
+ * @param metrics Metrics of the run, required by every reference but BoundingBox.
+ * @param guideLines When given, receives a line segment for each typographic level of the run
+ * (descender, baseline, x-height, cap height, ascender), placed like the text itself.
+ * @param typographicLines Emits a line for each typographic level into guideLines.
+ * @param letterLines Emits a line into guideLines at every glyph boundary, running from the
+ * descender to the ascender, so that a single letter of the run can be referred to.
+ * @param letterEdgeLines Emits a line into guideLines along the left and the right edge of the
+ * ink of every letter.
  */
 PartExport void transformAndConvertToGeometry(
     std::vector<std::unique_ptr<Part::Geometry>>& geos,
     const std::vector<TopoDS_Shape>& baseShapes,
     const Base::Vector3d& p1,
     const Base::Vector3d& p2,
-    bool height
+    bool height,
+    TextReference reference = TextReference::BoundingBox,
+    const TextMetrics* metrics = nullptr,
+    std::vector<std::unique_ptr<Part::Geometry>>* guideLines = nullptr,
+    bool typographicLines = true,
+    bool letterLines = false,
+    bool letterEdgeLines = false
 );
 
 PartExport std::vector<TopoDS_Shape> makeTextWires(
     std::string& text,
     std::string& fontFile,
     double height = 1.0,
-    double tracking = 0.0
+    double tracking = 0.0,
+    TextMetrics* metrics = nullptr
 );
 }  // namespace Part

--- a/src/Mod/Sketcher/App/Constraint.cpp
+++ b/src/Mod/Sketcher/App/Constraint.cpp
@@ -747,3 +747,167 @@ void Constraint::setIsTextHeight(bool isHeight)
     j["isTextHeight"] = isHeight;
     MetaData = j.dump();
 }
+
+int Constraint::getTextReference() const
+{
+    if (MetaData.empty()) {
+        return 0;
+    }
+    try {
+        auto j = nlohmann::json::parse(MetaData);
+        if (j.contains("textReference")) {
+            return j["textReference"].get<int>();
+        }
+    }
+    catch (...) {
+    }
+    // Bounding box, so texts saved before this option was added do not move
+    return 0;
+}
+
+void Constraint::setTextReference(int reference)
+{
+    nlohmann::json j;
+    if (!MetaData.empty()) {
+        try {
+            j = nlohmann::json::parse(MetaData);
+        }
+        catch (...) {
+        }
+    }
+    j["textReference"] = reference;
+    MetaData = j.dump();
+}
+
+bool Constraint::getTextGuideLines() const
+{
+    if (MetaData.empty()) {
+        return false;
+    }
+    try {
+        auto j = nlohmann::json::parse(MetaData);
+        if (j.contains("textGuides")) {
+            return j["textGuides"].get<bool>();
+        }
+    }
+    catch (...) {
+    }
+    return false;
+}
+
+void Constraint::setTextGuideLines(bool guideLines)
+{
+    nlohmann::json j;
+    if (!MetaData.empty()) {
+        try {
+            j = nlohmann::json::parse(MetaData);
+        }
+        catch (...) {
+        }
+    }
+    j["textGuides"] = guideLines;
+    MetaData = j.dump();
+}
+
+bool Constraint::getTextLetterLines() const
+{
+    if (MetaData.empty()) {
+        return false;
+    }
+    try {
+        auto j = nlohmann::json::parse(MetaData);
+        if (j.contains("textLetterLines")) {
+            return j["textLetterLines"].get<bool>();
+        }
+    }
+    catch (...) {
+    }
+    return false;
+}
+
+void Constraint::setTextLetterLines(bool letterLines)
+{
+    nlohmann::json j;
+    if (!MetaData.empty()) {
+        try {
+            j = nlohmann::json::parse(MetaData);
+        }
+        catch (...) {
+        }
+    }
+    j["textLetterLines"] = letterLines;
+    MetaData = j.dump();
+}
+
+bool Constraint::getTextLetterEdges() const
+{
+    if (MetaData.empty()) {
+        return false;
+    }
+    try {
+        auto j = nlohmann::json::parse(MetaData);
+        if (j.contains("textLetterEdges")) {
+            return j["textLetterEdges"].get<bool>();
+        }
+    }
+    catch (...) {
+    }
+    return false;
+}
+
+void Constraint::setTextLetterEdges(bool letterEdges)
+{
+    nlohmann::json j;
+    if (!MetaData.empty()) {
+        try {
+            j = nlohmann::json::parse(MetaData);
+        }
+        catch (...) {
+        }
+    }
+    j["textLetterEdges"] = letterEdges;
+    MetaData = j.dump();
+}
+
+int Constraint::getTextGuideCount() const
+{
+    if (MetaData.empty()) {
+        return 0;
+    }
+    try {
+        auto j = nlohmann::json::parse(MetaData);
+        if (j.contains("textGuideCount")) {
+            return j["textGuideCount"].get<int>();
+        }
+    }
+    catch (...) {
+    }
+    return 0;
+}
+
+void Constraint::setTextGuideCount(int count)
+{
+    nlohmann::json j;
+    if (!MetaData.empty()) {
+        try {
+            j = nlohmann::json::parse(MetaData);
+        }
+        catch (...) {
+        }
+    }
+    j["textGuideCount"] = count;
+    MetaData = j.dump();
+}
+
+bool Constraint::isTextGuideElement(size_t index) const
+{
+    if (Type != Text || index == 0) {
+        return false;
+    }
+    int count = getTextGuideCount();
+    if (count <= 0) {
+        return false;
+    }
+    // The guides are appended after the glyphs, so they are the trailing elements.
+    return index + static_cast<size_t>(count) >= elements.size();
+}

--- a/src/Mod/Sketcher/App/Constraint.h
+++ b/src/Mod/Sketcher/App/Constraint.h
@@ -269,6 +269,23 @@ public:
     void setFont(const std::string& font);
     bool getIsTextHeight() const;
     void setIsTextHeight(bool val);
+    /// Typographic reference of a Text constraint, as a Part::TextReference value
+    int getTextReference() const;
+    void setTextReference(int reference);
+    /// Whether the text carries construction lines for its typographic levels
+    bool getTextGuideLines() const;
+    void setTextGuideLines(bool guideLines);
+    /// Whether the text carries a construction line at every letter boundary
+    bool getTextLetterLines() const;
+    void setTextLetterLines(bool letterLines);
+    /// Whether the text carries construction lines along the edges of every letter
+    bool getTextLetterEdges() const;
+    void setTextLetterEdges(bool letterEdges);
+    /// Number of trailing elements of a Text constraint that are guide lines
+    int getTextGuideCount() const;
+    void setTextGuideCount(int count);
+    /// True if the element at this index is a guide line rather than glyph geometry
+    bool isTextGuideElement(size_t index) const;
 
 #ifdef SKETCHER_CONSTRAINT_USE_LEGACY_ELEMENTS
     // Deprecated, use getElement/setElement instead

--- a/src/Mod/Sketcher/App/ConstraintPyImp.cpp
+++ b/src/Mod/Sketcher/App/ConstraintPyImp.cpp
@@ -158,16 +158,26 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     }
     PyErr_Clear();
 
-    // Attempt to parse (string, list, string, string, bool) for 'Text'
+    // Attempt to parse (string, list, string, string, bool, int, bool, int, bool) for 'Text'
+    int text_reference = 0;
+    PyObject* py_guide_lines = nullptr;
+    int text_guide_count = 0;
+    PyObject* py_letter_lines = nullptr;
+    PyObject* py_letter_edges = nullptr;
     if (PyArg_ParseTuple(
             args,
-            "sO!ss|O",
+            "sO!ss|OiOiOO",
             &ConstraintType,
             &PyList_Type,
             &py_elements_list,
             &text_str,
             &font_str,
-            &py_is_height
+            &py_is_height,
+            &text_reference,
+            &py_guide_lines,
+            &text_guide_count,
+            &py_letter_lines,
+            &py_letter_edges
         )) {
 
         if (strcmp(ConstraintType, "Text") == 0) {
@@ -189,6 +199,18 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             else {
                 constraint->setIsTextHeight(true);
             }
+
+            constraint->setTextReference(text_reference);
+            constraint->setTextGuideLines(
+                py_guide_lines && PyBool_Check(py_guide_lines) && py_guide_lines == Py_True
+            );
+            constraint->setTextLetterLines(
+                py_letter_lines && PyBool_Check(py_letter_lines) && py_letter_lines == Py_True
+            );
+            constraint->setTextLetterEdges(
+                py_letter_edges && PyBool_Check(py_letter_edges) && py_letter_edges == Py_True
+            );
+            constraint->setTextGuideCount(text_guide_count);
 
             return 0;  // Success!
         }

--- a/src/Mod/Sketcher/App/PythonConverter.cpp
+++ b/src/Mod/Sketcher/App/PythonConverter.cpp
@@ -630,13 +630,11 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                     res += ", " + std::to_string(constraint->getTextReference());
                 }
                 if (hasGuides) {
-                    res += std::string(", ")
-                        + (constraint->getTextGuideLines() ? "True" : "False") + ", "
-                        + std::to_string(constraint->getTextGuideCount());
+                    res += std::string(", ") + (constraint->getTextGuideLines() ? "True" : "False")
+                        + ", " + std::to_string(constraint->getTextGuideCount());
                 }
                 if (constraint->getTextLetterLines() || constraint->getTextLetterEdges()) {
-                    res += std::string(", ")
-                        + (constraint->getTextLetterLines() ? "True" : "False");
+                    res += std::string(", ") + (constraint->getTextLetterLines() ? "True" : "False");
                 }
                 if (constraint->getTextLetterEdges()) {
                     res += ", True";

--- a/src/Mod/Sketcher/App/PythonConverter.cpp
+++ b/src/Mod/Sketcher/App/PythonConverter.cpp
@@ -622,6 +622,25 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 res = "Text', " + list + ", '" + escapeForPython(constraint->getText()) + "', '"
                     + escapeForPython(constraint->getFont()) + "', "
                     + (constraint->getIsTextHeight() ? "True" : "False");
+
+                // Only emitted when set, to keep the output of plain texts unchanged
+                const bool hasGuides = constraint->getTextGuideLines()
+                    || constraint->getTextLetterLines() || constraint->getTextLetterEdges();
+                if (constraint->getTextReference() != 0 || hasGuides) {
+                    res += ", " + std::to_string(constraint->getTextReference());
+                }
+                if (hasGuides) {
+                    res += std::string(", ")
+                        + (constraint->getTextGuideLines() ? "True" : "False") + ", "
+                        + std::to_string(constraint->getTextGuideCount());
+                }
+                if (constraint->getTextLetterLines() || constraint->getTextLetterEdges()) {
+                    res += std::string(", ")
+                        + (constraint->getTextLetterLines() ? "True" : "False");
+                }
+                if (constraint->getTextLetterEdges()) {
+                    res += ", True";
+                }
             }
             break;
         }

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -5752,12 +5752,7 @@ Sketch::GroupLineState Sketch::getGroupLineState(int geoId) const
     return state;
 }
 
-void Sketch::addGroupReferenceTie(
-    const GCS::Line& frame,
-    const GCS::Point& point,
-    double alpha,
-    double beta
-)
+void Sketch::addGroupReferenceTie(const GCS::Line& frame, const GCS::Point& point, double alpha, double beta)
 {
     // With S and E the ends of the frame and d = E - S, the point is held at
     // S + alpha * d + beta * rot90(d), where rot90(d) = (-d.y, d.x). Written out per coordinate
@@ -5781,8 +5776,7 @@ void Sketch::addGroupReferenceTie(
 void Sketch::addGroupReferenceConstraints()
 {
     for (const auto& referenceSet : groupReferenceSets) {
-        if (referenceSet.frameGeoId < 0
-            || referenceSet.frameGeoId >= static_cast<int>(Geoms.size())) {
+        if (referenceSet.frameGeoId < 0 || referenceSet.frameGeoId >= static_cast<int>(Geoms.size())) {
             continue;
         }
 

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -261,14 +261,31 @@ int Sketch::setUpSketch(
 
     clear();
 
-    // The geometries that are in groups are going to be ignored by the solver.
+    // The geometries that are in groups are going to be ignored by the solver. The guide lines
+    // of a text are the exception: they are derived geometry, tied to the handle of their group
+    // by addGroupReferenceConstraints() so that other elements can be constrained to them.
     std::set<int> inGroupGeoIds;
+    groupReferenceSets.clear();
     for (const auto& c : ConstraintList) {
-        if (c->Type == Group || c->Type == Text) {
-            // Start from index 1, as 0 is the frame.
-            for (int i = 1; c->hasElement(i); ++i) {
+        if (c->Type != Group && c->Type != Text) {
+            continue;
+        }
+
+        GroupReferenceSet referenceSet;
+        referenceSet.frameGeoId = c->getGeoId(0);
+
+        // Start from index 1, as 0 is the frame.
+        for (size_t i = 1; c->hasElement(i); ++i) {
+            if (c->isTextGuideElement(i)) {
+                referenceSet.referenceGeoIds.push_back(c->getGeoId(i));
+            }
+            else {
                 inGroupGeoIds.insert(c->getGeoId(i));
             }
+        }
+
+        if (!referenceSet.referenceGeoIds.empty()) {
+            groupReferenceSets.push_back(std::move(referenceSet));
         }
     }
 
@@ -324,6 +341,8 @@ int Sketch::setUpSketch(
     buildInternalAlignmentGeometryMap(ConstraintList);
 
     addGeometry(intGeoList, onlyBlockedGeometry, inGroupGeoIds);
+
+    addGroupReferenceConstraints();
     int extStart = Geoms.size();
     addGeometry(extGeoList, true);
     int extEnd = Geoms.size() - 1;
@@ -5733,6 +5752,84 @@ Sketch::GroupLineState Sketch::getGroupLineState(int geoId) const
     return state;
 }
 
+void Sketch::addGroupReferenceTie(
+    const GCS::Line& frame,
+    const GCS::Point& point,
+    double alpha,
+    double beta
+)
+{
+    // With S and E the ends of the frame and d = E - S, the point is held at
+    // S + alpha * d + beta * rot90(d), where rot90(d) = (-d.y, d.x). Written out per coordinate
+    // both equations are linear in the frame and in the point, with constant coefficients.
+
+    // P.x + (alpha - 1) * S.x - beta * S.y - alpha * E.x + beta * E.y = 0
+    GCSsys.addConstraintLinearCombination(
+        {point.x, frame.p1.x, frame.p1.y, frame.p2.x, frame.p2.y},
+        {1.0, alpha - 1.0, -beta, -alpha, beta}
+    );
+
+    // P.y + (alpha - 1) * S.y + beta * S.x - alpha * E.y - beta * E.x = 0
+    // The tag stays 0: these are internal, they are not a constraint of the sketch and must not
+    // show up as one in the diagnosis.
+    GCSsys.addConstraintLinearCombination(
+        {point.y, frame.p1.y, frame.p1.x, frame.p2.y, frame.p2.x},
+        {1.0, alpha - 1.0, beta, -alpha, -beta}
+    );
+}
+
+void Sketch::addGroupReferenceConstraints()
+{
+    for (const auto& referenceSet : groupReferenceSets) {
+        if (referenceSet.frameGeoId < 0
+            || referenceSet.frameGeoId >= static_cast<int>(Geoms.size())) {
+            continue;
+        }
+
+        const GeoDef& frameDef = Geoms[referenceSet.frameGeoId];
+        if (frameDef.type != Line || frameDef.index < 0) {
+            continue;
+        }
+
+        const GCS::Line& frame = Lines[frameDef.index];
+        double startX = *frame.p1.x;
+        double startY = *frame.p1.y;
+        double dirX = *frame.p2.x - startX;
+        double dirY = *frame.p2.y - startY;
+        double lengthSquared = dirX * dirX + dirY * dirY;
+
+        // Without a direction there is no frame to express the references in. Leave them where
+        // the text generated them.
+        if (lengthSquared < Precision::Confusion() * Precision::Confusion()) {
+            continue;
+        }
+
+        for (int geoId : referenceSet.referenceGeoIds) {
+            if (geoId < 0 || geoId >= static_cast<int>(Geoms.size())) {
+                continue;
+            }
+
+            const GeoDef& def = Geoms[geoId];
+            if (def.type != Line || def.index < 0) {
+                continue;
+            }
+
+            const GCS::Line& reference = Lines[def.index];
+            for (const GCS::Point& point : {reference.p1, reference.p2}) {
+                // The coefficients come from the current configuration. They remain valid
+                // under any similarity of the frame, so the guide follows it when the text is
+                // moved, rotated or resized.
+                double relX = *point.x - startX;
+                double relY = *point.y - startY;
+                double alpha = (relX * dirX + relY * dirY) / lengthSquared;
+                double beta = (relY * dirX - relX * dirY) / lengthSquared;
+
+                addGroupReferenceTie(frame, point, alpha, beta);
+            }
+        }
+    }
+}
+
 void Sketch::captureGroupStates()
 {
     preSolveGroupStates.clear();
@@ -5815,7 +5912,13 @@ void Sketch::applyGroupTransformations()
         Base::Matrix4D transform = T2 * R * S * T1;
 
         // --- Loop through grouped elements and apply the transform ---
-        for (int i = 1; c->hasElement(i); ++i) {
+        for (size_t i = 1; c->hasElement(i); ++i) {
+            if (c->isTextGuideElement(i)) {
+                // The solver has already placed these, transforming them here would move them
+                // a second time.
+                continue;
+            }
+
             int groupedGeoId = c->getGeoId(i);
             if (groupedGeoId == GeoEnum::GeoUndef) {
                 continue;

--- a/src/Mod/Sketcher/App/Sketch.h
+++ b/src/Mod/Sketcher/App/Sketch.h
@@ -689,12 +689,7 @@ private:
     void captureGroupStates();
     void applyGroupTransformations();
     void addGroupReferenceConstraints();
-    void addGroupReferenceTie(
-        const GCS::Line& frame,
-        const GCS::Point& point,
-        double alpha,
-        double beta
-    );
+    void addGroupReferenceTie(const GCS::Line& frame, const GCS::Point& point, double alpha, double beta);
     GroupLineState getGroupLineState(int geoId) const;
 
 public:

--- a/src/Mod/Sketcher/App/Sketch.h
+++ b/src/Mod/Sketcher/App/Sketch.h
@@ -674,8 +674,27 @@ private:
     // Key: GeoId of the frame line.
     // Value: it's initial position.
     std::map<int, GroupLineState> preSolveGroupStates;
+
+    /// The guide lines of a text and the handle they are derived from. Unlike the other members
+    /// of a group these take part in the solve: each end point is tied to the handle by linear
+    /// constraints, so they follow it with no degree of freedom of their own and other geometry
+    /// can be constrained to them.
+    struct GroupReferenceSet
+    {
+        int frameGeoId;
+        std::vector<int> referenceGeoIds;
+    };
+    std::vector<GroupReferenceSet> groupReferenceSets;
+
     void captureGroupStates();
     void applyGroupTransformations();
+    void addGroupReferenceConstraints();
+    void addGroupReferenceTie(
+        const GCS::Line& frame,
+        const GCS::Point& point,
+        double alpha,
+        double beta
+    );
     GroupLineState getGroupLineState(int geoId) const;
 
 public:

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -692,7 +692,11 @@ SketchSolveStatus SketchObject::setTextAndFont(
     std::string& newText,
     std::string& newFont,
     bool isHeight,
-    bool isConstruction
+    bool isConstruction,
+    int textReference,
+    bool guideLines,
+    bool letterLines,
+    bool letterEdges
 )
 {
     // no need to check input data validity as this is an sketchobject managed operation.
@@ -716,6 +720,11 @@ SketchSolveStatus SketchObject::setTextAndFont(
     const std::string oldText = constr->getText();
     const std::string oldFont = constr->getFont();
     const bool oldIsHeight = constr->getIsTextHeight();
+    const int oldReference = constr->getTextReference();
+    const bool oldGuideLines = constr->getTextGuideLines();
+    const bool oldLetterLines = constr->getTextLetterLines();
+    const bool oldLetterEdges = constr->getTextLetterEdges();
+    const int oldGuideCount = constr->getTextGuideCount();
     int handleGeoId = constr->getGeoId(0);
     int firstTextGeoId = constr->getGeoId(1);
     bool hasExistingText = firstTextGeoId != GeoEnum::GeoUndef;
@@ -746,21 +755,34 @@ SketchSolveStatus SketchObject::setTextAndFont(
         return SketchSolveStatus::SolverError;
     }
 
+    auto reference = Part::TextReference::BoundingBox;
+    if (textReference > 0 && textReference <= static_cast<int>(Part::TextReference::EmBox)) {
+        reference = static_cast<Part::TextReference>(textReference);
+    }
+
     // Generate text geos based on new text/font :
     std::vector<std::unique_ptr<Part::Geometry>> newGeos;
-    std::vector<TopoDS_Shape> shapes = Part::makeTextWires(newText, newFont);
+    std::vector<std::unique_ptr<Part::Geometry>> guideGeos;
+    Part::TextMetrics metrics;
+    std::vector<TopoDS_Shape> shapes = Part::makeTextWires(newText, newFont, 1.0, 0.0, &metrics);
     Part::transformAndConvertToGeometry(
         newGeos,
         shapes,
         line->getStartPoint(),
         line->getEndPoint(),
-        isHeight
+        isHeight,
+        reference,
+        &metrics,
+        (guideLines || letterLines || letterEdges) ? &guideGeos : nullptr,
+        guideLines,
+        letterLines,
+        letterEdges
     );
 
     // Add the geometries to sketch
     int lastGeoid = getHighestCurveIndex();
     std::vector<Part::Geometry*> newGeosRawPtrs;
-    newGeosRawPtrs.reserve(newGeos.size());
+    newGeosRawPtrs.reserve(newGeos.size() + guideGeos.size());
 
     // Populate the raw pointer vector and release ownership from the unique_ptrs.
     for (auto& geo_ptr : newGeos) {
@@ -773,6 +795,17 @@ SketchSolveStatus SketchObject::setTextAndFont(
         geo_ptr.release();
     }
     newGeos.clear();
+
+    // Guides go after the glyphs so that element 1 of the constraint stays the first glyph.
+    // They are references rather than profile, so they are always construction.
+    const int guideCount = static_cast<int>(guideGeos.size());
+    for (auto& geo_ptr : guideGeos) {
+        Sketcher::GeometryFacade::setConstruction(geo_ptr.get(), true);
+        newGeosRawPtrs.push_back(geo_ptr.get());
+        geo_ptr.release();
+    }
+    guideGeos.clear();
+
     addGeometry(newGeosRawPtrs);
 
     int newLastGeoid = getHighestCurveIndex();
@@ -791,6 +824,11 @@ SketchSolveStatus SketchObject::setTextAndFont(
     constr->setText(newText);
     constr->setFont(newFont);
     constr->setIsTextHeight(isHeight);
+    constr->setTextReference(static_cast<int>(reference));
+    constr->setTextGuideLines(guideLines);
+    constr->setTextLetterLines(letterLines);
+    constr->setTextLetterEdges(letterEdges);
+    constr->setTextGuideCount(guideCount);
 
     if (hasExistingText) {
         addConstraint(constr);
@@ -802,6 +840,11 @@ SketchSolveStatus SketchObject::setTextAndFont(
         constr->setText(oldText);
         constr->setFont(oldFont);
         constr->setIsTextHeight(oldIsHeight);
+        constr->setTextReference(oldReference);
+        constr->setTextGuideLines(oldGuideLines);
+        constr->setTextLetterLines(oldLetterLines);
+        constr->setTextLetterEdges(oldLetterEdges);
+        constr->setTextGuideCount(oldGuideCount);
     }
 
     return status;
@@ -860,6 +903,25 @@ bool SketchObject::isGroupHandle(int geoId) const
     for (const auto& constr : vals) {
         if (constr->Type == Group || constr->Type == Text) {
             if (constr->getGeoId(0) == geoId) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool SketchObject::isGroupReference(int geoId) const
+{
+    if (geoId < 0) {
+        return false;
+    }
+
+    for (const auto& constr : Constraints.getValues()) {
+        if (constr->Type != Text || constr->getTextGuideCount() <= 0) {
+            continue;
+        }
+        for (size_t i = 1; constr->hasElement(i); ++i) {
+            if (constr->isTextGuideElement(i) && constr->getGeoId(i) == geoId) {
                 return true;
             }
         }

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -153,6 +153,11 @@ public:
      */
     bool isInGroup(int geoId, bool includeHandle = true) const;
     bool isGroupHandle(int geoId) const;
+    /** Returns true if geoId is a reference of a group, that is a typographic guide line of a
+     * Text. Such geometry belongs to the group, but the solver derives it from the handle of
+     * that group, so other elements can be constrained to it.
+     */
+    bool isGroupReference(int geoId) const;
     std::set<int> getGroupGeometries(int handleGeoId) const;
     /*!
      \brief Returns geoId if it's not in a group. Or the group handle if it is in a group.
@@ -357,7 +362,11 @@ public:
         std::string& newText,
         std::string& newFont,
         bool isHeight,
-        bool isConstruction = false
+        bool isConstruction = false,
+        int textReference = 0,
+        bool guideLines = false,
+        bool letterLines = false,
+        bool letterEdges = false
     );
     /// set the driving status of this constraint and solve
     int setDriving(int ConstrId, bool isdriving);

--- a/src/Mod/Sketcher/App/SketchObject.pyi
+++ b/src/Mod/Sketcher/App/SketchObject.pyi
@@ -410,12 +410,22 @@ class SketchObject(Part2DObject):
         ...
 
     def setTextAndFont(
-        self, constraint: int, text: str, font: str, isheight: bool, isConstruction: bool
+        self,
+        constraint: int,
+        text: str,
+        font: str,
+        isheight: bool,
+        isConstruction: bool,
+        reference: int = 0,
+        guideLines: bool = False,
+        letterLines: bool = False,
+        letterEdges: bool = False,
     ) -> None:
         """
         Set the text and font of a Text constraint.
 
-        setTextAndFont(constraint: int, text: str, font: str, isHeight: bool, isConstruction: bool)
+        setTextAndFont(constraint, text, font, isHeight, isConstruction, reference,
+                       guideLines, letterLines, letterEdges)
 
             Args:
                 constraint: The index of the Text constraint.
@@ -423,6 +433,15 @@ class SketchObject(Part2DObject):
                 font: The full path to the font file (.ttf, .otf, etc.).
                 isHeight: Is the line handle of the group the height of the text.
                 isConstruction: Are text geometry construction of not.
+                reference: Typographic line the handle refers to. 0 bounding box,
+                    1 cap height, 2 x-height, 3 ascender, 4 em. Every value but 0
+                    anchors the text on the start of its baseline.
+                guideLines: Add construction lines for the descender, baseline,
+                    x-height, cap height and ascender of the text.
+                letterLines: Add a construction line at every letter boundary,
+                    running from the descender to the ascender.
+                letterEdges: Add construction lines along the left and the right
+                    edge of the ink of every letter.
         """
         ...
 

--- a/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
@@ -341,9 +341,11 @@ bool SketchObject::isConstraintActiveInSketch(const Sketcher::Constraint* cstr) 
         return true;
     }
 
-    // If the constraint is not deactivated, it could still constraint something in a group
+    // If the constraint is not deactivated, it could still constraint something in a group.
+    // Guide lines are derived geometry the solver knows about, so constraining to them is fine.
     for (int j = 0; cstr->hasElement(j); ++j) {
-        if (isInGroup(cstr->getGeoId(j), false)) {
+        int geoId = cstr->getGeoId(j);
+        if (isInGroup(geoId, false) && !isGroupReference(geoId)) {
             return false;
         }
     }

--- a/src/Mod/Sketcher/App/SketchObjectOperations.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectOperations.cpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <set>
 #include <tuple>
 
 #include <App/Expression.h>
@@ -145,6 +146,28 @@ int SketchObject::delGeometries(InputIt first, InputIt last, DeleteOptions optio
     // Proceed with non-negative GeoIds
     if (sGeoIds.empty()) {
         return 0; // No positive GeoIds to delete
+    }
+
+    // A guide line only exists as a reference of the text it belongs to, so it goes away with
+    // that text but not on its own. Managed operations regenerate the text and are exempt.
+    if (!managedoperation) {
+        std::set<int> requested(sGeoIds.begin(), sGeoIds.end());
+        auto isOrphanGuide = [this, &requested](int geoId) {
+            return isGroupReference(geoId)
+                && requested.count(getGroupHandleIfInGroup(geoId)) == 0;
+        };
+
+        auto orphans = std::remove_if(sGeoIds.begin(), sGeoIds.end(), isOrphanGuide);
+        if (orphans != sGeoIds.end()) {
+            sGeoIds.erase(orphans, sGeoIds.end());
+            Base::Console().warning(
+                "Text guide lines cannot be deleted on their own. Delete the text itself, or "
+                "clear the guide lines option in its edit dialog.\n"
+            );
+            if (sGeoIds.empty()) {
+                return 0;
+            }
+        }
     }
 
     // if a GeoId has internal geometry, it must delete internal geometries too

--- a/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
@@ -769,18 +769,29 @@ PyObject* SketchObjectPy::setTextAndFont(PyObject* args, PyObject* /*kwd*/)
     char* fontStr;
     PyObject* isHeightObj = Py_True;
     PyObject* isConstrObj = Py_False;  // Default to null (parameter not provided)
+    int reference = 0;                 // Part::TextReference::BoundingBox
+    PyObject* guidesObj = Py_False;
+    PyObject* lettersObj = Py_False;
+    PyObject* letterEdgesObj = Py_False;
 
-    // "iss|O!O!" (int, str, str, | bool, bool)
+    // "iss|O!O!iO!O!O!" (int, str, str, | bool, bool, int, bool, bool, bool)
     if (!PyArg_ParseTuple(
             args,
-            "iss|O!O!",
+            "iss|O!O!iO!O!O!",
             &constrIndex,
             &textStr,
             &fontStr,
             &PyBool_Type,
             &isHeightObj,
             &PyBool_Type,
-            &isConstrObj
+            &isConstrObj,
+            &reference,
+            &PyBool_Type,
+            &guidesObj,
+            &PyBool_Type,
+            &lettersObj,
+            &PyBool_Type,
+            &letterEdgesObj
         )) {
         return nullptr;
     }
@@ -794,7 +805,11 @@ PyObject* SketchObjectPy::setTextAndFont(PyObject* args, PyObject* /*kwd*/)
         text,
         font,
         Base::asBoolean(isHeightObj),
-        Base::asBoolean(isConstrObj)
+        Base::asBoolean(isConstrObj),
+        reference,
+        Base::asBoolean(guidesObj),
+        Base::asBoolean(lettersObj),
+        Base::asBoolean(letterEdgesObj)
     );
 
     // Handle errors returned from the C++ function

--- a/src/Mod/Sketcher/App/planegcs/Constraints.cpp
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.cpp
@@ -214,6 +214,51 @@ double ConstraintWeightedLinearCombination::grad(double* param)
 
 
 // --------------------------------------------------------
+// LinearCombination
+ConstraintLinearCombination::ConstraintLinearCombination(
+    const std::vector<double*>& givenpvec,
+    const std::vector<double>& givenfactors,
+    double givenconstant
+)
+    : factors(givenfactors)
+    , constant(givenconstant)
+{
+    pvec = givenpvec;
+
+    assert(factors.size() == pvec.size());
+    origpvec = pvec;
+    rescale();
+}
+
+ConstraintType ConstraintLinearCombination::getTypeId()
+{
+    return LinearCombination;
+}
+
+double ConstraintLinearCombination::error()
+{
+    double result = constant;
+    for (size_t i = 0; i < pvec.size(); ++i) {
+        result += factors[i] * *pvec[i];
+    }
+
+    return scale * result;
+}
+
+double ConstraintLinearCombination::grad(double* param)
+{
+    double deriv = 0.;
+    for (size_t i = 0; i < pvec.size(); ++i) {
+        if (param == pvec[i]) {
+            deriv += factors[i];
+        }
+    }
+
+    return scale * deriv;
+}
+
+
+// --------------------------------------------------------
 // Center of Gravity
 ConstraintCenterOfGravity::ConstraintCenterOfGravity(
     const std::vector<double*>& givenpvec,

--- a/src/Mod/Sketcher/App/planegcs/Constraints.h
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.h
@@ -85,6 +85,7 @@ enum ConstraintType
     AngleViaPointAndTwoParams = 34,
     AngleViaTwoPoints = 35,
     ArcLength = 36,
+    LinearCombination = 37,
 };
 
 enum InternalAlignmentType
@@ -311,6 +312,30 @@ public:
 private:
     std::vector<double> factors;
     size_t numpoles;
+};
+
+// LinearCombination
+class ConstraintLinearCombination: public Constraint
+{
+public:
+    /// Constrains the parameters to satisfy `sum(factors[i] * pvec[i]) + constant = 0`. The
+    /// factors are given once and stay constant, unlike ConstraintWeightedLinearCombination
+    /// where the weights are parameters themselves, so this constraint is linear.
+    ///
+    /// It is used to derive geometry from other geometry. A point expressed in the frame of a
+    /// line, for example, follows that line through four of these.
+    ConstraintLinearCombination(
+        const std::vector<double*>& givenpvec,
+        const std::vector<double>& givenfactors,
+        double givenconstant = 0.0
+    );
+    ConstraintType getTypeId() override;
+    double error() override;
+    double grad(double*) override;
+
+private:
+    std::vector<double> factors;
+    double constant;
 };
 
 // Slope at knot

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -918,6 +918,20 @@ int System::addConstraintArcLength(Arc& a, double* distance, int tagId, bool dri
     return addConstraint(constr);
 }
 
+int System::addConstraintLinearCombination(
+    const std::vector<double*>& params,
+    const std::vector<double>& factors,
+    double constant,
+    int tagId,
+    bool driving
+)
+{
+    Constraint* constr = new ConstraintLinearCombination(params, factors, constant);
+    constr->setTag(tagId);
+    constr->setDriving(driving);
+    return addConstraint(constr);
+}
+
 
 // derived constraints
 

--- a/src/Mod/Sketcher/App/planegcs/GCS.h
+++ b/src/Mod/Sketcher/App/planegcs/GCS.h
@@ -504,6 +504,13 @@ public:
     );
     int addConstraintP2CDistance(Point& p, Circle& c, double* distance, int tagId = 0, bool driving = true);
     int addConstraintArcLength(Arc& a, double* dist, int tagId, bool driving = true);
+    int addConstraintLinearCombination(
+        const std::vector<double*>& params,
+        const std::vector<double>& factors,
+        double constant = 0.0,
+        int tagId = 0,
+        bool driving = true
+    );
 
     // internal alignment constraints
     int addConstraintInternalAlignmentPoint2Ellipse(

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerText.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerText.h
@@ -67,8 +67,8 @@ using DSHTextController = DrawSketchDefaultWidgetController<
     /*PAutoConstraintSize =*/2,
     /*OnViewParametersT =*/OnViewParameters<4, 4>,  // NOLINT
     /*WidgetParametersT =*/WidgetParameters<0, 0>,  // NOLINT
-    /*WidgetCheckboxesT =*/WidgetCheckboxes<0, 0>,  // NOLINT
-    /*WidgetComboboxesT =*/WidgetComboboxes<2, 2>,  // NOLINT
+    /*WidgetCheckboxesT =*/WidgetCheckboxes<3, 3>,  // NOLINT
+    /*WidgetComboboxesT =*/WidgetComboboxes<3, 3>,  // NOLINT
     /*WidgetLineEditsT =*/WidgetLineEdits<1, 1>,    // NOLINT
     ConstructionMethods::TextConstructionMethod,
     /*bool PFirstComboboxIsConstructionMethod =*/true>;
@@ -92,7 +92,11 @@ public:
         , font("")
         , cachedTextName("")
         , cachedFontName("")
-        , cachedBaseShapes({}) {};
+        , cachedBaseShapes({})
+        , reference(Part::TextReference::BoundingBox)
+        , guideLines(false)
+        , letterLines(false)
+        , letterEdges(false) {};
     ~DrawSketchHandlerText() override = default;
 
 private:
@@ -145,6 +149,10 @@ private:
             bool isHeight = constructionMethod() == ConstructionMethod::Height;
             const char* constrBoolStr = isConstructionMode() ? "True" : "False";
             const char* heightBoolStr = isHeight ? "True" : "False";
+            int referenceInt = static_cast<int>(reference);
+            const char* guidesBoolStr = guideLines ? "True" : "False";
+            const char* lettersBoolStr = letterLines ? "True" : "False";
+            const char* edgesBoolStr = letterEdges ? "True" : "False";
 
             // Add the 'Text' Constraint (Empty)
             // We initialize the constraint containing ONLY the handle (element 0).
@@ -152,11 +160,16 @@ private:
             // associated with Python serialization.
             Gui::cmdAppObjectArgs(
                 getSketchObject(),
-                "addConstraint(Sketcher.Constraint('Text', [%d, 0], '%s', '%s', %s))",
+                "addConstraint(Sketcher.Constraint('Text', [%d, 0], '%s', '%s', %s, %d, %s, 0, "
+                "%s, %s))",
                 handleId,
                 escText.c_str(),
                 escFontPath.c_str(),
-                heightBoolStr
+                heightBoolStr,
+                referenceInt,
+                guidesBoolStr,
+                lettersBoolStr,
+                edgesBoolStr
             );
 
             // Generate Text Geometry by calling setTextAndFont on the new constraint.
@@ -165,12 +178,16 @@ private:
             Gui::cmdAppObjectArgs(
                 getSketchObject(),
                 "setTextAndFont(len(App.ActiveDocument.getObject('%s').Constraints)-1, '%s', '%s', "
-                "%s, %s)",
+                "%s, %s, %d, %s, %s, %s)",
                 getSketchObject()->getNameInDocument(),
                 escText.c_str(),
                 escFontPath.c_str(),
                 heightBoolStr,
-                constrBoolStr
+                constrBoolStr,
+                referenceInt,
+                guidesBoolStr,
+                lettersBoolStr,
+                edgesBoolStr
             );
 
             commitCommand();
@@ -275,6 +292,11 @@ private:
     std::string cachedTextName;
     std::string cachedFontName;
     std::vector<TopoDS_Shape> cachedBaseShapes;
+    Part::TextMetrics cachedMetrics;
+    Part::TextReference reference;
+    bool guideLines;
+    bool letterLines;
+    bool letterEdges;
 
     void createShape(bool onlyeditoutline) override
     {
@@ -293,20 +315,28 @@ private:
                 cachedTextName = text;
                 cachedFontName = font;
                 // This is the one-time slow operation to get the template shapes.
-                cachedBaseShapes = Part::makeTextWires(text, font);
+                cachedBaseShapes = Part::makeTextWires(text, font, 1.0, 0.0, &cachedMetrics);
             }
             else {
                 cachedBaseShapes.clear();
+                cachedMetrics = Part::TextMetrics();
             }
         }
 
         // 2. Call the generic helper to transform and create the final geometry.
+        std::vector<std::unique_ptr<Part::Geometry>> guideGeos;
         transformAndConvertToGeometry(
             ShapeGeometry,
             cachedBaseShapes,
             toVector3d(startPoint),
             toVector3d(endPoint),
-            constructionMethod() == ConstructionMethod::Height
+            constructionMethod() == ConstructionMethod::Height,
+            reference,
+            &cachedMetrics,
+            (guideLines || letterLines || letterEdges) ? &guideGeos : nullptr,
+            guideLines,
+            letterLines,
+            letterEdges
         );
 
         // 3. Set construction mode on the newly created geometry
@@ -314,6 +344,12 @@ private:
             for (auto& geo : ShapeGeometry) {
                 Sketcher::GeometryFacade::setConstruction(geo.get(), true);
             }
+        }
+
+        // 4. Guide lines are references, so they are construction whatever the text is.
+        for (auto& geo : guideGeos) {
+            Sketcher::GeometryFacade::setConstruction(geo.get(), true);
+            ShapeGeometry.push_back(std::move(geo));
         }
     }
 
@@ -332,6 +368,9 @@ private:
     using HintTable = std::vector<HintEntry>;
 
     static Gui::InputHint switchModeHint();
+    static Gui::InputHint guideLinesHint();
+    static Gui::InputHint letterLinesHint();
+    static Gui::InputHint letterEdgesHint();
     static HintTable getTextHintTable();
     static std::list<Gui::InputHint> lookupTextHints(int method, int state);
 };
@@ -372,6 +411,51 @@ void DSHTextController::configureToolWidget()
         toolWidget->setComboboxLabel(
             WCombobox::SecondCombo,
             QApplication::translate("TaskSketcherTool_Text", "Font")
+        );
+
+        toolWidget->setComboboxLabel(
+            WCombobox::ThirdCombo,
+            QApplication::translate("TaskSketcherTool_Text", "Reference")
+        );
+        toolWidget->setComboboxElements(WCombobox::ThirdCombo, textReferenceNames());
+
+        toolWidget->setCheckboxLabel(
+            WCheckbox::FirstBox,
+            QApplication::translate("TaskSketcherTool_Text", "Guide lines (U)")
+        );
+        toolWidget->setCheckboxToolTip(
+            WCheckbox::FirstBox,
+            QApplication::translate(
+                "TaskSketcherTool_Text",
+                "Adds construction lines for the descender, baseline, x-height, cap height and "
+                "ascender of the text"
+            )
+        );
+
+        toolWidget->setCheckboxLabel(
+            WCheckbox::SecondBox,
+            QApplication::translate("TaskSketcherTool_Text", "Letter lines (J)")
+        );
+        toolWidget->setCheckboxToolTip(
+            WCheckbox::SecondBox,
+            QApplication::translate(
+                "TaskSketcherTool_Text",
+                "Adds a construction line at every letter boundary, so that a single letter can "
+                "be referred to"
+            )
+        );
+
+        toolWidget->setCheckboxLabel(
+            WCheckbox::ThirdBox,
+            QApplication::translate("TaskSketcherTool_Text", "Letter edges (R)")
+        );
+        toolWidget->setCheckboxToolTip(
+            WCheckbox::ThirdBox,
+            QApplication::translate(
+                "TaskSketcherTool_Text",
+                "Adds construction lines touching the left and the right edge of every letter, "
+                "leaving out the space a font keeps around it"
+            )
         );
 
         // 1. Scan for font files and store the map
@@ -425,6 +509,24 @@ void DSHTextController::configureToolWidget()
         SketcherToolDefaultWidget::LineEdit::FirstEdit,
         QString::fromStdString(handler->text)
     );
+
+    syncCheckboxToHandler(WCheckbox::FirstBox, handler->guideLines);
+    syncCheckboxToHandler(WCheckbox::SecondBox, handler->letterLines);
+    syncCheckboxToHandler(WCheckbox::ThirdBox, handler->letterEdges);
+}
+
+template<>
+void DSHTextController::adaptDrawingToCheckboxChange(int checkboxindex, bool value)
+{
+    if (checkboxindex == WCheckbox::FirstBox) {
+        handler->guideLines = value;
+    }
+    else if (checkboxindex == WCheckbox::SecondBox) {
+        handler->letterLines = value;
+    }
+    else if (checkboxindex == WCheckbox::ThirdBox) {
+        handler->letterEdges = value;
+    }
 }
 
 template<>
@@ -450,6 +552,11 @@ void DSHTextController::adaptDrawingToComboboxChange(int comboboxindex, int valu
             handler->font = handler->fontPathMap.value(fontName).toStdString();
         }
         // The redraw is handled by the controller's finishControlsChanged()
+    }
+    else if (comboboxindex == WCombobox::ThirdCombo) {
+        if (value >= 0 && value <= static_cast<int>(Part::TextReference::EmBox)) {
+            handler->reference = static_cast<Part::TextReference>(value);
+        }
     }
 }
 
@@ -725,27 +832,57 @@ Gui::InputHint DrawSketchHandlerText::switchModeHint()
     return {QObject::tr("%1 switch mode"), {Gui::InputHint::UserInput::KeyM}};
 }
 
+Gui::InputHint DrawSketchHandlerText::guideLinesHint()
+{
+    return {QObject::tr("%1 toggle guide lines"), {Gui::InputHint::UserInput::KeyU}};
+}
+
+Gui::InputHint DrawSketchHandlerText::letterLinesHint()
+{
+    return {QObject::tr("%1 toggle letter lines"), {Gui::InputHint::UserInput::KeyJ}};
+}
+
+Gui::InputHint DrawSketchHandlerText::letterEdgesHint()
+{
+    return {QObject::tr("%1 toggle letter edges"), {Gui::InputHint::UserInput::KeyR}};
+}
+
 DrawSketchHandlerText::HintTable DrawSketchHandlerText::getTextHintTable()
 {
     const auto switchHint = switchModeHint();
+    const auto guidesHint = guideLinesHint();
+    const auto lettersHint = letterLinesHint();
+    const auto edgesHint = letterEdgesHint();
     return {
         // Structure: {constructionMethod, state, {hints...}}
         {static_cast<int>(ConstructionMethod::Height),
          0,
          {{QObject::tr("%1 pick bottom-left point"), {Gui::InputHint::UserInput::MouseLeft}},
-          switchHint}},
+          switchHint,
+          guidesHint,
+          lettersHint,
+          edgesHint}},
         {static_cast<int>(ConstructionMethod::Height),
          1,
          {{QObject::tr("%1 pick top-left point"), {Gui::InputHint::UserInput::MouseLeft}},
-          switchHint}},
+          switchHint,
+          guidesHint,
+          lettersHint,
+          edgesHint}},
         {static_cast<int>(ConstructionMethod::Width),
          0,
          {{QObject::tr("%1 pick bottom-left point"), {Gui::InputHint::UserInput::MouseLeft}},
-          switchHint}},
+          switchHint,
+          guidesHint,
+          lettersHint,
+          edgesHint}},
         {static_cast<int>(ConstructionMethod::Width),
          1,
          {{QObject::tr("%1 pick bottom-right point"), {Gui::InputHint::UserInput::MouseLeft}},
-          switchHint}}
+          switchHint,
+          guidesHint,
+          lettersHint,
+          edgesHint}}
     };
 }
 

--- a/src/Mod/Sketcher/Gui/EditModeGeometryCoinConverter.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeGeometryCoinConverter.cpp
@@ -177,8 +177,8 @@ void EditModeGeometryCoinConverter::convert(const Sketcher::GeoListFacade& geoli
         auto* obj = viewProvider.getSketchObject();
         // References are drawn like ordinary geometry, points included, so that they can be
         // picked and constrained.
-        bool isGroupMember =
-            GeoId >= 0 && obj->isInGroup(GeoId, false) && !obj->isGroupReference(GeoId);
+        bool isGroupMember = GeoId >= 0 && obj->isInGroup(GeoId, false)
+            && !obj->isGroupReference(GeoId);
 
         if (type == Part::GeomPoint::getClassTypeId()) {  // add a point
             convert<

--- a/src/Mod/Sketcher/Gui/EditModeGeometryCoinConverter.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeGeometryCoinConverter.cpp
@@ -175,7 +175,10 @@ void EditModeGeometryCoinConverter::convert(const Sketcher::GeoListFacade& geoli
         auto coinLayer = geometryLayerParameters.getSafeCoinLayer(layerId);
 
         auto* obj = viewProvider.getSketchObject();
-        bool isGroupMember = GeoId >= 0 && obj->isInGroup(GeoId, false);
+        // References are drawn like ordinary geometry, points included, so that they can be
+        // picked and constrained.
+        bool isGroupMember =
+            GeoId >= 0 && obj->isInGroup(GeoId, false) && !obj->isGroupReference(GeoId);
 
         if (type == Part::GeomPoint::getClassTypeId()) {  // add a point
             convert<

--- a/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
@@ -474,7 +474,8 @@ void EditModeGeometryCoinManager::updateGeometryColor(
                 bool preselected = (preselectcurve == GeoId);
 
                 auto* obj = viewProvider.getSketchObject();
-                bool isGroupMember = GeoId >= 0 && obj->isInGroup(GeoId, false);
+                bool isGroupMember =
+                    GeoId >= 0 && obj->isInGroup(GeoId, false) && !obj->isGroupReference(GeoId);
                 if (isGroupMember) {
                     // We use the same color as group handle.
                     GeoId = obj->getGroupHandleIfInGroup(GeoId);

--- a/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
@@ -474,8 +474,8 @@ void EditModeGeometryCoinManager::updateGeometryColor(
                 bool preselected = (preselectcurve == GeoId);
 
                 auto* obj = viewProvider.getSketchObject();
-                bool isGroupMember =
-                    GeoId >= 0 && obj->isInGroup(GeoId, false) && !obj->isGroupReference(GeoId);
+                bool isGroupMember = GeoId >= 0 && obj->isInGroup(GeoId, false)
+                    && !obj->isGroupReference(GeoId);
                 if (isGroupMember) {
                     // We use the same color as group handle.
                     GeoId = obj->getGroupHandleIfInGroup(GeoId);

--- a/src/Mod/Sketcher/Gui/EditTextDialog.cpp
+++ b/src/Mod/Sketcher/Gui/EditTextDialog.cpp
@@ -23,6 +23,7 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
+# include <QCheckBox>
 # include <QComboBox>
 # include <QLineEdit>
 # include <QMessageBox>
@@ -57,6 +58,17 @@ EditTextDialog::EditTextDialog(ViewProviderSketch* viewProvider, int constraintI
 
     ui->radioButton_height->setChecked(constraint->getIsTextHeight());
     ui->radioButton_width->setChecked(!constraint->getIsTextHeight());
+
+    // Initialize the typographic reference the handle refers to
+    ui->comboBox_reference->addItems(textReferenceNames());
+    int reference = constraint->getTextReference();
+    if (reference >= 0 && reference < ui->comboBox_reference->count()) {
+        ui->comboBox_reference->setCurrentIndex(reference);
+    }
+
+    ui->checkBox_guides->setChecked(constraint->getTextGuideLines());
+    ui->checkBox_letters->setChecked(constraint->getTextLetterLines());
+    ui->checkBox_letterEdges->setChecked(constraint->getTextLetterEdges());
 
     // Initialize Font
     populateFontList();
@@ -100,12 +112,20 @@ void EditTextDialog::on_buttonBox_accepted()
     QString selectedFontName = ui->comboBox_font->currentText();
     std::string newFontPath = fontPathMap.value(selectedFontName).toStdString();
     bool newIsHeight = ui->radioButton_height->isChecked();
+    int newReference = ui->comboBox_reference->currentIndex();
+    bool newGuideLines = ui->checkBox_guides->isChecked();
+    bool newLetterLines = ui->checkBox_letters->isChecked();
+    bool newLetterEdges = ui->checkBox_letterEdges->isChecked();
 
     const Sketcher::Constraint* constraint = sketch->Constraints[constrIndex];
 
     // Check if anything changed
     if (newText == constraint->getText() && selectedFontName.toStdString() == constraint->getFont()
-        && newIsHeight == constraint->getIsTextHeight()) {
+        && newIsHeight == constraint->getIsTextHeight()
+        && newReference == constraint->getTextReference()
+        && newGuideLines == constraint->getTextGuideLines()
+        && newLetterLines == constraint->getTextLetterLines()
+        && newLetterEdges == constraint->getTextLetterEdges()) {
         return;  // Nothing to do
     }
 
@@ -124,17 +144,21 @@ void EditTextDialog::on_buttonBox_accepted()
             );
         }
 
-        // Send the updated 5-parameter call to Python
+        // Send the updated 9-parameter call to Python
         std::string escText = escapeForPython(newText);
         std::string escFont = escapeForPython(newFontPath);
         Gui::cmdAppObjectArgs(
             sketch,
-            "setTextAndFont(%i, '%s', '%s', %s, %s)",
+            "setTextAndFont(%i, '%s', '%s', %s, %s, %i, %s, %s, %s)",
             constrIndex,
             escText.c_str(),
             escFont.c_str(),
             newIsHeight ? "True" : "False",
-            isConstruction ? "True" : "False"
+            isConstruction ? "True" : "False",
+            newReference,
+            newGuideLines ? "True" : "False",
+            newLetterLines ? "True" : "False",
+            newLetterEdges ? "True" : "False"
         );
 
         sketchView->getDocument()->commitCommand();

--- a/src/Mod/Sketcher/Gui/EditTextDialog.ui
+++ b/src/Mod/Sketcher/Gui/EditTextDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>320</width>
-    <height>100</height>
+    <height>210</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -36,7 +36,17 @@
      <item row="1" column="1">
       <widget class="QComboBox" name="comboBox_font"/>
      </item>
-     <item row="2" column="0" colspan="2">
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_reference">
+       <property name="text">
+        <string>Reference</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QComboBox" name="comboBox_reference"/>
+     </item>
+     <item row="3" column="0" colspan="2">
       <layout class="QHBoxLayout" name="layoutType">
        <item>
         <widget class="QRadioButton" name="radioButton_height">
@@ -54,6 +64,36 @@
        </item>
      </layout>
     </item>
+     <item row="4" column="0" colspan="2">
+      <widget class="QCheckBox" name="checkBox_guides">
+       <property name="text">
+        <string>Guide lines</string>
+       </property>
+       <property name="toolTip">
+        <string>Adds construction lines for the descender, baseline, x-height, cap height and ascender of the text</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0" colspan="2">
+      <widget class="QCheckBox" name="checkBox_letters">
+       <property name="text">
+        <string>Letter lines</string>
+       </property>
+       <property name="toolTip">
+        <string>Adds a construction line at every letter boundary, so that a single letter can be referred to</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0" colspan="2">
+      <widget class="QCheckBox" name="checkBox_letterEdges">
+       <property name="text">
+        <string>Letter edges</string>
+       </property>
+       <property name="toolTip">
+        <string>Adds construction lines touching the left and the right edge of every letter, leaving out the space a font keeps around it</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -1567,9 +1567,12 @@ void TaskSketcherElements::updateVisibility()
     const auto& constraints = sketchView->getSketchObject()->Constraints.getValues();
     for (const auto* c : constraints) {
         if (c->Type == Sketcher::Group || c->Type == Sketcher::Text) {
-            // Member geometries start from index 1.
-            for (int j = 1; c->hasElement(j); ++j) {
-                groupedGeoIds.insert(c->getGeoId(j));
+            // Member geometries start from index 1. Guide lines are references and are listed
+            // like ordinary elements.
+            for (size_t j = 1; c->hasElement(j); ++j) {
+                if (!c->isTextGuideElement(j)) {
+                    groupedGeoIds.insert(c->getGeoId(j));
+                }
             }
         }
     }
@@ -2006,9 +2009,12 @@ void TaskSketcherElements::slotElementsChanged()
             if (c->hasElement(0)) {
                 handleIdToType[c->getGeoId(0)] = c->Type;
             }
-            // Elements from index 1 onwards are the members.
-            for (int j = 1; c->hasElement(j); ++j) {
-                groupedGeoIds.insert(c->getGeoId(j));
+            // Elements from index 1 onwards are the members. Guide lines are references and
+            // are listed like ordinary elements.
+            for (size_t j = 1; c->hasElement(j); ++j) {
+                if (!c->isTextGuideElement(j)) {
+                    groupedGeoIds.insert(c->getGeoId(j));
+                }
             }
         }
     }

--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -22,6 +22,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <QCoreApplication>
 #include <QCursor>
 #include <QLocale>
 #include <QRegularExpression>
@@ -1012,6 +1013,18 @@ int SketcherGui::indexOfGeoId(const std::vector<int>& vec, int elem)
         }
     }
     return -1;
+}
+
+QStringList SketcherGui::textReferenceNames()
+{
+    const char* context = "SketcherGui::TextReference";
+    return {
+        QCoreApplication::translate(context, "Bounding box"),
+        QCoreApplication::translate(context, "Cap height"),
+        QCoreApplication::translate(context, "x-height"),
+        QCoreApplication::translate(context, "Ascender"),
+        QCoreApplication::translate(context, "Em (point size)")
+    };
 }
 
 QMap<QString, QString> SketcherGui::findAvailableFontFiles()

--- a/src/Mod/Sketcher/Gui/Utils.h
+++ b/src/Mod/Sketcher/Gui/Utils.h
@@ -31,6 +31,7 @@
 #include <QListWidget>
 #include <QMap>
 #include <QString>
+#include <QStringList>
 
 #include "AutoConstraint.h"
 #include "ViewProviderSketchGeometryExtension.h"
@@ -236,6 +237,9 @@ inline void scrollTo(QListWidget* list, int i, bool select)
 }
 
 QMap<QString, QString> findAvailableFontFiles();
+
+/// User visible names of the typographic references, ordered as Part::TextReference
+QStringList textReferenceNames();
 
 }  // namespace SketcherGui
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -2749,8 +2749,11 @@ void ViewProviderSketch::onSelectionChanged(const Gui::SelectionChanges& msg)
                         selection.SelCurvSet.insert(GeoId);
 
                         // Check if this is in a group.
-                        // If so we cancel this addition and select the group instead
-                        int handleId = getSketchObject()->getGroupHandleIfInGroup(GeoId);
+                        // If so we cancel this addition and select the group instead.
+                        // Guide lines are references, they are selected on their own.
+                        int handleId = getSketchObject()->isGroupReference(GeoId)
+                            ? GeoId
+                            : getSketchObject()->getGroupHandleIfInGroup(GeoId);
                         if (handleId != GeoId) {
                             // Remove the selected edge
                             Gui::Selection().rmvSelection(msg.pDocName, msg.pObjectName, msg.pSubName);
@@ -2951,9 +2954,12 @@ bool ViewProviderSketch::detectAndShowPreselection(
         else if (result.Kind == EditModeCoinManager::PreselectionResult::HitKind::Edge
                  && result.GeoIndex != preselection.PreselectCurve) {// if a new curve is hit
 
-            // If the picked edge is part of a text/group, treat the handle as the preselected item
+            // If the picked edge is part of a text/group, treat the handle as the preselected
+            // item. Guide lines are references, they are preselected on their own.
             int geoIndex = result.GeoIndex;
-            int handleId = getSketchObject()->getGroupHandleIfInGroup(geoIndex);
+            int handleId = getSketchObject()->isGroupReference(geoIndex)
+                ? geoIndex
+                : getSketchObject()->getGroupHandleIfInGroup(geoIndex);
             if (handleId != geoIndex) {
                 if (handleId == preselection.PreselectCurve) {
                     if (result.hasPickedPoint()) {


### PR DESCRIPTION
A text was sized and placed by the ink bounding box of its glyphs, so both depended on which letters the string contained. It can now be anchored on its baseline and sized from cap height, x-height, ascender or the em square, and can draw its typographic levels, glyph boundaries and letter edges as construction lines. Existing documents keep the bounding box and do not move.

Those lines are derived geometry rather than plain group members, so that other elements can be constrained to them. planegcs gains ConstraintLinearCombination, and two of them per end point tie a guide to the handle of its text, leaving no degree of freedom.

Fixes #32446
[+] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.