### PR TITLE
Add cancellable async feature previews

### DIFF
--- a/.github/workflows/actions/runCPPTests/runQtTests/action.yml
+++ b/.github/workflows/actions/runCPPTests/runQtTests/action.yml
@@ -30,7 +30,12 @@ runs:
         TEST_LOG_FILE: ${{ inputs.testLogFile }}
       run: |
         set -o pipefail
-        ctest --test-dir "$BUILD_DIR" -L Qt --output-on-failure | tee -a "$TEST_LOG_FILE"
+        if [[ "${RUNNER_OS:-}" == "Linux" ]]; then
+          xvfb-run -a -s "-screen 0 1024x768x24 -nolisten tcp" \
+            ctest --test-dir "$BUILD_DIR" -L Qt --output-on-failure | tee -a "$TEST_LOG_FILE"
+        else
+          ctest --test-dir "$BUILD_DIR" -L Qt --output-on-failure | tee -a "$TEST_LOG_FILE"
+        fi
     - name: Parse test results
       if: always()
       id: report

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -291,6 +291,24 @@ void markCanceledRecomputeResult(RecomputeResult& result)
     }
 }
 
+bool documentObjectCanRecomputeOnWorker(const DocumentObject& documentObject, bool recursive)
+{
+    if (!recursive) {
+        return documentObject.canRecomputeOnWorker();
+    }
+
+    try {
+        std::vector<DocumentObject*> roots {const_cast<DocumentObject*>(&documentObject)};
+        const auto recomputeObjects = Document::getDependencyList(roots, Document::DepSort);
+        return std::ranges::all_of(recomputeObjects, [](const DocumentObject* object) {
+            return object && object->canRecomputeOnWorker();
+        });
+    }
+    catch (const Base::BadGraphError&) {
+        return false;
+    }
+}
+
 RecomputeResult processRecomputeRequest(RecomputeRequest& request)
 {
     RecomputeResult result;
@@ -897,7 +915,7 @@ bool Application::isFineGrainedRecomputeEnabled()
 bool Application::canRecomputeRequestOnWorker(const RecomputeRequest& req) const
 {
     if (DocumentObject* documentObject = req.resolveDocumentObject()) {
-        return documentObject->canRecomputeOnWorker();
+        return documentObjectCanRecomputeOnWorker(*documentObject, req.recursive);
     }
 
     Document* document = req.resolveDocument();

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -312,6 +312,11 @@ bool documentObjectCanRecomputeOnWorker(const DocumentObject& documentObject, bo
 RecomputeResult processRecomputeRequest(RecomputeRequest& request)
 {
     RecomputeResult result;
+    // Object-targeted recomputeFeature() does not acquire the GIL itself,
+    // unlike Document::recompute(). Keep the same worker contract for both
+    // request forms because MainThreadSignal releases the GIL while it hops
+    // document notifications to the GUI thread.
+    Base::PyGILStateLocker gilLocker;
     ScopedCurrentRecomputeCancellation cancellationScope(request.cancellation);
 
     if (currentRecomputeWasCanceled()) {

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -215,6 +215,29 @@ namespace fs = std::filesystem;
 namespace
 {
 
+thread_local RecomputeCancellationHandle currentRecomputeCancellation;
+
+class ScopedCurrentRecomputeCancellation
+{
+public:
+    explicit ScopedCurrentRecomputeCancellation(RecomputeCancellationHandle cancellation)
+        : _previous(std::move(currentRecomputeCancellation))
+    {
+        currentRecomputeCancellation = std::move(cancellation);
+    }
+
+    ~ScopedCurrentRecomputeCancellation()
+    {
+        currentRecomputeCancellation = std::move(_previous);
+    }
+
+    ScopedCurrentRecomputeCancellation(const ScopedCurrentRecomputeCancellation&) = delete;
+    ScopedCurrentRecomputeCancellation& operator=(const ScopedCurrentRecomputeCancellation&) = delete;
+
+private:
+    RecomputeCancellationHandle _previous;
+};
+
 RecomputeRequest takeNextRecomputeRequest(std::deque<RecomputeRequest>& requests)
 {
     RecomputeRequest request = std::move(requests.front());
@@ -259,18 +282,39 @@ void reportRecomputeException(const Base::Exception& exception)
     exception.reportException();
 }
 
+void markCanceledRecomputeResult(RecomputeResult& result)
+{
+    result.success = false;
+    result.failure = RecomputeFailure::Canceled;
+    if (!result.exception) {
+        result.exception = std::make_unique<Base::AbortException>("User aborted");
+    }
+}
+
 RecomputeResult processRecomputeRequest(RecomputeRequest& request)
 {
     RecomputeResult result;
+    ScopedCurrentRecomputeCancellation cancellationScope(request.cancellation);
+
+    if (currentRecomputeWasCanceled()) {
+        markCanceledRecomputeResult(result);
+        return result;
+    }
 
     try {
-        if (Document* document = request.resolveDocument()) {
+        if (!request.documentObjectName.empty()) {
+            if (DocumentObject* documentObject = request.resolveDocumentObject()) {
+                documentObject->recomputeFeature(request.recursive);
+            }
+        }
+        else if (Document* document = request.resolveDocument()) {
             document->recompute({}, request.force, nullptr, request.options);
         }
-
-        if (DocumentObject* documentObject = request.resolveDocumentObject()) {
-            documentObject->recomputeFeature(request.recursive);
-        }
+    }
+    catch (Base::AbortException& exception) {
+        result.exception = std::make_unique<Base::AbortException>(std::move(exception));
+        result.failure = RecomputeFailure::Canceled;
+        result.success = false;
     }
     catch (Base::BadGraphError& exception) {
         result.exception = std::make_unique<Base::BadGraphError>(std::move(exception));
@@ -284,10 +328,36 @@ RecomputeResult processRecomputeRequest(RecomputeRequest& request)
         result.success = false;
     }
 
+    if (currentRecomputeWasCanceled() && result.failure == RecomputeFailure::None) {
+        markCanceledRecomputeResult(result);
+    }
+
     return result;
 }
 
 }  // namespace
+
+void App::RecomputeCancellationState::cancel() noexcept
+{
+    _canceled.store(true, std::memory_order_release);
+}
+
+bool App::RecomputeCancellationState::isCanceled() const noexcept
+{
+    return _canceled.load(std::memory_order_acquire);
+}
+
+bool App::currentRecomputeWasCanceled() noexcept
+{
+    return currentRecomputeCancellation && currentRecomputeCancellation->isCanceled();
+}
+
+void App::throwIfRecomputeCanceled()
+{
+    if (currentRecomputeWasCanceled()) {
+        throw Base::AbortException("User aborted");
+    }
+}
 
 //==========================================================================
 // Application
@@ -836,6 +906,10 @@ bool Application::canRecomputeRequestOnWorker(const RecomputeRequest& req) const
 
 void Application::queueRecomputeRequest(RecomputeRequest req)
 {
+    if (!req.cancellation) {
+        req.cancellation = std::make_shared<RecomputeCancellationState>();
+    }
+
     if (!canRecomputeRequestOnWorker(req)) {
         RecomputeResult result;
 
@@ -867,6 +941,25 @@ void Application::queueRecomputeRequest(RecomputeRequest req)
     notifyRecomputeWorker();
 }
 
+bool Application::cancelRecomputeRequest(const RecomputeCancellationHandle& cancellation)
+{
+    if (!cancellation) {
+        return false;
+    }
+
+    // Set the bit before taking the queue lock so a worker that is just about
+    // to begin the request observes cancellation even if it wins the race.
+    cancellation->cancel();
+
+    std::lock_guard<std::mutex> lock(_recomputeMutex);
+    const bool active = _recomputeRequestInProgress
+        && _recomputeRequestInProgress->cancellation == cancellation;
+    const bool queued = std::ranges::any_of(_recomputeRequests, [&cancellation](const auto& request) {
+        return request.cancellation == cancellation;
+    });
+    return active || queued;
+}
+
 void Application::cancelRecomputeRequestsForDocument(const std::string& documentName)
 {
     if (documentName.empty()) {
@@ -874,15 +967,37 @@ void Application::cancelRecomputeRequestsForDocument(const std::string& document
     }
 
     std::unique_lock<std::mutex> lock(_recomputeMutex);
-    _recomputeStateChanged.wait(lock, [this, &documentName] {
-        return !_recomputeDocumentsInProgress.contains(documentName);
-    });
+    if (_recomputeRequestInProgress
+        && requestTargetsDocument(*_recomputeRequestInProgress, documentName)
+        && _recomputeRequestInProgress->cancellation) {
+        _recomputeRequestInProgress->cancellation->cancel();
+    }
 
-    // Cancellation runs on document-close boundaries, so a linear scan keeps
-    // the queue simple without affecting the steady-state worker path.
-    std::erase_if(_recomputeRequests, [&documentName](const RecomputeRequest& request) {
-        return requestTargetsDocument(request, documentName);
-    });
+    // Keep canceled queued requests in the queue until the worker observes
+    // them. This preserves the normal worker callback thread and guarantees
+    // that each queued request receives exactly one Canceled completion.
+    for (auto& request : _recomputeRequests) {
+        if (requestTargetsDocument(request, documentName) && request.cancellation) {
+            request.cancellation->cancel();
+        }
+    }
+
+    while (_recomputeDocumentsInProgress.contains(documentName)) {
+        if (MainThreadSignalConfig::hasHooks() && MainThreadSignalConfig::isMainThread()
+            && MainThreadSignalConfig::canPumpEvents()) {
+            lock.unlock();
+            MainThreadSignalConfig::pumpEvents();
+            lock.lock();
+            if (_recomputeDocumentsInProgress.contains(documentName)) {
+                _recomputeStateChanged.wait_for(lock, std::chrono::milliseconds(1));
+            }
+        }
+        else {
+            _recomputeStateChanged.wait(lock, [this, &documentName] {
+                return !_recomputeDocumentsInProgress.contains(documentName);
+            });
+        }
+    }
 }
 
 struct DocTiming {
@@ -3239,6 +3354,7 @@ void Application::recomputeWorker()
         // Process all pending recompute requests.
         while (!_recomputeRequests.empty()) {
             RecomputeRequest request = takeNextRecomputeRequest(_recomputeRequests);
+            _recomputeRequestInProgress = request;
             if (!request.documentName.empty()) {
                 _recomputeDocumentsInProgress.insert(request.documentName);
             }
@@ -3253,6 +3369,7 @@ void Application::recomputeWorker()
             }
 
             lock.lock();
+            _recomputeRequestInProgress.reset();
             if (!request.documentName.empty()) {
                 _recomputeDocumentsInProgress.erase(request.documentName);
                 _recomputeStateChanged.notify_all();

--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -97,11 +97,31 @@ struct DocumentInitFlags {
 };
 
 /**
+ * @brief Cooperative cancellation state owned by one recompute request.
+ *
+ * The state is deliberately separate from RecomputeRequest so callers can
+ * retain the exact cancellation identity while the request is queued or
+ * executing on the worker.
+ */
+class AppExport RecomputeCancellationState
+{
+public:
+    void cancel() noexcept;
+    bool isCanceled() const noexcept;
+
+private:
+    std::atomic_bool _canceled {false};
+};
+
+using RecomputeCancellationHandle = std::shared_ptr<RecomputeCancellationState>;
+
+/**
  * @brief Failure category for async recompute processing.
  */
 enum class RecomputeFailure
 {
     None,
+    Canceled,
     DependencyCycle,
     Exception
 };
@@ -136,9 +156,16 @@ struct AppExport RecomputeRequest
     bool force {false};
     int options {0};
     bool recursive {false};
+    RecomputeCancellationHandle cancellation {std::make_shared<RecomputeCancellationState>()};
     // Callback to be invoked when recompute is complete.
     std::function<void(RecomputeRequest&, RecomputeResult&)> callback {};
 };
+
+/// Returns whether the currently executing recompute request was canceled.
+AppExport bool currentRecomputeWasCanceled() noexcept;
+
+/// Throws a cooperative abort exception when the current request was canceled.
+AppExport void throwIfRecomputeCanceled();
 
 /**
  * @brief The class that represents the whole application.
@@ -398,6 +425,10 @@ public:
 
     // Adds a recompute request to the processing queue.
     void queueRecomputeRequest(RecomputeRequest req);
+    // Cancels exactly the request represented by this token, if it is queued
+    // or currently executing. The request callback still runs once with a
+    // Canceled result.
+    bool cancelRecomputeRequest(const RecomputeCancellationHandle& cancellation);
 
     // NOLINTBEGIN
     // clang-format off
@@ -1054,6 +1085,7 @@ private:
     // Protects the queued/in-progress recompute state below
     std::mutex _recomputeMutex;
     std::deque<RecomputeRequest> _recomputeRequests;
+    std::optional<RecomputeRequest> _recomputeRequestInProgress;
     std::set<std::string> _recomputeDocumentsInProgress;
     std::condition_variable _recomputeRequestAvailable;
     std::condition_variable _recomputeStateChanged;

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -3277,6 +3277,9 @@ int Document::_recomputeFeature(DocumentObject* Feat) // NOLINT
         }
     }
     catch (Base::AbortException& e) {
+        if (App::currentRecomputeWasCanceled()) {
+            return -1;
+        }
         e.reportException();
         FC_LOG("Failed to recompute " << Feat->getFullName() << ": " << e.what());
         d->addRecomputeLog("User abort", Feat);
@@ -3310,6 +3313,10 @@ int Document::_recomputeFeature(DocumentObject* Feat) // NOLINT
         Feat->resetError();
     }
     else {
+        if (App::currentRecomputeWasCanceled()) {
+            delete returnCode;
+            return -1;
+        }
         returnCode->Which = Feat;
         d->addRecomputeLog(returnCode);
         FC_LOG("Failed to recompute " << Feat->getFullName() << ": " << returnCode->Why);

--- a/src/App/FeatureTest.cpp
+++ b/src/App/FeatureTest.cpp
@@ -34,6 +34,8 @@
 #include <Base/Unit.h>
 #include <CXX/Objects.hxx>
 
+#include "Application.h"
+
 #include "FeatureTest.h"
 #include "Material.h"
 #include "Range.h"
@@ -433,5 +435,8 @@ DocumentObjectExecReturn* FeatureTestAsyncBlocker::execute()
     state.started = true;
     state.changed.notify_all();
     state.changed.wait(lock, [&state] { return state.proceed; });
+    if (App::currentRecomputeWasCanceled()) {
+        throw Base::AbortException("User aborted");
+    }
     return StdReturn;
 }

--- a/src/App/MainThreadSignal.h
+++ b/src/App/MainThreadSignal.h
@@ -47,11 +47,17 @@ class MainThreadSignalConfig
 public:
     using IsMainThreadFn = bool (*)();  // true iff currently on GUI/main thread
     using InvokeFn = void (*)(std::function<void()>&& fn, bool blocking);
+    using PumpEventsFn = void (*)();
 
-    static void setHooks(IsMainThreadFn isMainThread, InvokeFn invoke)
+    static void setHooks(
+        IsMainThreadFn isMainThread,
+        InvokeFn invoke,
+        PumpEventsFn pumpEvents = nullptr
+    )
     {
         isMainThreadSlot() = isMainThread;
         invokeSlot() = invoke;
+        pumpEventsSlot() = pumpEvents;
     }
 
     static inline bool isMainThread()
@@ -65,6 +71,11 @@ public:
         return isMainThreadSlot() && invokeSlot();
     }
 
+    static inline bool canPumpEvents()
+    {
+        return pumpEventsSlot() != nullptr;
+    }
+
     static inline void invoke(std::function<void()>&& fn, bool blocking)
     {
         auto* f = invokeSlot();
@@ -73,6 +84,13 @@ public:
         }
         else {
             fn();  // no hooks, run inline
+        }
+    }
+
+    static inline void pumpEvents()
+    {
+        if (auto* f = pumpEventsSlot()) {
+            f();
         }
     }
 
@@ -85,6 +103,11 @@ private:
     static InvokeFn& invokeSlot()
     {
         static InvokeFn fn = nullptr;
+        return fn;
+    }
+    static PumpEventsFn& pumpEventsSlot()
+    {
+        static PumpEventsFn fn = nullptr;
         return fn;
     }
 };

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -437,7 +437,7 @@ void qtInvokeOnMain(std::function<void()>&& fn, bool blocking)
 void qtPumpMainThreadDispatches()
 {
     if (qApp) {
-        QCoreApplication::sendPostedEvents(nullptr, QEvent::MetaCall);
+        QCoreApplication::sendPostedEvents(MainThreadInvoker::instance(), QEvent::MetaCall);
     }
 }
 

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -431,6 +431,16 @@ void qtInvokeOnMain(std::function<void()>&& fn, bool blocking)
     );
 }
 
+// Document close can wait for a worker recompute. Process only queued
+// MetaCall events in that narrow wait so a worker blocked in a synchronous
+// MainThreadSignal hop can finish without opening a nested user-event loop.
+void qtPumpMainThreadDispatches()
+{
+    if (qApp) {
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::MetaCall);
+    }
+}
+
 }  // namespace Gui
 
 void Application::initStyleParameterManager()
@@ -517,7 +527,11 @@ Application::Application(bool GUIenabled)
 {
     // App::GetApplication().Attach(this);
     if (GUIenabled) {
-        App::MainThreadSignalConfig::setHooks(&qtIsMainThread, &qtInvokeOnMain);
+        App::MainThreadSignalConfig::setHooks(
+            &qtIsMainThread,
+            &qtInvokeOnMain,
+            &qtPumpMainThreadDispatches
+        );
 
         // NOLINTBEGIN
         App::GetApplication().signalNewDocument.connect(

--- a/src/Gui/AsyncPreviewStatus.cpp
+++ b/src/Gui/AsyncPreviewStatus.cpp
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "PreCompiled.h"
+
+#include "AsyncPreviewStatus.h"
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QSizePolicy>
+#include <QTimer>
+
+namespace Gui
+{
+
+AsyncPreviewStatus::AsyncPreviewStatus(QWidget* parent)
+    : QWidget(parent)
+    , _label(new QLabel(tr("Computing preview..."), this))
+    , _cancelButton(new QPushButton(tr("Cancel"), this))
+    , _showTimer(new QTimer(this))
+{
+    auto* layout = new QHBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->addWidget(_label);
+    layout->addStretch();
+    layout->addWidget(_cancelButton);
+
+    _showTimer->setSingleShot(true);
+    _showTimer->setInterval(150);
+    connect(_showTimer, &QTimer::timeout, this, [this] {
+        if (_busy) {
+            setVisible(true);
+        }
+    });
+    connect(_cancelButton, &QPushButton::clicked, this, [this] {
+        if (_cancelCallback) {
+            _cancelCallback();
+        }
+    });
+
+    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+    setVisible(false);
+}
+
+void AsyncPreviewStatus::setCancelCallback(std::function<void()> callback)
+{
+    _cancelCallback = std::move(callback);
+}
+
+void AsyncPreviewStatus::setBusy(bool busy)
+{
+    if (_busy == busy) {
+        return;
+    }
+
+    _busy = busy;
+    _showTimer->stop();
+    if (_busy) {
+        setVisible(false);
+        _showTimer->start();
+    }
+    else {
+        setVisible(false);
+    }
+}
+
+}  // namespace Gui

--- a/src/Gui/AsyncPreviewStatus.h
+++ b/src/Gui/AsyncPreviewStatus.h
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <QWidget>
+
+#include <FCGlobal.h>
+
+#include <functional>
+
+class QLabel;
+class QPushButton;
+class QTimer;
+
+namespace Gui
+{
+
+/**
+ * @brief Small delayed status row for an asynchronous preview.
+ *
+ * The row stays hidden for a short period so quick previews do not flicker.
+ * It deliberately has no progress model; the Cancel button only requests
+ * cooperative cancellation from the owning task.
+ */
+class GuiExport AsyncPreviewStatus: public QWidget
+{
+public:
+    explicit AsyncPreviewStatus(QWidget* parent = nullptr);
+
+    void setCancelCallback(std::function<void()> callback);
+    void setBusy(bool busy);
+
+private:
+    QLabel* _label {nullptr};
+    QPushButton* _cancelButton {nullptr};
+    QTimer* _showTimer {nullptr};
+    std::function<void()> _cancelCallback;
+    bool _busy {false};
+};
+
+}  // namespace Gui

--- a/src/Gui/AsyncTaskRecompute.cpp
+++ b/src/Gui/AsyncTaskRecompute.cpp
@@ -103,6 +103,11 @@ bool AsyncTaskRecompute::isSettling() const
     return static_cast<bool>(_activeCancellation);
 }
 
+bool AsyncTaskRecompute::isAsyncRecomputeEnabled() const
+{
+    return App::GetApplication().isAsyncRecomputeEnabled();
+}
+
 bool AsyncTaskRecompute::hasCurrentSuccessfulPreview() const
 {
     return !_pendingRequest && !_activeCancellation && _completedSerial == _editSerial

--- a/src/Gui/AsyncTaskRecompute.cpp
+++ b/src/Gui/AsyncTaskRecompute.cpp
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "PreCompiled.h"
+
+#include "AsyncTaskRecompute.h"
+
+#include <QCoreApplication>
+#include <QMetaObject>
+#include <QPointer>
+
+namespace Gui
+{
+
+AsyncTaskRecompute::AsyncTaskRecompute(QObject* parent)
+    : QObject(parent)
+{
+    _timer.setSingleShot(true);
+    connect(&_timer, &QTimer::timeout, this, &AsyncTaskRecompute::startPending);
+}
+
+AsyncTaskRecompute::~AsyncTaskRecompute()
+{
+    _timer.stop();
+    if (_activeCancellation) {
+        App::GetApplication().cancelRecomputeRequest(_activeCancellation);
+    }
+}
+
+void AsyncTaskRecompute::schedule(App::RecomputeRequest request, int delayMs, Completion completion)
+{
+    ++_editSerial;
+    _completedSerial = 0;
+
+    _timer.stop();
+    if (_activeCancellation) {
+        App::GetApplication().cancelRecomputeRequest(_activeCancellation);
+    }
+
+    if (!request.cancellation) {
+        request.cancellation = std::make_shared<App::RecomputeCancellationState>();
+    }
+    _pendingRequest = std::move(request);
+    _pendingCompletion = std::move(completion);
+    if (!_activeCancellation) {
+        _running = false;
+    }
+
+    if (delayMs <= 0) {
+        startPending();
+    }
+    else {
+        _timer.start(delayMs);
+    }
+}
+
+void AsyncTaskRecompute::setRunningChanged(RunningChanged callback)
+{
+    _runningChanged = std::move(callback);
+}
+
+bool AsyncTaskRecompute::flushPending()
+{
+    if (!_pendingRequest) {
+        return false;
+    }
+
+    _timer.stop();
+    startPending();
+    return true;
+}
+
+void AsyncTaskRecompute::cancel()
+{
+    _timer.stop();
+
+    if (_pendingRequest && _pendingRequest->cancellation) {
+        _pendingRequest->cancellation->cancel();
+    }
+    _pendingRequest.reset();
+    _pendingCompletion = {};
+
+    if (_activeCancellation) {
+        App::GetApplication().cancelRecomputeRequest(_activeCancellation);
+        return;
+    }
+
+    _running = false;
+    _completedSerial = 0;
+}
+
+bool AsyncTaskRecompute::isPending() const
+{
+    return _pendingRequest.has_value() && _timer.isActive();
+}
+
+bool AsyncTaskRecompute::isRunning() const
+{
+    return _running;
+}
+
+bool AsyncTaskRecompute::isSettling() const
+{
+    return static_cast<bool>(_activeCancellation);
+}
+
+bool AsyncTaskRecompute::hasCurrentSuccessfulPreview() const
+{
+    return !_pendingRequest && !_activeCancellation && _completedSerial == _editSerial
+        && _completedSerial != 0;
+}
+
+std::uint64_t AsyncTaskRecompute::editSerial() const
+{
+    return _editSerial;
+}
+
+std::uint64_t AsyncTaskRecompute::completedSerial() const
+{
+    return _completedSerial;
+}
+
+void AsyncTaskRecompute::startPending()
+{
+    if (!_pendingRequest) {
+        return;
+    }
+
+    App::RecomputeRequest request = std::move(*_pendingRequest);
+    _pendingRequest.reset();
+    _activeCompletion = std::move(_pendingCompletion);
+    _pendingCompletion = {};
+    _activeSerial = _editSerial;
+    _activeCancellation = request.cancellation;
+    _running = true;
+    if (_runningChanged) {
+        _runningChanged(true);
+    }
+
+    QPointer<AsyncTaskRecompute> guard(this);
+    QPointer<QCoreApplication> application(QCoreApplication::instance());
+    const auto serial = _activeSerial;
+    request.callback =
+        [guard, application, serial](App::RecomputeRequest&, App::RecomputeResult& result) {
+            if (!application) {
+                return;
+            }
+
+            auto completed = std::make_shared<App::RecomputeResult>();
+            completed->success = result.success;
+            completed->failure = result.failure;
+            completed->exception = std::move(result.exception);
+
+            QMetaObject::invokeMethod(
+                application,
+                [guard, serial, completed]() mutable {
+                    if (guard) {
+                        guard->finish(serial, std::move(completed));
+                    }
+                },
+                Qt::QueuedConnection
+            );
+        };
+
+    App::GetApplication().queueRecomputeRequest(std::move(request));
+}
+
+void AsyncTaskRecompute::finish(std::uint64_t serial, CompletionData result)
+{
+    if (serial != _activeSerial) {
+        return;
+    }
+
+    _activeCancellation.reset();
+    _running = false;
+    if (_runningChanged) {
+        _runningChanged(false);
+    }
+    const bool current = serial == _editSerial && !_pendingRequest;
+    if (current && result->success && result->failure == App::RecomputeFailure::None) {
+        _completedSerial = serial;
+    }
+    else {
+        _completedSerial = 0;
+    }
+
+    Completion completion = std::move(_activeCompletion);
+    _activeCompletion = {};
+    if (current && completion) {
+        completion(*result);
+    }
+}
+
+}  // namespace Gui

--- a/src/Gui/AsyncTaskRecompute.cpp
+++ b/src/Gui/AsyncTaskRecompute.cpp
@@ -170,6 +170,12 @@ void AsyncTaskRecompute::finish(std::uint64_t serial, CompletionData result)
         return;
     }
 
+    if (_activeCancellation && _activeCancellation->isCanceled()) {
+        result->success = false;
+        result->failure = App::RecomputeFailure::Canceled;
+        result->exception.reset();
+    }
+
     _activeCancellation.reset();
     _running = false;
     if (_runningChanged) {

--- a/src/Gui/AsyncTaskRecompute.h
+++ b/src/Gui/AsyncTaskRecompute.h
@@ -50,6 +50,9 @@ public:
     bool isRunning() const;
     bool isSettling() const;
 
+    /// Whether callers should use the asynchronous recompute path.
+    bool isAsyncRecomputeEnabled() const;
+
     /// True only when the latest edit has a successfully completed request.
     bool hasCurrentSuccessfulPreview() const;
     std::uint64_t editSerial() const;

--- a/src/Gui/AsyncTaskRecompute.h
+++ b/src/Gui/AsyncTaskRecompute.h
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <App/Application.h>
+
+#include <QObject>
+#include <QTimer>
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+
+namespace Gui
+{
+
+/**
+ * @brief Small GUI-side coordinator for one asynchronous recompute preview.
+ *
+ * Recompute itself remains an App concern. This class only handles request
+ * replacement/cancellation, debounce, edit serials, and delivery of the
+ * completion callback on the Qt thread.
+ */
+class GuiExport AsyncTaskRecompute: public QObject
+{
+public:
+    using Completion = std::function<void(App::RecomputeResult&)>;
+    using RunningChanged = std::function<void(bool)>;
+
+    explicit AsyncTaskRecompute(QObject* parent = nullptr);
+    ~AsyncTaskRecompute() override;
+
+    AsyncTaskRecompute(const AsyncTaskRecompute&) = delete;
+    AsyncTaskRecompute& operator=(const AsyncTaskRecompute&) = delete;
+
+    /// Queue a request after delayMs. A new schedule supersedes pending work.
+    void schedule(App::RecomputeRequest request, int delayMs, Completion completion);
+
+    /// Called on the GUI thread when worker ownership starts or ends.
+    void setRunningChanged(RunningChanged callback);
+
+    /// Start a pending request immediately, preserving its edit serial.
+    bool flushPending();
+
+    /// Cooperatively cancel the active request and discard pending work.
+    void cancel();
+
+    bool isPending() const;
+    bool isRunning() const;
+    bool isSettling() const;
+
+    /// True only when the latest edit has a successfully completed request.
+    bool hasCurrentSuccessfulPreview() const;
+    std::uint64_t editSerial() const;
+    std::uint64_t completedSerial() const;
+
+private:
+    using CompletionData = std::shared_ptr<App::RecomputeResult>;
+
+    void startPending();
+    void finish(std::uint64_t serial, CompletionData result);
+
+    QTimer _timer;
+    std::optional<App::RecomputeRequest> _pendingRequest;
+    Completion _pendingCompletion;
+    Completion _activeCompletion;
+    RunningChanged _runningChanged;
+    App::RecomputeCancellationHandle _activeCancellation;
+    std::uint64_t _editSerial {0};
+    std::uint64_t _activeSerial {0};
+    std::uint64_t _completedSerial {0};
+    bool _running {false};
+};
+
+}  // namespace Gui

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1323,6 +1323,7 @@ SET(FreeCADGui_CPP_SRCS
     ${FreeCADGui_MODULE_GENERATED_SRCS}
     ${PySideUic_MODULE_GENERATED_SRCS}
     Application.cpp
+    AsyncPreviewStatus.cpp
     AsyncTaskRecompute.cpp
     ApplicationPy.cpp
     AutoSaver.cpp
@@ -1369,6 +1370,7 @@ SET(FreeCADGui_CPP_SRCS
 )
 SET(FreeCADGui_SRCS
     Application.h
+    AsyncPreviewStatus.h
     AsyncTaskRecompute.h
     AutoSaver.h
     BitmapFactory.h

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1323,6 +1323,7 @@ SET(FreeCADGui_CPP_SRCS
     ${FreeCADGui_MODULE_GENERATED_SRCS}
     ${PySideUic_MODULE_GENERATED_SRCS}
     Application.cpp
+    AsyncTaskRecompute.cpp
     ApplicationPy.cpp
     AutoSaver.cpp
     BitmapFactory.cpp
@@ -1368,6 +1369,7 @@ SET(FreeCADGui_CPP_SRCS
 )
 SET(FreeCADGui_SRCS
     Application.h
+    AsyncTaskRecompute.h
     AutoSaver.h
     BitmapFactory.h
     Document.h

--- a/src/Mod/Part/App/PartFeatures.cpp
+++ b/src/Mod/Part/App/PartFeatures.cpp
@@ -23,6 +23,7 @@
  ***************************************************************************/
 
 #include <memory>
+#include <utility>
 #include <BRepAdaptor_CompCurve.hxx>
 #include <BRepAdaptor_Curve.hxx>
 #include <BRepBuilderAPI_Copy.hxx>
@@ -43,6 +44,7 @@
 #include <TopTools_ListOfShape.hxx>
 
 
+#include <App/Application.h>
 #include <App/Link.h>
 
 #include <App/Document.h>
@@ -422,6 +424,8 @@ void Thickness::handleChangedPropertyType(
 
 App::DocumentObjectExecReturn* Thickness::execute()
 {
+    App::throwIfRecomputeCanceled();
+
     std::vector<TopoShape> shapes;
     auto base = getTopoShape(Faces.getValue(), ShapeOption::ResolveLink | ShapeOption::Transform);
     if (base.isNull()) {
@@ -443,10 +447,19 @@ App::DocumentObjectExecReturn* Thickness::execute()
     short mode = (short)Mode.getValue();
     short join = (short)Join.getValue();
 
-    this->Shape.setValue(
-        TopoShape(0, getDocument()->getStringHasher())
-            .makeElementThickSolid(base, shapes, thickness, tol, inter, self, mode, static_cast<JoinType>(join))
-    );
+    auto result = TopoShape(0, getDocument()->getStringHasher())
+                      .makeElementThickSolid(
+                          base,
+                          shapes,
+                          thickness,
+                          tol,
+                          inter,
+                          self,
+                          mode,
+                          static_cast<JoinType>(join)
+                      );
+    App::throwIfRecomputeCanceled();
+    this->Shape.setValue(std::move(result));
     return Part::Feature::execute();
 }
 

--- a/src/Mod/Part/App/ProgressIndicator.cpp
+++ b/src/Mod/Part/App/ProgressIndicator.cpp
@@ -24,6 +24,8 @@
 
 #include "PreCompiled.h"
 
+#include <App/Application.h>
+
 #include "ProgressIndicator.h"
 
 
@@ -66,7 +68,7 @@ void ProgressIndicator::Show(const Message_ProgressScope& theScope, const Standa
 
 Standard_Boolean ProgressIndicator::UserBreak()
 {
-    return progress->wasCanceled();
+    return progress->wasCanceled() || App::currentRecomputeWasCanceled();
 }
 
 void ProgressIndicator::Reset()

--- a/src/Mod/Part/Gui/TaskThickness.cpp
+++ b/src/Mod/Part/Gui/TaskThickness.cpp
@@ -30,13 +30,16 @@
 #include <App/DocumentObject.h>
 #include <Base/Tools.h>
 #include <Gui/Application.h>
+#include <Gui/AsyncTaskRecompute.h>
 #include <Gui/BitmapFactory.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
+#include <Gui/Control.h>
 #include <Gui/Document.h>
 #include <Gui/Selection/Selection.h>
 #include <Gui/Selection/SelectionFilter.h>
 #include <Gui/Selection/SelectionObject.h>
+#include <Gui/TaskView/TaskView.h>
 #include <Gui/ViewProvider.h>
 #include <Gui/Inventor/Draggers/Gizmo.h>
 #include <Mod/Part/App/GizmoHelper.h>
@@ -56,6 +59,9 @@ public:
     QString text;
     std::string selection;
     Part::Thickness* thickness {nullptr};
+    std::unique_ptr<Gui::AsyncTaskRecompute> recompute;
+    bool acceptRequested {false};
+    bool rejectRequested {false};
 
     class FaceSelection: public Gui::SelectionFilterGate
     {
@@ -90,6 +96,8 @@ ThicknessWidget::ThicknessWidget(Part::Thickness* thickness, QWidget* parent)
     Gui::Command::runCommand(Gui::Command::App, "import Part");
 
     d->thickness = thickness;
+    d->recompute = std::make_unique<Gui::AsyncTaskRecompute>(this);
+    d->recompute->setRunningChanged([this](bool running) { setEnabled(!running); });
     d->ui.setupUi(this);
     setupConnections();
 
@@ -154,44 +162,92 @@ Part::Thickness* ThicknessWidget::getObject() const
     return d->thickness;
 }
 
+void ThicknessWidget::schedulePreview()
+{
+    if (!d->ui.updateView->isChecked()) {
+        d->recompute->cancel();
+        return;
+    }
+
+    auto request = App::RecomputeRequest::fromDocumentObject(*d->thickness, true);
+    d->recompute->schedule(std::move(request), 150, [this](App::RecomputeResult&) {
+        completeDeferredAction();
+    });
+}
+
+void ThicknessWidget::applyUiState()
+{
+    if (!d->selection.empty()) {
+        Gui::cmdAppObjectArgs(d->thickness, "Faces = %s", d->selection.c_str());
+    }
+    Gui::cmdAppObjectArgs(d->thickness, "Value = %f", d->ui.spinOffset->value().getValue());
+    Gui::cmdAppObjectArgs(d->thickness, "Mode = %d", d->ui.modeType->currentIndex());
+    Gui::cmdAppObjectArgs(d->thickness, "Join = %d", d->ui.joinType->currentIndex());
+    Gui::cmdAppObjectArgs(
+        d->thickness,
+        "Intersection = %s",
+        d->ui.intersection->isChecked() ? "True" : "False"
+    );
+    Gui::cmdAppObjectArgs(
+        d->thickness,
+        "SelfIntersection = %s",
+        d->ui.selfIntersection->isChecked() ? "True" : "False"
+    );
+}
+
+void ThicknessWidget::completeDeferredAction()
+{
+    if (d->rejectRequested) {
+        if (d->recompute->isSettling()) {
+            return;
+        }
+
+        d->rejectRequested = false;
+        Gui::Control().reject(d->thickness->getDocument());
+        return;
+    }
+
+    if (!d->acceptRequested || d->recompute->isSettling()) {
+        return;
+    }
+
+    if (!d->recompute->hasCurrentSuccessfulPreview() || !d->thickness->isValid()) {
+        d->acceptRequested = false;
+        return;
+    }
+
+    d->acceptRequested = false;
+    Gui::Control().accept(d->thickness->getDocument());
+}
+
 void ThicknessWidget::onSpinOffsetValueChanged(double val)
 {
     d->thickness->Value.setValue(val);
-    if (d->ui.updateView->isChecked()) {
-        d->thickness->getDocument()->recomputeFeature(d->thickness);
-    }
+    schedulePreview();
 }
 
 void ThicknessWidget::onModeTypeActivated(int val)
 {
     d->thickness->Mode.setValue(val);
-    if (d->ui.updateView->isChecked()) {
-        d->thickness->getDocument()->recomputeFeature(d->thickness);
-    }
+    schedulePreview();
 }
 
 void ThicknessWidget::onJoinTypeActivated(int val)
 {
     d->thickness->Join.setValue((long)val);
-    if (d->ui.updateView->isChecked()) {
-        d->thickness->getDocument()->recomputeFeature(d->thickness);
-    }
+    schedulePreview();
 }
 
 void ThicknessWidget::onIntersectionToggled(bool on)
 {
     d->thickness->Intersection.setValue(on);
-    if (d->ui.updateView->isChecked()) {
-        d->thickness->getDocument()->recomputeFeature(d->thickness);
-    }
+    schedulePreview();
 }
 
 void ThicknessWidget::onSelfIntersectionToggled(bool on)
 {
     d->thickness->SelfIntersection.setValue(on);
-    if (d->ui.updateView->isChecked()) {
-        d->thickness->getDocument()->recomputeFeature(d->thickness);
-    }
+    schedulePreview();
 }
 
 void ThicknessWidget::onFacesButtonToggled(bool on)
@@ -240,9 +296,7 @@ void ThicknessWidget::onFacesButtonToggled(bool on)
         Gui::Selection().rmvSelectionGate();
         Gui::Application::Instance->showViewProvider(d->thickness);
         Gui::Application::Instance->hideViewProvider(d->thickness->Faces.getValue());
-        if (d->ui.updateView->isChecked()) {
-            d->thickness->getDocument()->recomputeFeature(d->thickness);
-        }
+        schedulePreview();
 
         if (gizmoContainer) {
             gizmoContainer->visible = true;
@@ -254,7 +308,10 @@ void ThicknessWidget::onFacesButtonToggled(bool on)
 void ThicknessWidget::onUpdateViewToggled(bool on)
 {
     if (on) {
-        d->thickness->getDocument()->recomputeFeature(d->thickness);
+        schedulePreview();
+    }
+    else {
+        d->recompute->cancel();
     }
 }
 
@@ -265,27 +322,40 @@ bool ThicknessWidget::accept()
     }
 
     try {
-        if (!d->selection.empty()) {
-            Gui::cmdAppObjectArgs(d->thickness, "Faces = %s", d->selection.c_str());
+        if (d->recompute->isSettling()) {
+            d->acceptRequested = true;
+            return false;
         }
-        Gui::cmdAppObjectArgs(d->thickness, "Value = %f", d->ui.spinOffset->value().getValue());
-        Gui::cmdAppObjectArgs(d->thickness, "Mode = %d", d->ui.modeType->currentIndex());
-        Gui::cmdAppObjectArgs(d->thickness, "Join = %d", d->ui.joinType->currentIndex());
-        Gui::cmdAppObjectArgs(
-            d->thickness,
-            "Intersection = %s",
-            d->ui.intersection->isChecked() ? "True" : "False"
-        );
-        Gui::cmdAppObjectArgs(
-            d->thickness,
-            "SelfIntersection = %s",
-            d->ui.selfIntersection->isChecked() ? "True" : "False"
-        );
 
-        Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.recompute()");
+        applyUiState();
+
+        if (d->recompute->isPending()) {
+            d->acceptRequested = true;
+            d->recompute->flushPending();
+            return false;
+        }
+
+        if (!d->recompute->hasCurrentSuccessfulPreview() || !d->thickness->isValid()) {
+            d->acceptRequested = true;
+            auto request = App::RecomputeRequest::fromDocument(*d->thickness->getDocument());
+            d->recompute->schedule(std::move(request), 0, [this](App::RecomputeResult&) {
+                completeDeferredAction();
+            });
+            return false;
+        }
+
+        // The expensive Thickness feature has already been computed by the
+        // accepted preview. Clear its touched state and settle only its
+        // dependents so accepting does not execute Thickness a second time.
+        d->thickness->purgeTouched();
         if (!d->thickness->isValid()) {
             throw Base::CADKernelError(d->thickness->getStatusString());
         }
+        for (auto* obj : d->thickness->getInList()) {
+            obj->touch();
+        }
+        d->thickness->getDocument()->recompute();
+
         Gui::Command::doCommand(Gui::Command::Gui, "Gui.ActiveDocument.resetEdit()");
         d->thickness->getDocument()->commitTransaction();  // Opened in
                                                            // ViewProviderDocumentObject::startDefaultEditMode()
@@ -307,6 +377,16 @@ bool ThicknessWidget::reject()
 {
     if (d->ui.facesButton->isChecked()) {
         return false;
+    }
+
+    if (d->recompute->isSettling()) {
+        d->rejectRequested = true;
+        d->recompute->cancel();
+        return false;
+    }
+
+    if (d->recompute->isPending()) {
+        d->recompute->cancel();
     }
 
     // save this and check if the object is still there after the

--- a/src/Mod/Part/Gui/TaskThickness.cpp
+++ b/src/Mod/Part/Gui/TaskThickness.cpp
@@ -358,9 +358,8 @@ bool ThicknessWidget::accept()
             return false;
         }
 
-        applyUiState();
-
         if (d->recompute->isPending()) {
+            applyUiState();
             d->acceptRequested = true;
             d->recompute->flushPending();
             return false;
@@ -369,6 +368,7 @@ bool ThicknessWidget::accept()
         const bool canReusePreview = d->recompute->hasCurrentSuccessfulPreview()
             && d->thickness->isValid() && !d->thickness->mustRecompute();
         if (!canReusePreview) {
+            applyUiState();
             if (d->recompute->isAsyncRecomputeEnabled()) {
                 d->acceptRequested = true;
                 auto request = App::RecomputeRequest::fromDocumentObject(*d->thickness);
@@ -398,7 +398,9 @@ bool ThicknessWidget::accept()
         }
         d->thickness->getDocument()->recompute();
 
-        Gui::Command::doCommand(Gui::Command::Gui, "Gui.ActiveDocument.resetEdit()");
+        if (Gui::Application::Instance->editDocument()) {
+            Gui::Command::doCommand(Gui::Command::Gui, "Gui.ActiveDocument.resetEdit()");
+        }
         d->thickness->getDocument()->commitTransaction();  // Opened in
                                                            // ViewProviderDocumentObject::startDefaultEditMode()
     }

--- a/src/Mod/Part/Gui/TaskThickness.cpp
+++ b/src/Mod/Part/Gui/TaskThickness.cpp
@@ -189,8 +189,18 @@ void ThicknessWidget::schedulePreview()
         return;
     }
 
-    auto request = App::RecomputeRequest::fromDocumentObject(*d->thickness, true);
-    d->recompute->schedule(std::move(request), 150, [this](App::RecomputeResult&) {
+    if (!d->recompute->isAsyncRecomputeEnabled()) {
+        d->recompute->cancel();
+        d->thickness->getDocument()->recomputeFeature(d->thickness);
+        return;
+    }
+
+    auto request = App::RecomputeRequest::fromDocumentObject(*d->thickness);
+    d->recompute->schedule(std::move(request), 150, [this](App::RecomputeResult& result) {
+        if (result.success && result.failure == App::RecomputeFailure::None
+            && d->thickness->isValid()) {
+            d->thickness->purgeTouched();
+        }
         completeDeferredAction();
     });
 }
@@ -231,7 +241,8 @@ void ThicknessWidget::completeDeferredAction()
         return;
     }
 
-    if (!d->recompute->hasCurrentSuccessfulPreview() || !d->thickness->isValid()) {
+    if (!d->recompute->hasCurrentSuccessfulPreview() || !d->thickness->isValid()
+        || d->thickness->mustRecompute()) {
         d->acceptRequested = false;
         return;
     }
@@ -355,18 +366,29 @@ bool ThicknessWidget::accept()
             return false;
         }
 
-        if (!d->recompute->hasCurrentSuccessfulPreview() || !d->thickness->isValid()) {
-            d->acceptRequested = true;
-            auto request = App::RecomputeRequest::fromDocument(*d->thickness->getDocument());
-            d->recompute->schedule(std::move(request), 0, [this](App::RecomputeResult&) {
-                completeDeferredAction();
-            });
-            return false;
+        const bool canReusePreview = d->recompute->hasCurrentSuccessfulPreview()
+            && d->thickness->isValid() && !d->thickness->mustRecompute();
+        if (!canReusePreview) {
+            if (d->recompute->isAsyncRecomputeEnabled()) {
+                d->acceptRequested = true;
+                auto request = App::RecomputeRequest::fromDocumentObject(*d->thickness);
+                d->recompute->schedule(std::move(request), 0, [this](App::RecomputeResult& result) {
+                    if (result.success && result.failure == App::RecomputeFailure::None
+                        && d->thickness->isValid()) {
+                        d->thickness->purgeTouched();
+                    }
+                    completeDeferredAction();
+                });
+                return false;
+            }
+
+            d->recompute->cancel();
+            d->thickness->getDocument()->recomputeFeature(d->thickness);
         }
 
-        // The expensive Thickness feature has already been computed by the
-        // accepted preview. Clear its touched state and settle only its
-        // dependents so accepting does not execute Thickness a second time.
+        // Keep the feature clean after a preview or final recompute, then
+        // settle only its dependents so accepting does not execute Thickness
+        // a second time.
         d->thickness->purgeTouched();
         if (!d->thickness->isValid()) {
             throw Base::CADKernelError(d->thickness->getStatusString());

--- a/src/Mod/Part/Gui/TaskThickness.cpp
+++ b/src/Mod/Part/Gui/TaskThickness.cpp
@@ -30,6 +30,7 @@
 #include <App/DocumentObject.h>
 #include <Base/Tools.h>
 #include <Gui/Application.h>
+#include <Gui/AsyncPreviewStatus.h>
 #include <Gui/AsyncTaskRecompute.h>
 #include <Gui/BitmapFactory.h>
 #include <Gui/Command.h>
@@ -60,6 +61,7 @@ public:
     std::string selection;
     Part::Thickness* thickness {nullptr};
     std::unique_ptr<Gui::AsyncTaskRecompute> recompute;
+    Gui::AsyncPreviewStatus* previewStatus {nullptr};
     bool acceptRequested {false};
     bool rejectRequested {false};
 
@@ -97,8 +99,15 @@ ThicknessWidget::ThicknessWidget(Part::Thickness* thickness, QWidget* parent)
 
     d->thickness = thickness;
     d->recompute = std::make_unique<Gui::AsyncTaskRecompute>(this);
-    d->recompute->setRunningChanged([this](bool running) { setEnabled(!running); });
     d->ui.setupUi(this);
+
+    d->previewStatus = new Gui::AsyncPreviewStatus(this);
+    d->ui.gridLayout->addWidget(d->previewStatus, 10, 0, 1, 3);
+    d->previewStatus->setCancelCallback([this] { d->recompute->cancel(); });
+    d->recompute->setRunningChanged([this](bool running) {
+        setEditingEnabled(!running);
+        d->previewStatus->setBusy(running);
+    });
     setupConnections();
 
     d->ui.labelOffset->setText(tr("Thickness"));
@@ -160,6 +169,17 @@ void ThicknessWidget::setupConnections()
 Part::Thickness* ThicknessWidget::getObject() const
 {
     return d->thickness;
+}
+
+void ThicknessWidget::setEditingEnabled(bool enabled)
+{
+    d->ui.spinOffset->setEnabled(enabled);
+    d->ui.modeType->setEnabled(enabled);
+    d->ui.joinType->setEnabled(enabled);
+    d->ui.intersection->setEnabled(enabled);
+    d->ui.selfIntersection->setEnabled(enabled);
+    d->ui.facesButton->setEnabled(enabled);
+    d->ui.updateView->setEnabled(enabled);
 }
 
 void ThicknessWidget::schedulePreview()

--- a/src/Mod/Part/Gui/TaskThickness.h
+++ b/src/Mod/Part/Gui/TaskThickness.h
@@ -31,6 +31,7 @@
 namespace Gui
 {
 class AsyncTaskRecompute;
+class AsyncPreviewStatus;
 class LinearGizmo;
 class GizmoContainer;
 }  // namespace Gui
@@ -56,6 +57,7 @@ public:
 
 private:
     void setupConnections();
+    void setEditingEnabled(bool enabled);
     void schedulePreview();
     void applyUiState();
     void completeDeferredAction();

--- a/src/Mod/Part/Gui/TaskThickness.h
+++ b/src/Mod/Part/Gui/TaskThickness.h
@@ -30,6 +30,7 @@
 
 namespace Gui
 {
+class AsyncTaskRecompute;
 class LinearGizmo;
 class GizmoContainer;
 }  // namespace Gui
@@ -55,6 +56,9 @@ public:
 
 private:
     void setupConnections();
+    void schedulePreview();
+    void applyUiState();
+    void completeDeferredAction();
     void onSpinOffsetValueChanged(double);
     void onModeTypeActivated(int);
     void onJoinTypeActivated(int);

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -41,6 +41,7 @@
 #include <Base/Exception.h>
 #include <Base/Reader.h>
 #include <Base/Sequencer.h>
+#include <App/Application.h>
 #include <Mod/Part/App/modelRefine.h>
 
 #include "FeatureTransformed.h"
@@ -58,6 +59,16 @@ using namespace PartDesign;
 
 namespace PartDesign
 {
+namespace
+{
+
+bool operationCanceled()
+{
+    return Base::Sequencer().wasCanceled() || App::currentRecomputeWasCanceled();
+}
+
+}  // namespace
+
 extern bool getPDRefineModelParameter();
 
 PROPERTY_SOURCE(PartDesign::Transformed, PartDesign::FeatureRefine)
@@ -326,6 +337,10 @@ void Transformed::onChanged(const App::Property* prop)
 
 App::DocumentObjectExecReturn* Transformed::execute()
 {
+    if (operationCanceled()) {
+        return new App::DocumentObjectExecReturn("User aborted");
+    }
+
     if (isMultiTransformChild()) {
         return App::DocumentObject::StdReturn;
     }
@@ -394,7 +409,7 @@ App::DocumentObjectExecReturn* Transformed::execute()
         auto transformIter = transformations.cbegin();
         transformIter++;
         for (; transformIter != transformations.end(); transformIter++) {
-            if (Base::Sequencer().wasCanceled()) {
+            if (operationCanceled()) {
                 return std::vector<TopoShape>();
             }
             auto opName = Data::indexSuffix(idx++);
@@ -439,14 +454,14 @@ App::DocumentObjectExecReturn* Transformed::execute()
                 }
                 if (!fuseShape.isNull()) {
                     auto shapes = getTransformedCompShape(supportShape, fuseShape);
-                    if (Base::Sequencer().wasCanceled()) {
+                    if (operationCanceled()) {
                         return new App::DocumentObjectExecReturn("User aborted");
                     }
                     supportShape.makeElementFuse(shapes);
                 }
                 if (!cutShape.isNull()) {
                     auto shapes = getTransformedCompShape(supportShape, cutShape);
-                    if (Base::Sequencer().wasCanceled()) {
+                    if (operationCanceled()) {
                         return new App::DocumentObjectExecReturn("User aborted");
                     }
                     supportShape.makeElementCut(shapes);
@@ -455,7 +470,7 @@ App::DocumentObjectExecReturn* Transformed::execute()
             break;
         case Mode::WholeShape: {
             auto shapes = getTransformedCompShape(supportShape, supportShape);
-            if (Base::Sequencer().wasCanceled()) {
+            if (operationCanceled()) {
                 return new App::DocumentObjectExecReturn("User aborted");
             }
             supportShape.makeElementFuse(shapes);

--- a/src/Mod/PartDesign/Gui/TaskPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPatternParameters.cpp
@@ -40,6 +40,7 @@
 #include <App/Origin.h>
 #include <Base/Console.h>
 #include <Gui/Application.h>
+#include <Gui/AsyncPreviewStatus.h>
 #include <Gui/AsyncTaskRecompute.h>
 #include <Gui/MainWindow.h>
 #include <Gui/BitmapFactory.h>
@@ -75,8 +76,14 @@ TaskPatternParameters::TaskPatternParameters(ViewProviderTransformed* Transforme
     , ui(new Ui_TaskPatternParameters)
 {
     setupUI();
+    previewStatus = new Gui::AsyncPreviewStatus(this);
+    groupLayout()->addWidget(previewStatus);
     asyncRecompute = std::make_unique<Gui::AsyncTaskRecompute>(this);
-    asyncRecompute->setRunningChanged([this](bool running) { setEditingEnabled(!running); });
+    previewStatus->setCancelCallback([this] { asyncRecompute->cancel(); });
+    asyncRecompute->setRunningChanged([this](bool running) {
+        setEditingEnabled(!running);
+        previewStatus->setBusy(running);
+    });
     updateSpacingLabels();
 }
 

--- a/src/Mod/PartDesign/Gui/TaskPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPatternParameters.cpp
@@ -545,7 +545,10 @@ void TaskPatternParameters::apply()
             return;
         }
         else {
-            asyncRecompute->cancel();
+            // MultiTransform deliberately has no async coordinator.
+            if (asyncRecompute) {
+                asyncRecompute->cancel();
+            }
             recomputeFeature();
             updateSpacingLabels();
             updateUI();

--- a/src/Mod/PartDesign/Gui/TaskPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPatternParameters.cpp
@@ -40,10 +40,13 @@
 #include <App/Origin.h>
 #include <Base/Console.h>
 #include <Gui/Application.h>
+#include <Gui/AsyncTaskRecompute.h>
 #include <Gui/MainWindow.h>
 #include <Gui/BitmapFactory.h>
+#include <Gui/Control.h>
 #include <Gui/Selection/Selection.h>
 #include <Gui/Command.h>
+#include <Gui/TaskView/TaskView.h>
 #include <Gui/View3DInventor.h>
 #include <Gui/View3DInventorViewer.h>
 #include <Gui/ViewProviderCoordinateSystem.h>
@@ -72,6 +75,8 @@ TaskPatternParameters::TaskPatternParameters(ViewProviderTransformed* Transforme
     , ui(new Ui_TaskPatternParameters)
 {
     setupUI();
+    asyncRecompute = std::make_unique<Gui::AsyncTaskRecompute>(this);
+    asyncRecompute->setRunningChanged([this](bool running) { setEditingEnabled(!running); });
     updateSpacingLabels();
 }
 
@@ -285,15 +290,92 @@ void TaskPatternParameters::exitReferenceSelectionMode()
 
 // --- SLOTS ---
 
+void TaskPatternParameters::recomputeFeature()
+{
+    if (asyncRecompute && !blockUpdate) {
+        kickUpdateViewTimer();
+    }
+    else {
+        TaskTransformedParameters::recomputeFeature();
+    }
+}
+
 void TaskPatternParameters::onUpdateViewTimer()
 {
     // Recompute is triggered when parameters change and this timer fires
-    setupTransaction();  // Group potential property changes
-    recomputeFeature();
+    if (asyncRecompute) {
+        startAsyncPreview();
+    }
+    else {
+        setupTransaction();  // Group potential property changes
+        recomputeFeature();
+        updateSpacingLabels();
+        updateUI();
+    }
+}
 
-    updateSpacingLabels();
+void TaskPatternParameters::startAsyncPreview()
+{
+    auto* pattern = getObject();
+    if (!pattern || !asyncRecompute) {
+        return;
+    }
 
-    updateUI();
+    setupTransaction();
+    auto request = App::RecomputeRequest::fromDocumentObject(*pattern, true);
+    asyncRecompute->schedule(std::move(request), 0, [this](App::RecomputeResult& result) {
+        const bool succeeded = result.success && result.failure == App::RecomputeFailure::None;
+        if (succeeded) {
+            getTopTransformedView()->refreshPreviewResult();
+            updateSpacingLabels();
+            updateUI();
+        }
+        finishDeferredAction(succeeded);
+    });
+}
+
+void TaskPatternParameters::finishDeferredAction(bool previewSucceeded)
+{
+    if (asyncRecompute && asyncRecompute->isSettling()) {
+        return;
+    }
+
+    if (rejectRequested) {
+        rejectRequested = false;
+        Gui::Control().reject(getObject()->getDocument());
+        return;
+    }
+
+    if (acceptRequested) {
+        acceptRequested = false;
+        if (previewSucceeded && getObject()->isValid()) {
+            Gui::Control().accept(getObject()->getDocument());
+        }
+    }
+}
+
+bool TaskPatternParameters::hasPendingAsyncAccept() const
+{
+    return acceptRequested;
+}
+
+bool TaskPatternParameters::deferAsyncReject()
+{
+    if (!asyncRecompute) {
+        return false;
+    }
+
+    if (asyncRecompute->isSettling()) {
+        rejectRequested = true;
+        asyncRecompute->cancel();
+        return true;
+    }
+
+    if (asyncRecompute->isPending()) {
+        asyncRecompute->cancel();
+    }
+
+    return false;
 }
 
 void TaskPatternParameters::onParameterWidgetRequestReferenceSelection()
@@ -327,6 +409,10 @@ void TaskPatternParameters::onUpdateView(bool on)
     blockUpdate = !on;
     if (on) {
         kickUpdateViewTimer();
+    }
+    else if (asyncRecompute) {
+        updateViewTimer->stop();
+        asyncRecompute->cancel();
     }
 }
 
@@ -380,7 +466,9 @@ void TaskPatternParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
             polarPattern->Axis.setValue(selObj, directions);
         }
         recomputeFeature();
-        updateUI();
+        if (!asyncRecompute) {
+            updateUI();
+        }
     }
     exitReferenceSelectionMode();
 }
@@ -397,6 +485,11 @@ void TaskPatternParameters::apply()
 {
     auto pattern = getObject();
     if (!pattern || !parametersWidget) {
+        return;
+    }
+
+    if (asyncRecompute && asyncRecompute->isSettling()) {
+        acceptRequested = true;
         return;
     }
 
@@ -433,9 +526,22 @@ void TaskPatternParameters::apply()
     // pending.
     if (updateViewTimer && updateViewTimer->isActive()) {
         updateViewTimer->stop();
-        recomputeFeature();
+        if (asyncRecompute) {
+            acceptRequested = true;
+            startAsyncPreview();
+            return;
+        }
+        else {
+            recomputeFeature();
+        }
+    }
+
+    if (asyncRecompute && !asyncRecompute->hasCurrentSuccessfulPreview()) {
+        acceptRequested = true;
+        startAsyncPreview();
     }
 }
+
 
 void TaskPatternParameters::updateSpacingLabels()
 {

--- a/src/Mod/PartDesign/Gui/TaskPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPatternParameters.cpp
@@ -297,9 +297,14 @@ void TaskPatternParameters::exitReferenceSelectionMode()
 
 // --- SLOTS ---
 
+bool TaskPatternParameters::isAsyncPreviewEnabled() const
+{
+    return asyncRecompute && asyncRecompute->isAsyncRecomputeEnabled();
+}
+
 void TaskPatternParameters::recomputeFeature()
 {
-    if (asyncRecompute && !blockUpdate) {
+    if (isAsyncPreviewEnabled() && !blockUpdate) {
         kickUpdateViewTimer();
     }
     else {
@@ -310,7 +315,7 @@ void TaskPatternParameters::recomputeFeature()
 void TaskPatternParameters::onUpdateViewTimer()
 {
     // Recompute is triggered when parameters change and this timer fires
-    if (asyncRecompute) {
+    if (isAsyncPreviewEnabled()) {
         startAsyncPreview();
     }
     else {
@@ -329,10 +334,11 @@ void TaskPatternParameters::startAsyncPreview()
     }
 
     setupTransaction();
-    auto request = App::RecomputeRequest::fromDocumentObject(*pattern, true);
+    auto request = App::RecomputeRequest::fromDocumentObject(*pattern);
     asyncRecompute->schedule(std::move(request), 0, [this](App::RecomputeResult& result) {
         const bool succeeded = result.success && result.failure == App::RecomputeFailure::None;
-        if (succeeded) {
+        if (succeeded && getObject()->isValid()) {
+            getObject()->purgeTouched();
             getTopTransformedView()->refreshPreviewResult();
             updateSpacingLabels();
             updateUI();
@@ -473,7 +479,7 @@ void TaskPatternParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
             polarPattern->Axis.setValue(selObj, directions);
         }
         recomputeFeature();
-        if (!asyncRecompute) {
+        if (!isAsyncPreviewEnabled()) {
             updateUI();
         }
     }
@@ -533,17 +539,22 @@ void TaskPatternParameters::apply()
     // pending.
     if (updateViewTimer && updateViewTimer->isActive()) {
         updateViewTimer->stop();
-        if (asyncRecompute) {
+        if (isAsyncPreviewEnabled()) {
             acceptRequested = true;
             startAsyncPreview();
             return;
         }
         else {
+            asyncRecompute->cancel();
             recomputeFeature();
+            updateSpacingLabels();
+            updateUI();
         }
     }
 
-    if (asyncRecompute && !asyncRecompute->hasCurrentSuccessfulPreview()) {
+    if (isAsyncPreviewEnabled()
+        && (!asyncRecompute->hasCurrentSuccessfulPreview() || !pattern->isValid()
+            || pattern->mustRecompute())) {
         acceptRequested = true;
         startAsyncPreview();
     }

--- a/src/Mod/PartDesign/Gui/TaskPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPatternParameters.h
@@ -36,6 +36,11 @@ namespace PartGui
 class PatternParametersWidget;
 }
 
+namespace Gui
+{
+class AsyncTaskRecompute;
+}
+
 namespace PartDesignGui
 {
 
@@ -53,8 +58,11 @@ public:
     ~TaskPatternParameters() override;
 
     void apply() override;
+    bool hasPendingAsyncAccept() const override;
+    bool deferAsyncReject() override;
 
 protected:
+    void recomputeFeature() override;
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;
 
 private Q_SLOTS:
@@ -75,6 +83,8 @@ private:
     void updateUI();
     void kickUpdateViewTimer() const;
     void updateSpacingLabels();
+    void startAsyncPreview();
+    void finishDeferredAction(bool previewSucceeded);
 
     void bindProperties();
 
@@ -92,6 +102,9 @@ private:
 
     std::unique_ptr<Ui_TaskPatternParameters> ui;
     QTimer* updateViewTimer = nullptr;
+    std::unique_ptr<Gui::AsyncTaskRecompute> asyncRecompute;
+    bool acceptRequested {false};
+    bool rejectRequested {false};
 };
 
 

--- a/src/Mod/PartDesign/Gui/TaskPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPatternParameters.h
@@ -38,8 +38,9 @@ class PatternParametersWidget;
 
 namespace Gui
 {
+class AsyncPreviewStatus;
 class AsyncTaskRecompute;
-}
+}  // namespace Gui
 
 namespace PartDesignGui
 {
@@ -103,6 +104,7 @@ private:
     std::unique_ptr<Ui_TaskPatternParameters> ui;
     QTimer* updateViewTimer = nullptr;
     std::unique_ptr<Gui::AsyncTaskRecompute> asyncRecompute;
+    Gui::AsyncPreviewStatus* previewStatus = nullptr;
     bool acceptRequested {false};
     bool rejectRequested {false};
 };

--- a/src/Mod/PartDesign/Gui/TaskPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPatternParameters.h
@@ -86,6 +86,7 @@ private:
     void updateSpacingLabels();
     void startAsyncPreview();
     void finishDeferredAction(bool previewSucceeded);
+    bool isAsyncPreviewEnabled() const;
 
     void bindProperties();
 

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.cpp
@@ -285,6 +285,13 @@ void TaskTransformedParameters::setEnabledTransaction(bool on)
     enableTransaction = on;
 }
 
+void TaskTransformedParameters::setEditingEnabled(bool enabled)
+{
+    if (proxy) {
+        proxy->setEnabled(enabled);
+    }
+}
+
 bool TaskTransformedParameters::isEnabledTransaction() const
 {
     return enableTransaction;
@@ -596,6 +603,10 @@ bool TaskDlgTransformedParameters::accept()
     parameter->exitSelectionMode();
     parameter->apply();
 
+    if (parameter->hasPendingAsyncAccept()) {
+        return false;
+    }
+
     return TaskDlgFeatureParameters::accept();
 }
 
@@ -603,6 +614,11 @@ bool TaskDlgTransformedParameters::reject()
 {
     // ensure that we are not in selection mode
     parameter->exitSelectionMode();
+
+    if (parameter->deferAsyncReject()) {
+        return false;
+    }
+
     return TaskDlgFeatureParameters::reject();
 }
 

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
@@ -82,6 +82,16 @@ public:
     /// Apply changes for python console
     virtual void apply() = 0;
 
+    /// Whether accept/reject must wait for a task-specific async preview.
+    virtual bool hasPendingAsyncAccept() const
+    {
+        return false;
+    }
+    virtual bool deferAsyncReject()
+    {
+        return false;
+    }
+
     /*!
      * \brief setEnabledTransaction
      * The transaction handling of this panel can be disabled if there is another
@@ -123,8 +133,9 @@ protected:
      */
     bool originalSelected(const Gui::SelectionChanges& msg);
 
-    /// Recompute either this feature or the parent MultiTransform feature
-    void recomputeFeature();
+    /// Recompute either this feature or the parent MultiTransform feature.
+    /// Standalone Pattern overrides this to use its existing debounce timer.
+    virtual void recomputeFeature();
 
     /// Hide the top transformed object (see getTopTransformedObject())
     void hideObject();
@@ -136,6 +147,10 @@ protected:
     void showBase();
 
     void addReferenceSelectionGate(AllowSelectionFlags);
+
+    /// Disable only the editable transformed-task controls while a worker
+    /// owns the feature. MultiTransform keeps the legacy synchronous path.
+    void setEditingEnabled(bool enabled);
 
     int getUpdateViewTimeout() const;
 

--- a/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
@@ -189,6 +189,13 @@ void ViewProviderTransformed::recomputeFeature(bool recompute)
     handleTransformedResult(pcTransformed);
 }
 
+void ViewProviderTransformed::refreshPreviewResult()
+{
+    auto* pcTransformed = getObject<PartDesign::Transformed>();
+    updatePreview();
+    handleTransformedResult(pcTransformed);
+}
+
 
 Gui::View3DInventorViewer* ViewProviderTransformed::getViewer()
 {

--- a/src/Mod/PartDesign/Gui/ViewProviderTransformed.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderTransformed.h
@@ -57,6 +57,8 @@ public:
     std::string featureIcon() const;
 
     void recomputeFeature(bool recompute = true);
+    /// Refresh the GUI representation after a worker-side feature recompute.
+    void refreshPreviewResult();
     void setupContextMenu(QMenu*, QObject*, const char*) override;
 
     /// signals if the transformation contains errors

--- a/tests/src/App/AsyncRecompute.cpp
+++ b/tests/src/App/AsyncRecompute.cpp
@@ -148,6 +148,37 @@ struct CallbackResults
 
 }  // namespace
 
+TEST_F(AsyncRecomputeTest, RecursiveRequestChecksDependentWorkerSafety)
+{
+    auto* safeObject = dynamic_cast<App::FeatureTest*>(
+        _doc->addObject("App::FeatureTest", "SafeFeature")
+    );
+    auto* unsafeDependency = dynamic_cast<App::FeatureTestAttribute*>(
+        _doc->addObject("App::FeatureTestAttribute", "UnsafeDependency")
+    );
+    ASSERT_NE(safeObject, nullptr);
+    ASSERT_NE(unsafeDependency, nullptr);
+
+    safeObject->Link.setValue(unsafeDependency);
+    safeObject->touch();
+    unsafeDependency->touch();
+
+    auto request = App::RecomputeRequest::fromDocumentObject(*safeObject, true);
+    EXPECT_FALSE(App::GetApplication().canRecomputeRequestOnWorker(request));
+
+    const auto callerThread = std::this_thread::get_id();
+    std::thread::id callbackThread;
+    CallbackResults callbacks;
+    request.callback = [&](App::RecomputeRequest&, App::RecomputeResult& result) {
+        callbackThread = std::this_thread::get_id();
+        callbacks.add(result.failure);
+    };
+    App::GetApplication().queueRecomputeRequest(std::move(request));
+
+    ASSERT_TRUE(callbacks.waitForCount(1));
+    EXPECT_EQ(callbackThread, callerThread);
+}
+
 TEST_F(AsyncRecomputeTest, CloseDocumentCancelsActiveRequest)
 {
     auto* blocker = dynamic_cast<App::FeatureTestAsyncBlocker*>(

--- a/tests/src/App/AsyncRecompute.cpp
+++ b/tests/src/App/AsyncRecompute.cpp
@@ -20,8 +20,11 @@
  ******************************************************************************/
 
 #include <chrono>
+#include <condition_variable>
 #include <future>
+#include <mutex>
 #include <thread>
+#include <vector>
 
 #include <boost/scope_exit.hpp>
 #include <gtest/gtest.h>
@@ -116,4 +119,184 @@ TEST_F(AsyncRecomputeTest, WorkerSafetyIsCheckedFromRequest)
     EXPECT_FALSE(
         App::GetApplication().canRecomputeRequestOnWorker(App::RecomputeRequest::fromDocument(*_doc))
     );
+}
+
+namespace
+{
+
+struct CallbackResults
+{
+    void add(App::RecomputeFailure failure)
+    {
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            failures.push_back(failure);
+        }
+        changed.notify_all();
+    }
+
+    bool waitForCount(std::size_t count)
+    {
+        std::unique_lock<std::mutex> lock(mutex);
+        return changed.wait_for(lock, 2s, [&] { return failures.size() == count; });
+    }
+
+    std::mutex mutex;
+    std::condition_variable changed;
+    std::vector<App::RecomputeFailure> failures;
+};
+
+}  // namespace
+
+TEST_F(AsyncRecomputeTest, CloseDocumentCancelsActiveRequest)
+{
+    auto* blocker = dynamic_cast<App::FeatureTestAsyncBlocker*>(
+        _doc->addObject("App::FeatureTestAsyncBlocker", "BlockingFeature")
+    );
+    ASSERT_NE(blocker, nullptr);
+
+    App::FeatureTestAsyncBlocker::resetBlocker();
+    BOOST_SCOPE_EXIT_ALL(&)
+    {
+        App::FeatureTestAsyncBlocker::releaseBlocker();
+    };
+
+    CallbackResults callbacks;
+    auto request = App::RecomputeRequest::fromDocumentObject(*blocker);
+    request.callback = [&callbacks](App::RecomputeRequest&, App::RecomputeResult& result) {
+        callbacks.add(result.failure);
+    };
+    App::GetApplication().queueRecomputeRequest(std::move(request));
+    ASSERT_TRUE(App::FeatureTestAsyncBlocker::waitUntilStarted(2s));
+
+    auto closeFuture = std::async(std::launch::async, [this] {
+        return App::GetApplication().closeDocument(_docName.c_str());
+    });
+    EXPECT_EQ(closeFuture.wait_for(50ms), std::future_status::timeout);
+
+    App::FeatureTestAsyncBlocker::releaseBlocker();
+    ASSERT_EQ(closeFuture.wait_for(2s), std::future_status::ready);
+    EXPECT_TRUE(closeFuture.get());
+    ASSERT_TRUE(callbacks.waitForCount(1));
+
+    std::lock_guard<std::mutex> lock(callbacks.mutex);
+    ASSERT_EQ(callbacks.failures.size(), 1U);
+    EXPECT_EQ(callbacks.failures.front(), App::RecomputeFailure::Canceled);
+    _doc = nullptr;
+}
+
+TEST_F(AsyncRecomputeTest, CancelQueuedRequestBeforeItStarts)
+{
+    auto* blocker = dynamic_cast<App::FeatureTestAsyncBlocker*>(
+        _doc->addObject("App::FeatureTestAsyncBlocker", "BlockingFeature")
+    );
+    ASSERT_NE(blocker, nullptr);
+
+    App::FeatureTestAsyncBlocker::resetBlocker();
+    BOOST_SCOPE_EXIT_ALL(&)
+    {
+        App::FeatureTestAsyncBlocker::releaseBlocker();
+    };
+
+    CallbackResults callbacks;
+    auto firstRequest = App::RecomputeRequest::fromDocumentObject(*blocker);
+    firstRequest.callback = [&callbacks](App::RecomputeRequest&, App::RecomputeResult& result) {
+        callbacks.add(result.failure);
+    };
+    App::GetApplication().queueRecomputeRequest(firstRequest);
+    ASSERT_TRUE(App::FeatureTestAsyncBlocker::waitUntilStarted(2s));
+
+    auto queuedRequest = App::RecomputeRequest::fromDocumentObject(*blocker);
+    queuedRequest.callback = [&callbacks](App::RecomputeRequest&, App::RecomputeResult& result) {
+        callbacks.add(result.failure);
+    };
+    const auto queuedCancellation = queuedRequest.cancellation;
+    App::GetApplication().queueRecomputeRequest(std::move(queuedRequest));
+
+    EXPECT_TRUE(App::GetApplication().cancelRecomputeRequest(queuedCancellation));
+    App::FeatureTestAsyncBlocker::releaseBlocker();
+
+    ASSERT_TRUE(callbacks.waitForCount(2));
+    std::lock_guard<std::mutex> lock(callbacks.mutex);
+    ASSERT_EQ(callbacks.failures.size(), 2U);
+    EXPECT_EQ(callbacks.failures[0], App::RecomputeFailure::None);
+    EXPECT_EQ(callbacks.failures[1], App::RecomputeFailure::Canceled);
+}
+
+TEST_F(AsyncRecomputeTest, CancelRunningRequestReportsCanceled)
+{
+    auto* blocker = dynamic_cast<App::FeatureTestAsyncBlocker*>(
+        _doc->addObject("App::FeatureTestAsyncBlocker", "BlockingFeature")
+    );
+    ASSERT_NE(blocker, nullptr);
+
+    App::FeatureTestAsyncBlocker::resetBlocker();
+    BOOST_SCOPE_EXIT_ALL(&)
+    {
+        App::FeatureTestAsyncBlocker::releaseBlocker();
+    };
+
+    CallbackResults callbacks;
+    auto request = App::RecomputeRequest::fromDocumentObject(*blocker);
+    request.callback = [&callbacks](App::RecomputeRequest&, App::RecomputeResult& result) {
+        callbacks.add(result.failure);
+    };
+    const auto cancellation = request.cancellation;
+    App::GetApplication().queueRecomputeRequest(std::move(request));
+    ASSERT_TRUE(App::FeatureTestAsyncBlocker::waitUntilStarted(2s));
+
+    EXPECT_TRUE(App::GetApplication().cancelRecomputeRequest(cancellation));
+    App::FeatureTestAsyncBlocker::releaseBlocker();
+
+    ASSERT_TRUE(callbacks.waitForCount(1));
+    std::lock_guard<std::mutex> lock(callbacks.mutex);
+    ASSERT_EQ(callbacks.failures.size(), 1U);
+    EXPECT_EQ(callbacks.failures.front(), App::RecomputeFailure::Canceled);
+}
+
+TEST_F(AsyncRecomputeTest, SameObjectRequestsUseIndependentCancellationTokens)
+{
+    auto* blocker = dynamic_cast<App::FeatureTestAsyncBlocker*>(
+        _doc->addObject("App::FeatureTestAsyncBlocker", "BlockingFeature")
+    );
+    ASSERT_NE(blocker, nullptr);
+
+    App::FeatureTestAsyncBlocker::resetBlocker();
+    BOOST_SCOPE_EXIT_ALL(&)
+    {
+        App::FeatureTestAsyncBlocker::releaseBlocker();
+    };
+
+    CallbackResults callbacks;
+    auto firstRequest = App::RecomputeRequest::fromDocumentObject(*blocker);
+    firstRequest.callback = [&callbacks](App::RecomputeRequest&, App::RecomputeResult& result) {
+        callbacks.add(result.failure);
+    };
+    const auto firstCancellation = firstRequest.cancellation;
+    App::GetApplication().queueRecomputeRequest(std::move(firstRequest));
+    ASSERT_TRUE(App::FeatureTestAsyncBlocker::waitUntilStarted(2s));
+
+    auto secondRequest = App::RecomputeRequest::fromDocumentObject(*blocker);
+    secondRequest.callback = [&callbacks](App::RecomputeRequest&, App::RecomputeResult& result) {
+        callbacks.add(result.failure);
+    };
+    const auto secondCancellation = secondRequest.cancellation;
+    App::GetApplication().queueRecomputeRequest(std::move(secondRequest));
+
+    EXPECT_TRUE(App::GetApplication().cancelRecomputeRequest(firstCancellation));
+    EXPECT_FALSE(
+        App::GetApplication().cancelRecomputeRequest(
+            std::make_shared<App::RecomputeCancellationState>()
+        )
+    );
+    EXPECT_TRUE(secondCancellation);
+    EXPECT_FALSE(secondCancellation->isCanceled());
+
+    App::FeatureTestAsyncBlocker::releaseBlocker();
+
+    ASSERT_TRUE(callbacks.waitForCount(2));
+    std::lock_guard<std::mutex> lock(callbacks.mutex);
+    ASSERT_EQ(callbacks.failures.size(), 2U);
+    EXPECT_EQ(callbacks.failures[0], App::RecomputeFailure::Canceled);
+    EXPECT_EQ(callbacks.failures[1], App::RecomputeFailure::None);
 }

--- a/tests/src/App/AsyncRecompute.cpp
+++ b/tests/src/App/AsyncRecompute.cpp
@@ -252,6 +252,40 @@ TEST_F(AsyncRecomputeTest, CancelRunningRequestReportsCanceled)
     std::lock_guard<std::mutex> lock(callbacks.mutex);
     ASSERT_EQ(callbacks.failures.size(), 1U);
     EXPECT_EQ(callbacks.failures.front(), App::RecomputeFailure::Canceled);
+    EXPECT_FALSE(blocker->isError());
+    EXPECT_EQ(_doc->getErrorDescription(blocker), nullptr);
+}
+
+TEST_F(AsyncRecomputeTest, ObjectRequestDoesNotRecomputeUnrelatedObjects)
+{
+    auto* requested = dynamic_cast<App::FeatureTest*>(
+        _doc->addObject("App::FeatureTest", "RequestedFeature")
+    );
+    auto* unrelated = dynamic_cast<App::FeatureTest*>(
+        _doc->addObject("App::FeatureTest", "UnrelatedFeature")
+    );
+    ASSERT_NE(requested, nullptr);
+    ASSERT_NE(unrelated, nullptr);
+
+    requested->touch();
+    unrelated->touch();
+
+    CallbackResults callbacks;
+    auto request = App::RecomputeRequest::fromDocumentObject(*requested);
+    request.callback = [&callbacks](App::RecomputeRequest&, App::RecomputeResult& result) {
+        callbacks.add(result.failure);
+    };
+    App::GetApplication().queueRecomputeRequest(std::move(request));
+
+    ASSERT_TRUE(callbacks.waitForCount(1));
+    {
+        std::lock_guard<std::mutex> lock(callbacks.mutex);
+        ASSERT_EQ(callbacks.failures.size(), 1U);
+        EXPECT_EQ(callbacks.failures.front(), App::RecomputeFailure::None);
+    }
+    EXPECT_EQ(requested->ExecCount.getValue(), 1);
+    EXPECT_EQ(unrelated->ExecCount.getValue(), 0);
+    EXPECT_TRUE(unrelated->mustRecompute());
 }
 
 TEST_F(AsyncRecomputeTest, SameObjectRequestsUseIndependentCancellationTokens)

--- a/tests/src/Gui/AsyncPreviewTasks.cpp
+++ b/tests/src/Gui/AsyncPreviewTasks.cpp
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <chrono>
+#include <functional>
+#include <string>
+#include <thread>
+
+#include <QApplication>
+#include <QCheckBox>
+#include <QTest>
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+#include <Base/Interpreter.h>
+#include <Gui/AsyncTaskRecompute.h>
+#include <Gui/Application.h>
+#include <Gui/MainWindow.h>
+#include <Gui/Macro.h>
+#include <Gui/QuantitySpinBox.h>
+#include <Mod/Part/App/FeaturePartBox.h>
+#include <Mod/Part/App/PartFeatures.h>
+#include <Mod/Part/Gui/TaskThickness.h>
+#include <Mod/PartDesign/App/Body.h>
+#include <Mod/PartDesign/App/FeaturePolarPattern.h>
+#include <Mod/PartDesign/App/FeaturePrimitive.h>
+#include <src/App/InitApplication.h>
+
+using namespace std::chrono_literals;
+
+namespace
+{
+
+class AsyncPreviewTasksTest: public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void initTestCase()
+    {
+        tests::initApplication();
+        if (!Gui::Application::Instance) {
+            Gui::Application::initApplication();
+            Gui::Application::initOpenInventor();
+            // ThicknessWidget records the Python commands it runs through the
+            // GUI macro manager, so use the real GUI-enabled application even
+            // though the test is running headlessly under Xvfb.
+            new Gui::Application(true);
+        }
+        if (!Gui::getMainWindow()) {
+            new Gui::MainWindow;
+        }
+        Base::Interpreter().runString("import Part");
+        Base::Interpreter().loadModule("_PartDesign");
+        App::GetApplication()
+            .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document")
+            ->SetBool("EnableAsyncRecompute", true);
+    }
+
+    void thicknessPreviewIsReusedByAccept()
+    {
+        _docName = App::GetApplication().getUniqueDocumentName("async_preview_tasks");
+        // No 3D view is needed for this widget-level test.
+        _doc = App::GetApplication().newDocument(
+            _docName.c_str(),
+            "testUser",
+            App::DocumentInitFlags {.createView = false}
+        );
+
+        _box = _doc->addObject<Part::Box>("Box");
+        _box->Length.setValue(1.0);
+        _box->Width.setValue(2.0);
+        _box->Height.setValue(3.0);
+
+        _thickness = _doc->addObject<Part::Thickness>("Thickness");
+        _thickness->Faces.setValue(_box, {"Face1"});
+        _thickness->Value.setValue(0.25);
+        _thickness->Join.setValue("Intersection");
+        QVERIFY2(_doc->recompute(), "The fixture model must recompute before opening the task");
+        int recomputeCount = 0;
+        fastsignals::scoped_connection recomputed = _doc->signalRecomputedObject.connect(
+            [&](const App::DocumentObject& object) {
+                if (&object == _thickness) {
+                    ++recomputeCount;
+                }
+            }
+        );
+
+        Gui::MacroManager::MacroRedirector macroRedirector([](Gui::MacroManager::LineType,
+                                                              const char*) {});
+        PartGui::ThicknessWidget widget(_thickness);
+        widget.show();
+
+        auto* updateView = widget.findChild<QCheckBox*>(QStringLiteral("updateView"));
+        auto* offset = widget.findChild<Gui::QuantitySpinBox*>(QStringLiteral("spinOffset"));
+        QVERIFY(updateView);
+        QVERIFY(offset);
+
+        updateView->setChecked(true);
+        offset->setValue(0.30);
+
+        QVERIFY2(
+            waitFor([&] {
+                return recomputeCount == 1 && _thickness->isValid() && !_thickness->mustRecompute();
+            }),
+            "The Thickness task did not settle one successful async preview"
+        );
+        QCOMPARE(recomputeCount, 1);
+        QVERIFY(offset->isEnabled());
+        QVERIFY(_thickness->isValid());
+        QVERIFY(!_thickness->mustRecompute());
+
+        QCOMPARE(recomputeCount, 1);
+        QVERIFY(widget.accept());
+
+        // Accepting a successful preview settles dependents, but must not execute Thickness again.
+        QTest::qWait(100);
+        QCOMPARE(recomputeCount, 1);
+    }
+
+    void cleanup()
+    {
+        if (_doc && App::GetApplication().getDocument(_docName.c_str())) {
+            App::GetApplication().closeDocument(_docName.c_str());
+        }
+        _doc = nullptr;
+        _box = nullptr;
+        _thickness = nullptr;
+
+        if (_patternDoc && App::GetApplication().getDocument(_patternDocName.c_str())) {
+            App::GetApplication().closeDocument(_patternDocName.c_str());
+        }
+        _patternDoc = nullptr;
+        _polarPattern = nullptr;
+    }
+
+    void polarPatternPreviewRecomputesAsynchronously()
+    {
+        _patternDocName = App::GetApplication().getUniqueDocumentName("async_polar_pattern");
+        _patternDoc = App::GetApplication().newDocument(
+            _patternDocName.c_str(),
+            "testUser",
+            App::DocumentInitFlags {.createView = false}
+        );
+
+        auto* body = _patternDoc->addObject<PartDesign::Body>("Body");
+        auto* box = _patternDoc->addObject<PartDesign::Box>("Box");
+        body->addObject(box);
+        box->Length.setValue(2.0);
+        box->Width.setValue(2.0);
+        box->Height.setValue(2.0);
+        QVERIFY2(_patternDoc->recompute(), "The Pattern fixture support must recompute");
+
+        _polarPattern = _patternDoc->addObject<PartDesign::PolarPattern>("PolarPattern");
+        body->addObject(_polarPattern);
+        _polarPattern->Originals.setValues({box});
+        _polarPattern->Axis.setValue(_patternDoc->getObject("Z_Axis"), {});
+        _polarPattern->Angle.setValue(360.0);
+        _polarPattern->Occurrences.setValue(24);
+        QVERIFY2(_patternDoc->recompute(), "The Pattern fixture must recompute");
+
+        int recomputeCount = 0;
+        fastsignals::scoped_connection recomputed = _patternDoc->signalRecomputedObject.connect(
+            [&](const App::DocumentObject& object) {
+                if (&object == _polarPattern) {
+                    ++recomputeCount;
+                }
+            }
+        );
+
+        _polarPattern->Angle.setValue(180.0);
+        bool callbackCalled = false;
+        App::RecomputeFailure failure = App::RecomputeFailure::Exception;
+        bool success = false;
+        Gui::AsyncTaskRecompute asyncRecompute;
+        auto request = App::RecomputeRequest::fromDocumentObject(*_polarPattern);
+        asyncRecompute.schedule(std::move(request), 0, [&](App::RecomputeResult& result) {
+            callbackCalled = true;
+            success = result.success;
+            failure = result.failure;
+            if (success && failure == App::RecomputeFailure::None) {
+                // This is the same main-thread settle performed by the
+                // Pattern task after a successful worker preview.
+                _polarPattern->purgeTouched();
+            }
+        });
+        QVERIFY2(
+            waitFor([&] { return callbackCalled; }),
+            "The Polar Pattern async preview did not deliver its completion"
+        );
+        QVERIFY(success);
+        QCOMPARE(failure, App::RecomputeFailure::None);
+        QCOMPARE(recomputeCount, 1);
+        QVERIFY(_polarPattern->isValid());
+        QVERIFY(!_polarPattern->mustRecompute());
+    }
+
+private:
+    static bool waitFor(const std::function<bool()>& predicate)
+    {
+        const auto deadline = std::chrono::steady_clock::now() + 5s;
+        while (!predicate() && std::chrono::steady_clock::now() < deadline) {
+            QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+            std::this_thread::sleep_for(1ms);
+        }
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
+        return predicate();
+    }
+
+    std::string _docName;
+    App::Document* _doc = nullptr;
+    Part::Box* _box = nullptr;
+    Part::Thickness* _thickness = nullptr;
+    std::string _patternDocName;
+    App::Document* _patternDoc = nullptr;
+    PartDesign::PolarPattern* _polarPattern = nullptr;
+};
+
+}  // namespace
+
+QTEST_MAIN(AsyncPreviewTasksTest)
+#include "AsyncPreviewTasks.moc"

--- a/tests/src/Gui/AsyncTaskRecompute.cpp
+++ b/tests/src/Gui/AsyncTaskRecompute.cpp
@@ -19,6 +19,7 @@
 #include <App/Document.h>
 #include <App/FeatureTest.h>
 #include <App/MainThreadSignal.h>
+#include <Base/Parameter.h>
 #include <Gui/AsyncTaskRecompute.h>
 #include <src/App/InitApplication.h>
 
@@ -161,6 +162,25 @@ TEST_F(AsyncTaskRecomputeTest, CompletionIsDeliveredOnMainThread)
     EXPECT_TRUE(task.hasCurrentSuccessfulPreview());
 }
 
+TEST_F(AsyncTaskRecomputeTest, AsyncRecomputePreferenceIsRespected)
+{
+    auto preferences = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Document"
+    );
+    const bool previous = preferences->GetBool("EnableAsyncRecompute", true);
+    BOOST_SCOPE_EXIT_ALL(&)
+    {
+        preferences->SetBool("EnableAsyncRecompute", previous);
+    };
+
+    Gui::AsyncTaskRecompute task;
+    preferences->SetBool("EnableAsyncRecompute", false);
+    EXPECT_FALSE(task.isAsyncRecomputeEnabled());
+
+    preferences->SetBool("EnableAsyncRecompute", true);
+    EXPECT_TRUE(task.isAsyncRecomputeEnabled());
+}
+
 TEST_F(AsyncTaskRecomputeTest, CancellationInvalidatesCurrentPreview)
 {
     auto* blocker = dynamic_cast<App::FeatureTestAsyncBlocker*>(
@@ -236,6 +256,35 @@ TEST_F(AsyncTaskRecomputeTest, DebouncedBurstRunsOnlyLatestPreview)
     EXPECT_TRUE(processUntil([&] { return callbackCount == 1; }));
     EXPECT_EQ(feature->ExecCount.getValue(), 1);
     EXPECT_TRUE(task.hasCurrentSuccessfulPreview());
+}
+
+TEST_F(AsyncTaskRecomputeTest, SuccessfulPreviewCanBeSettledWithoutReexecution)
+{
+    auto* feature = dynamic_cast<App::FeatureTest*>(
+        _doc->addObject("App::FeatureTest", "PreviewFeature")
+    );
+    ASSERT_NE(feature, nullptr);
+    feature->touch();
+
+    Gui::AsyncTaskRecompute task;
+    bool callbackDone = false;
+    task.schedule(
+        App::RecomputeRequest::fromDocumentObject(*feature),
+        0,
+        [&](App::RecomputeResult& result) {
+            callbackDone = true;
+            EXPECT_TRUE(result.success);
+        }
+    );
+
+    ASSERT_TRUE(processUntil([&] { return callbackDone; }));
+    ASSERT_TRUE(task.hasCurrentSuccessfulPreview());
+    EXPECT_EQ(feature->ExecCount.getValue(), 1);
+
+    // This is the acceptance-side settlement used by the task integrations.
+    feature->purgeTouched();
+    EXPECT_FALSE(feature->mustRecompute());
+    EXPECT_EQ(feature->ExecCount.getValue(), 1);
 }
 
 TEST_F(AsyncTaskRecomputeTest, DestructionCancelsOutstandingCompletionSafely)

--- a/tests/src/Gui/AsyncTaskRecompute.cpp
+++ b/tests/src/Gui/AsyncTaskRecompute.cpp
@@ -12,6 +12,7 @@
 #include <QMetaObject>
 #include <QThread>
 
+#include <boost/scope_exit.hpp>
 #include <gtest/gtest.h>
 
 #include <App/Application.h>
@@ -36,6 +37,16 @@ std::mutex testSignalMutex;
 std::condition_variable testSignalChanged;
 bool testSignalInvocationPending = false;
 
+class TestMainThreadInvoker final: public QObject
+{
+};
+
+TestMainThreadInvoker* testMainThreadInvoker()
+{
+    static auto* invoker = new TestMainThreadInvoker();
+    return invoker;
+}
+
 void testInvokeOnMain(std::function<void()>&& function, bool blocking)
 {
     auto* app = QCoreApplication::instance();
@@ -51,7 +62,7 @@ void testInvokeOnMain(std::function<void()>&& function, bool blocking)
     testSignalChanged.notify_all();
 
     QMetaObject::invokeMethod(
-        app,
+        testMainThreadInvoker(),
         [function = std::move(function)]() mutable { function(); },
         blocking ? Qt::BlockingQueuedConnection : Qt::QueuedConnection
     );
@@ -59,7 +70,7 @@ void testInvokeOnMain(std::function<void()>&& function, bool blocking)
 
 void testPumpMainThreadDispatches()
 {
-    QCoreApplication::sendPostedEvents(nullptr, QEvent::MetaCall);
+    QCoreApplication::sendPostedEvents(testMainThreadInvoker(), QEvent::MetaCall);
 }
 
 class ScopedMainThreadSignalHooks
@@ -93,6 +104,7 @@ protected:
             static char* argv[] = {appName, nullptr};
             new QCoreApplication(argc, argv);
         }
+        testMainThreadInvoker();
         tests::initApplication();
     }
 
@@ -175,6 +187,83 @@ TEST_F(AsyncTaskRecomputeTest, CancellationInvalidatesCurrentPreview)
     EXPECT_FALSE(task.hasCurrentSuccessfulPreview());
 }
 
+TEST_F(AsyncTaskRecomputeTest, LateCancellationInvalidatesQueuedSuccess)
+{
+    auto* blocker = dynamic_cast<App::FeatureTestAsyncBlocker*>(
+        _doc->addObject("App::FeatureTestAsyncBlocker", "BlockingFeature")
+    );
+    ASSERT_NE(blocker, nullptr);
+
+    App::FeatureTestAsyncBlocker::resetBlocker();
+    Gui::AsyncTaskRecompute task;
+    bool callbackDone = false;
+    App::RecomputeFailure failure = App::RecomputeFailure::None;
+    auto request = App::RecomputeRequest::fromDocumentObject(*blocker);
+    task.schedule(std::move(request), 0, [&](App::RecomputeResult& result) {
+        callbackDone = true;
+        failure = result.failure;
+    });
+
+    ASSERT_TRUE(App::FeatureTestAsyncBlocker::waitUntilStarted(2s));
+    App::FeatureTestAsyncBlocker::releaseBlocker();
+    std::this_thread::sleep_for(50ms);
+
+    task.cancel();
+    EXPECT_FALSE(callbackDone);
+    EXPECT_TRUE(processUntil([&] { return callbackDone; }));
+    EXPECT_EQ(failure, App::RecomputeFailure::Canceled);
+    EXPECT_FALSE(task.hasCurrentSuccessfulPreview());
+}
+
+TEST_F(AsyncTaskRecomputeTest, DebouncedBurstRunsOnlyLatestPreview)
+{
+    auto* feature = dynamic_cast<App::FeatureTest*>(
+        _doc->addObject("App::FeatureTest", "PreviewFeature")
+    );
+    ASSERT_NE(feature, nullptr);
+    feature->touch();
+
+    Gui::AsyncTaskRecompute task;
+    int callbackCount = 0;
+    auto completion = [&](App::RecomputeResult& result) {
+        ++callbackCount;
+        EXPECT_TRUE(result.success);
+    };
+    for (int i = 0; i < 5; ++i) {
+        task.schedule(App::RecomputeRequest::fromDocumentObject(*feature), 25, completion);
+    }
+
+    EXPECT_TRUE(processUntil([&] { return callbackCount == 1; }));
+    EXPECT_EQ(feature->ExecCount.getValue(), 1);
+    EXPECT_TRUE(task.hasCurrentSuccessfulPreview());
+}
+
+TEST_F(AsyncTaskRecomputeTest, DestructionCancelsOutstandingCompletionSafely)
+{
+    auto* blocker = dynamic_cast<App::FeatureTestAsyncBlocker*>(
+        _doc->addObject("App::FeatureTestAsyncBlocker", "BlockingFeature")
+    );
+    ASSERT_NE(blocker, nullptr);
+
+    App::FeatureTestAsyncBlocker::resetBlocker();
+    BOOST_SCOPE_EXIT_ALL(&)
+    {
+        App::FeatureTestAsyncBlocker::releaseBlocker();
+    };
+    bool callbackDone = false;
+    {
+        auto task = std::make_unique<Gui::AsyncTaskRecompute>();
+        auto request = App::RecomputeRequest::fromDocumentObject(*blocker);
+        task->schedule(std::move(request), 0, [&](App::RecomputeResult&) { callbackDone = true; });
+        ASSERT_TRUE(App::FeatureTestAsyncBlocker::waitUntilStarted(2s));
+    }
+
+    App::FeatureTestAsyncBlocker::releaseBlocker();
+    std::this_thread::sleep_for(50ms);
+    QCoreApplication::processEvents();
+    EXPECT_FALSE(callbackDone);
+}
+
 TEST_F(AsyncTaskRecomputeTest, CloseDocumentPumpsBlockingMainThreadSignal)
 {
     ScopedMainThreadSignalHooks hooks;
@@ -203,7 +292,18 @@ TEST_F(AsyncTaskRecomputeTest, CloseDocumentPumpsBlockingMainThreadSignal)
         App::FeatureTestAsyncBlocker::releaseBlocker();
     });
 
+    QObject unrelated;
+    bool unrelatedCallRan = false;
+    QMetaObject::invokeMethod(
+        &unrelated,
+        [&unrelatedCallRan] { unrelatedCallRan = true; },
+        Qt::QueuedConnection
+    );
+
     EXPECT_TRUE(App::GetApplication().closeDocument(_docName.c_str()));
     releaser.join();
+    EXPECT_FALSE(unrelatedCallRan);
+    QCoreApplication::processEvents();
+    EXPECT_TRUE(unrelatedCallRan);
     _doc = nullptr;
 }

--- a/tests/src/Gui/AsyncTaskRecompute.cpp
+++ b/tests/src/Gui/AsyncTaskRecompute.cpp
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <memory>
+#include <thread>
+
+#include <QCoreApplication>
+#include <QEvent>
+#include <QMetaObject>
+#include <QThread>
+
+#include <gtest/gtest.h>
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/FeatureTest.h>
+#include <App/MainThreadSignal.h>
+#include <Gui/AsyncTaskRecompute.h>
+#include <src/App/InitApplication.h>
+
+using namespace std::chrono_literals;
+
+namespace
+{
+
+bool testIsMainThread()
+{
+    auto* app = QCoreApplication::instance();
+    return !app || QThread::currentThread() == app->thread();
+}
+
+std::mutex testSignalMutex;
+std::condition_variable testSignalChanged;
+bool testSignalInvocationPending = false;
+
+void testInvokeOnMain(std::function<void()>&& function, bool blocking)
+{
+    auto* app = QCoreApplication::instance();
+    if (!app || testIsMainThread()) {
+        function();
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(testSignalMutex);
+        testSignalInvocationPending = true;
+    }
+    testSignalChanged.notify_all();
+
+    QMetaObject::invokeMethod(
+        app,
+        [function = std::move(function)]() mutable { function(); },
+        blocking ? Qt::BlockingQueuedConnection : Qt::QueuedConnection
+    );
+}
+
+void testPumpMainThreadDispatches()
+{
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::MetaCall);
+}
+
+class ScopedMainThreadSignalHooks
+{
+public:
+    ScopedMainThreadSignalHooks()
+    {
+        App::MainThreadSignalConfig::setHooks(
+            &testIsMainThread,
+            &testInvokeOnMain,
+            &testPumpMainThreadDispatches
+        );
+    }
+
+    ~ScopedMainThreadSignalHooks()
+    {
+        App::MainThreadSignalConfig::setHooks(nullptr, nullptr);
+    }
+};
+
+}  // namespace
+
+class AsyncTaskRecomputeTest: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        if (!QCoreApplication::instance()) {
+            static int argc = 1;
+            static char appName[] = "Gui_tests_run";
+            static char* argv[] = {appName, nullptr};
+            new QCoreApplication(argc, argv);
+        }
+        tests::initApplication();
+    }
+
+    void SetUp() override
+    {
+        _docName = App::GetApplication().getUniqueDocumentName("async_gui_recompute");
+        _doc = App::GetApplication().newDocument(_docName.c_str(), "testUser");
+    }
+
+    void TearDown() override
+    {
+        if (!_docName.empty() && App::GetApplication().getDocument(_docName.c_str())) {
+            App::GetApplication().closeDocument(_docName.c_str());
+        }
+    }
+
+    bool processUntil(const std::function<bool()>& predicate)
+    {
+        const auto deadline = std::chrono::steady_clock::now() + 2s;
+        while (!predicate() && std::chrono::steady_clock::now() < deadline) {
+            QCoreApplication::processEvents();
+            std::this_thread::sleep_for(1ms);
+        }
+        QCoreApplication::processEvents();
+        return predicate();
+    }
+
+    std::string _docName;
+    App::Document* _doc {};
+};
+
+TEST_F(AsyncTaskRecomputeTest, CompletionIsDeliveredOnMainThread)
+{
+    auto* blocker = dynamic_cast<App::FeatureTestAsyncBlocker*>(
+        _doc->addObject("App::FeatureTestAsyncBlocker", "BlockingFeature")
+    );
+    ASSERT_NE(blocker, nullptr);
+
+    App::FeatureTestAsyncBlocker::resetBlocker();
+    App::FeatureTestAsyncBlocker::releaseBlocker();
+
+    Gui::AsyncTaskRecompute task;
+    bool callbackDone = false;
+    bool callbackOnMainThread = false;
+    auto request = App::RecomputeRequest::fromDocumentObject(*blocker);
+    task.schedule(std::move(request), 0, [&](App::RecomputeResult& result) {
+        callbackDone = true;
+        callbackOnMainThread = QThread::currentThread() == QCoreApplication::instance()->thread();
+        EXPECT_TRUE(result.success);
+    });
+
+    EXPECT_TRUE(processUntil([&] { return callbackDone; }));
+    EXPECT_TRUE(callbackOnMainThread);
+    EXPECT_TRUE(task.hasCurrentSuccessfulPreview());
+}
+
+TEST_F(AsyncTaskRecomputeTest, CancellationInvalidatesCurrentPreview)
+{
+    auto* blocker = dynamic_cast<App::FeatureTestAsyncBlocker*>(
+        _doc->addObject("App::FeatureTestAsyncBlocker", "BlockingFeature")
+    );
+    ASSERT_NE(blocker, nullptr);
+
+    App::FeatureTestAsyncBlocker::resetBlocker();
+    Gui::AsyncTaskRecompute task;
+    bool callbackDone = false;
+    App::RecomputeFailure failure = App::RecomputeFailure::None;
+    auto request = App::RecomputeRequest::fromDocumentObject(*blocker);
+    task.schedule(std::move(request), 0, [&](App::RecomputeResult& result) {
+        callbackDone = true;
+        failure = result.failure;
+    });
+
+    ASSERT_TRUE(App::FeatureTestAsyncBlocker::waitUntilStarted(2s));
+    task.cancel();
+    App::FeatureTestAsyncBlocker::releaseBlocker();
+
+    EXPECT_TRUE(processUntil([&] { return callbackDone; }));
+    EXPECT_EQ(failure, App::RecomputeFailure::Canceled);
+    EXPECT_FALSE(task.hasCurrentSuccessfulPreview());
+}
+
+TEST_F(AsyncTaskRecomputeTest, CloseDocumentPumpsBlockingMainThreadSignal)
+{
+    ScopedMainThreadSignalHooks hooks;
+
+    {
+        std::lock_guard<std::mutex> lock(testSignalMutex);
+        testSignalInvocationPending = false;
+    }
+
+    auto* blocker = dynamic_cast<App::FeatureTestAsyncBlocker*>(
+        _doc->addObject("App::FeatureTestAsyncBlocker", "BlockingFeature")
+    );
+    ASSERT_NE(blocker, nullptr);
+
+    App::FeatureTestAsyncBlocker::resetBlocker();
+    blocker->touch();
+    App::GetApplication().queueRecomputeRequest(App::RecomputeRequest::fromDocument(*_doc, true));
+
+    {
+        std::unique_lock<std::mutex> lock(testSignalMutex);
+        ASSERT_TRUE(testSignalChanged.wait_for(lock, 2s, [] { return testSignalInvocationPending; }));
+    }
+
+    std::thread releaser([] {
+        std::this_thread::sleep_for(25ms);
+        App::FeatureTestAsyncBlocker::releaseBlocker();
+    });
+
+    EXPECT_TRUE(App::GetApplication().closeDocument(_docName.c_str()));
+    releaser.join();
+    _doc = nullptr;
+}

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -18,6 +18,38 @@ add_executable(Gui_tests_run
         SelectionTest.cpp
 )
 
+# Async preview tests use a QApplication. They are kept separate from
+# Gui_tests_run, whose existing tests intentionally use QCoreApplication.
+add_executable(AsyncPreviewTasks_Tests_run AsyncPreviewTasks.cpp)
+add_test(NAME AsyncPreviewTasks_Tests_run COMMAND AsyncPreviewTasks_Tests_run)
+
+target_include_directories(AsyncPreviewTasks_Tests_run PUBLIC SYSTEM ${QtTest_INCLUDE_DIRS})
+target_link_libraries(AsyncPreviewTasks_Tests_run
+    FreeCADApp
+    FreeCADGui
+    Part
+    PartGui
+    PartDesign
+    ${QtTest_LIBRARIES}
+)
+
+if(WIN32)
+    set_target_properties(AsyncPreviewTasks_Tests_run PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+    )
+    set_tests_properties(AsyncPreviewTasks_Tests_run PROPERTIES
+        LABELS "Qt"
+        ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+    )
+else()
+    set_target_properties(AsyncPreviewTasks_Tests_run PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests
+    )
+    set_tests_properties(AsyncPreviewTasks_Tests_run PROPERTIES
+        LABELS "Qt"
+    )
+endif()
+
 # Qt tests
 setup_qt_test(ObjectSelection)
 setup_qt_test(QuantitySpinBox)

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(propertyeditor)
 # Standard C++ GTest tests
 add_executable(Gui_tests_run
         Assistant.cpp
+        AsyncTaskRecompute.cpp
         Camera.cpp
         ColorScaleOverlayTest.cpp
         FileDialog.cpp

--- a/tests/src/Gui/StyleParameters/StyleParametersApplicationTest.cpp
+++ b/tests/src/Gui/StyleParameters/StyleParametersApplicationTest.cpp
@@ -40,7 +40,10 @@ protected:
     static void SetUpTestSuite()
     {
         tests::initApplication();
-        app = new Application(true);
+        // These tests exercise style parameter substitution only.  Keep the
+        // application non-GUI because Gui_tests_run uses QCoreApplication and
+        // does not create a MainWindow.
+        app = new Application(false);
     }
 
     void SetUp() override


### PR DESCRIPTION
This PR splits a focused piece out of the larger async recompute work in #29757, making the changes easier to review and integrate incrementally.

It builds on the asynchronous document recompute infrastructure introduced in #21292 and applies it to interactive feature previews.

Expensive previews currently run synchronously on the GUI thread. For features such as Thickness and PartDesign patterns, changing a task parameter can make the interface unresponsive until the recompute finishes. Rapid parameter adjustments are also costly because every intermediate value may trigger work that is already obsolete by the time it completes.

This PR moves supported preview recomputes to the background while the main thread remains available for rendering and user input. Preview requests are debounced, and an in-progress request can be cancelled or superseded when the user changes another parameter. Results are delivered back on the main thread, with stale or cancelled results prevented from modifying the active preview.

A successfully computed preview can be adopted when the task is accepted without executing the feature a second time. Closing the task or document safely cancels outstanding work. The existing synchronous path remains available as a preference-controlled fallback.

The initial integration covers Part Thickness and PartDesign transformed-feature task dialogs, including pattern previews.

## Changes

- Add application-level support required by asynchronous preview recomputes.
- Add `Gui::AsyncTaskRecompute` for debounced and cancellable preview jobs.
- Deliver completion callbacks safely on the main thread.
- Prevent stale or cancelled jobs from updating the active preview.
- Allow successful previews to be accepted without executing the feature again.
- Add progress and cancellation feedback for asynchronous previews.
- Fall back to synchronous recompute when asynchronous recompute is disabled.
- Guard MultiTransform pattern fallback and worker-thread-sensitive paths.
- Handle document closure and task destruction while work is in flight.
- Add App and GUI coverage for recompute, cancellation, debouncing, document closure, and preview acceptance.
- Add headless coverage for Thickness and Polar Pattern preview tasks.

## Testing

Added coverage in:

- `tests/src/App/AsyncRecompute.cpp`
- `tests/src/Gui/AsyncTaskRecompute.cpp`
- `tests/src/Gui/AsyncPreviewTasks.cpp`

This work is done as part of an FPA grant: https://github.com/FreeCAD/FPA-grant-proposals/issues/36
