### PR TITLE
BIM: Introduce an IfcOpenShell capability backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,12 @@ if(NOT FREECAD_LIBPACK_USE OR FREECAD_LIBPACK_CHECKFILE_CLBUNDLER OR FREECAD_LIB
 
     if(BUILD_BIM)
         SetupLark()
-        find_python_runtime_dep(ifcopenshell ifcopenshell ifcopenshell_VERSION "IFC files support disabled.")
+        find_python_runtime_dep(
+            ifcopenshell
+            ifcopenshell
+            ifcopenshell_VERSION
+            "IfcOpenShell can still be installed in FreeCAD's user Python package directory at runtime."
+        )
     endif()
     if(BUILD_ASSEMBLY)
         find_python_runtime_dep(av av av_VERSION "Assembly simulation video export will not work properly.")

--- a/src/Mod/BIM/ArchReference.py
+++ b/src/Mod/BIM/ArchReference.py
@@ -437,10 +437,12 @@ class ArchReference:
         """Gets an IfcOpenShell object"""
 
         try:
-            import ifcopenshell
-        except:
-            t = translate("Arch", "NativeIFC not available - unable to process IFC files")
-            FreeCAD.Console.PrintError(t + "\n")
+            from nativeifc import backend
+
+            ifcopenshell = backend.get_backend(capability=backend.READ)
+        except ImportError as exc:
+            t = translate("Arch", "IfcOpenShell unavailable - unable to process IFC files")
+            FreeCAD.Console.PrintError(f"{t}: {exc}\n")
             return None
         if not getattr(self, "ifcfile", None):
             self.ifcfile = ifcopenshell.open(filename)

--- a/src/Mod/BIM/CMakeLists.txt
+++ b/src/Mod/BIM/CMakeLists.txt
@@ -230,7 +230,11 @@ SET(nativeifc_SRCS
 )
 
 SET(bimtests_SRCS
+    bimtests/TestIfcImportBackend.py
     bimtests/TestIfcOpenShellBackend.py
+    bimtests/TestBimSetup.py
+    bimtests/TestBimIfcExplorer.py
+    bimtests/TestBimClassification.py
     bimtests/TestArchAxis.py
     bimtests/TestArchAxisGui.py
     bimtests/TestArchBase.py

--- a/src/Mod/BIM/CMakeLists.txt
+++ b/src/Mod/BIM/CMakeLists.txt
@@ -235,6 +235,8 @@ SET(bimtests_SRCS
     bimtests/TestBimSetup.py
     bimtests/TestBimIfcExplorer.py
     bimtests/TestBimClassification.py
+    bimtests/TestIfcStructuralExport.py
+    bimtests/TestIfcLegacyExport.py
     bimtests/TestArchAxis.py
     bimtests/TestArchAxisGui.py
     bimtests/TestArchBase.py

--- a/src/Mod/BIM/CMakeLists.txt
+++ b/src/Mod/BIM/CMakeLists.txt
@@ -205,6 +205,7 @@ SET(BIM_templates
 )
 
 SET(nativeifc_SRCS
+    nativeifc/backend.py
     nativeifc/ifc_commands.py
     nativeifc/ifc_diff.py
     nativeifc/ifc_generator.py
@@ -229,6 +230,7 @@ SET(nativeifc_SRCS
 )
 
 SET(bimtests_SRCS
+    bimtests/TestIfcOpenShellBackend.py
     bimtests/TestArchAxis.py
     bimtests/TestArchAxisGui.py
     bimtests/TestArchBase.py

--- a/src/Mod/BIM/TestArch.py
+++ b/src/Mod/BIM/TestArch.py
@@ -23,6 +23,7 @@
 # ***************************************************************************
 
 # Unit test for the Arch module
+from bimtests.TestIfcOpenShellBackend import TestIfcOpenShellBackend
 from bimtests.TestArchRoof import TestArchRoof
 from bimtests.TestArchSpace import TestArchSpace
 from bimtests.TestArchWall import TestArchWall

--- a/src/Mod/BIM/bimcommands/BimClassification.py
+++ b/src/Mod/BIM/bimcommands/BimClassification.py
@@ -28,6 +28,7 @@ import os
 
 import FreeCAD
 import FreeCADGui
+from nativeifc import backend
 
 QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
 translate = FreeCAD.Qt.translate
@@ -482,9 +483,11 @@ class BIM_Classification:
         preset = os.path.join(FreeCAD.getUserAppDataDir(), "BIM", "Classification", system + ".ifc")
         if not os.path.exists(preset):
             return None
-        import ifcopenshell
-
-        f = ifcopenshell.open(preset)
+        try:
+            f = self.loadIfcClassification(preset)
+        except backend.IfcOpenShellUnavailable as exc:
+            FreeCAD.Console.PrintError(f"{exc}\n")
+            return None
         classes = f.by_type("IfcClassificationReference")
         rootclass = f.by_type("IfcClassification")
         if rootclass:
@@ -504,6 +507,12 @@ class BIM_Classification:
                     classdict[cl.ReferencedSource.id()].children.append(currentItem)
             classdict[cl.id()] = currentItem
         return [self.listize(c) for c in root.children]
+
+    def loadIfcClassification(self, filename):
+        """Open a classification file through the read-only backend."""
+
+        ifcopenshell = backend.get_backend(capability=backend.READ)
+        return ifcopenshell.open(filename)
 
     def build_xml(self, system):
         class Item:

--- a/src/Mod/BIM/bimcommands/BimIfcExplorer.py
+++ b/src/Mod/BIM/bimcommands/BimIfcExplorer.py
@@ -26,6 +26,7 @@ import os
 
 import FreeCAD
 import FreeCADGui
+from nativeifc import backend
 
 QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
 translate = FreeCAD.Qt.translate
@@ -49,14 +50,14 @@ class BIM_IfcExplorer:
 
         from PySide import QtGui
 
-        try:
-            import ifcopenshell
-        except ImportError:
+        status = backend.get_status(capability=backend.EXPLORER)
+        if not status.available:
             FreeCAD.Console.PrintError(
                 translate(
                     "BIM",
-                    "IfcOpenShell was not found on this system. IFC support is disabled",
+                    "IfcOpenShell is unavailable or cannot provide IFC Explorer previews",
                 )
+                + (f": {status.error}" if status.error else "")
                 + "\n"
             )
             return
@@ -174,7 +175,6 @@ class BIM_IfcExplorer:
     def open(self):
         "opens a file"
 
-        import ifcopenshell
         from PySide import QtGui
 
         self.filename = ""
@@ -215,7 +215,12 @@ class BIM_IfcExplorer:
         self.currentmesh = None
 
         # read file and order contents
-        self.ifc = ifcopenshell.open(self.filename)
+        try:
+            self.ifc = self.loadIfcFile(self.filename)
+        except backend.IfcOpenShellUnavailable as exc:
+            FreeCAD.Console.PrintError(f"{exc}\n")
+            self.filename = ""
+            return
         root = self.getEntitiesTree()
 
         # unable to find IfcSite
@@ -234,6 +239,12 @@ class BIM_IfcExplorer:
         for eid, children in root.items():
             self.addEntity(eid, children, self.tree)
         # self.tree.expandAll()
+
+    def loadIfcFile(self, filename):
+        """Open an IFC file through the validated Explorer backend."""
+
+        ifcopenshell = backend.get_backend(capability=backend.EXPLORER)
+        return ifcopenshell.open(filename)
 
     def close(self):
         "close the dialog"
@@ -275,8 +286,8 @@ class BIM_IfcExplorer:
         "turns mesh display on/off"
 
         import Mesh
-        import ifcopenshell
-        from ifcopenshell import geom
+
+        geom = backend.get_module("ifcopenshell.geom", capability=backend.EXPLORER)
 
         if not FreeCAD.ActiveDocument:
             doc = FreeCAD.newDocument()
@@ -300,8 +311,7 @@ class BIM_IfcExplorer:
                         trf = FreeCAD.Matrix()
                         trf.scale(s, s, s)
                     basemesh = Mesh.Mesh()
-                    s = geom.settings()
-                    s.set(s.USE_WORLD_COORDS, True)
+                    s = backend.create_mesh_settings()
                     for product in self.products:
                         try:
                             m = geom.create_shape(s, product)
@@ -466,8 +476,11 @@ class BIM_IfcExplorer:
     def addAttributes(self, eid, parent):
         "adds the attributes of the given IFC entity under the given QTreeWidgetITem"
 
-        import ifcopenshell
         from PySide import QtGui
+
+        entity_instance = backend.get_module(
+            "ifcopenshell.entity_instance", capability=backend.EXPLORER
+        ).entity_instance
 
         entity = self.ifc[eid]
 
@@ -488,7 +501,7 @@ class BIM_IfcExplorer:
                 else:
                     if argname not in ["Id", "GlobalId"]:
                         colored = False
-                        if isinstance(argvalue, ifcopenshell.entity_instance):
+                        if isinstance(argvalue, entity_instance):
                             if argvalue.id() == 0:
                                 t = self.tostr(argvalue)
                             else:
@@ -516,7 +529,7 @@ class BIM_IfcExplorer:
                             j = 0
                             for argitem in argvalue:
                                 colored = False
-                                if isinstance(argitem, ifcopenshell.entity_instance):
+                                if isinstance(argitem, entity_instance):
                                     if argitem.id() == 0:
                                         t = self.tostr(argitem)
                                     else:

--- a/src/Mod/BIM/bimcommands/BimPreflight.py
+++ b/src/Mod/BIM/bimcommands/BimPreflight.py
@@ -287,63 +287,24 @@ class BIM_Preflight_TaskPanel:
             self.results[test] = None
             self.culprits[test] = None
             msg = None
-            try:
-                import ifcopenshell
-            except ImportError:
+            from nativeifc import backend
+
+            status = backend.get_status()
+            if not status.available:
                 msg = (
                     translate(
                         "BIM",
-                        "ifcopenshell is not installed on the system or not available to FreeCAD. This library is responsible for IFC support in FreeCAD, and therefore IFC support is currently disabled. Check %1 to obtain more information.",
+                        "IfcOpenShell is not installed or does not provide the APIs required by FreeCAD. Check %1 to obtain more information.",
                     ).replace(
                         "%1", "https://www.freecad.org/wiki/Extra_python_modules#IfcOpenShell"
                     )
                     + " "
                 )
+                if status.error:
+                    msg += status.error
                 self.failed(test)
             else:
-                if hasattr(
-                    ifcopenshell, "schema_identifier"
-                ) and ifcopenshell.schema_identifier.startswith("IFC4"):
-                    self.passed(test)
-                elif hasattr(ifcopenshell, "version"):
-                    try:
-                        from packaging import version
-
-                        if "-" in ifcopenshell.version:
-                            # Prebuild version have a version like 'v0.7.0-<GIT_COMMIT_ID>,
-                            # trying to remove the commit id.
-                            cur_version = version.parse(ifcopenshell.version.split("-")[0])
-                        else:
-                            cur_version = version.parse(ifcopenshell.version)
-                        min_version = version.parse("0.6")
-                        if cur_version >= min_version:
-                            self.passed(test)
-                        else:
-                            msg = self.getToolTip(test)
-                            msg = (
-                                translate(
-                                    "BIM",
-                                    "The version of Ifcopenshell installed on the system could not be parsed",
-                                )
-                                + " "
-                            )
-                            self.failed(test)
-                    except Exception as e:
-                        self.failed(test)
-                else:
-                    msg = self.getToolTip(test)
-                    msg += (
-                        translate(
-                            "BIM",
-                            "The version of Ifcopenshell installed on the system will produce files with this schema version:",
-                        )
-                        + "\n\n"
-                    )
-                    if hasattr(ifcopenshell, "schema_identifier"):
-                        msg += ifcopenshell.schema_identifier + "\n\n"
-                    else:
-                        msg += "Unable to retrieve schemas information from ifcopenshell\n\n"
-                    self.failed(test)
+                self.passed(test)
             self.results[test] = msg
 
     def testHierarchy(self):

--- a/src/Mod/BIM/bimcommands/BimSetup.py
+++ b/src/Mod/BIM/bimcommands/BimSetup.py
@@ -24,11 +24,13 @@
 
 """The BIM Setup command"""
 
+import html
 import os
 import sys
 
 import FreeCAD
 import FreeCADGui
+from nativeifc import backend
 
 translate = FreeCAD.Qt.translate
 QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
@@ -107,12 +109,7 @@ class BIM_Setup:
             import report
         except ImportError:
             m.append("Reporting")
-        try:
-            import ifcopenshell
-        except ImportError:
-            ifcok = False
-        else:
-            ifcok = True
+        ifc_statuses = self.getIfcOpenShellStatus()
         libok = False
         librarypath = FreeCAD.ParamGet("User parameter:Plugins/parts_library").GetString(
             "destination", ""
@@ -142,8 +139,8 @@ class BIM_Setup:
             )
             self.form.labelMissingWorkbenches.setText(t)
             self.form.labelMissingWorkbenches.show()
-        if not ifcok:
-            self.form.labelIfcOpenShell.show()
+        self.form.labelIfcOpenShell.setText(self.formatIfcOpenShellStatus(ifc_statuses))
+        self.form.labelIfcOpenShell.show()
         if (
             FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft").GetString(
                 "snapModes", "111111111101111"
@@ -598,112 +595,56 @@ class BIM_Setup:
         return QtGui.QColor.fromRgbF(r, g, b)
 
     def getIfcOpenShell(self, force=False):
-        """downloads and installs IfcOpenShell"""
+        """Open the maintained pip-based IfcOpenShell installer when needed."""
 
-        # TODO WARNING the IfcOpenBot repo below is not actively kept updated.
-        # We need to use PIP
+        statuses = self.getIfcOpenShellStatus()
+        if not force and all(status.available for status in statuses.values()):
+            return statuses
 
-        ifcok = False
-        if not force:
-            try:
-                import ifcopenshell
-            except:
-                ifcok = False
-            else:
-                ifcok = False
-                v = [int(i) for i in ifcopenshell.version.split(".")]
-                if v[0] < 1:
-                    if v[1] > 6:
-                        ifcok = True
-        if not ifcok:
-            # ifcopenshell not installed
-            import json
-            import re
-            from urllib import request
-            import zipfile
-            from PySide import QtGui
+        from nativeifc import ifc_openshell  # noqa: F401
 
-            if not FreeCAD.GuiUp:
-                reply = QtGui.QMessageBox.Yes
-            else:
-                reply = QtGui.QMessageBox.question(
-                    None,
-                    translate("BIM", "IfcOpenShell Not Found"),
-                    translate(
-                        "BIM",
-                        "IfcOpenShell is needed to import and export IFC files. It appears to be missing on the system. Download and install it now? It will be installed in FreeCAD's macros directory.",
-                    ),
-                    QtGui.QMessageBox.Yes | QtGui.QMessageBox.No,
-                    QtGui.QMessageBox.No,
-                )
-            if reply == QtGui.QMessageBox.Yes:
-                print(
-                    "Loading list of latest IfcOpenBot builds from https://github.com/IfcOpenBot/IfcOpenShell..."
-                )
-                url1 = "https://api.github.com/repos/IfcOpenBot/IfcOpenShell/comments?per_page=100"
-                u = request.urlopen(url1)
-                if u:
-                    r = u.read()
-                    u.close()
-                    d = json.loads(r)
-                    l = d[-1]["body"]
-                    links = re.findall(r"http.*?zip", l)
-                    pyv = "python-" + str(sys.version_info.major) + str(sys.version_info.minor)
-                    if sys.platform.startswith("linux"):
-                        plat = "linux"
-                    elif sys.platform.startswith("win"):
-                        plat = "win"
-                    elif sys.platform.startswith("darwin"):
-                        plat = "macos"
-                    else:
-                        FreeCAD.Console.PrintError("Error - unknown platform")
-                        return
-                    if sys.maxsize > 2**32:
-                        plat += "64"
-                    else:
-                        plat += "32"
-                    print("Looking for", plat, pyv)
-                    for link in links:
-                        if ("ifcopenshell-" + pyv in link) and (plat in link):
-                            print("Downloading " + link + "...")
-                            p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Macro")
-                            fp = p.GetString(
-                                "MacroPath",
-                                os.path.join(FreeCAD.getUserAppDataDir(), "Macros"),
-                            )
-                            u = request.urlopen(link)
-                            if u:
-                                if sys.version_info.major < 3:
-                                    import StringIO as io
+        FreeCADGui.runCommand("IFC_UpdateIOS", 1)
+        statuses = self.getIfcOpenShellStatus(refresh=True)
+        if getattr(self, "form", None):
+            self.form.labelIfcOpenShell.setText(self.formatIfcOpenShellStatus(statuses))
+        return statuses
 
-                                    _stringio = io.StringIO
-                                else:
-                                    import io
+    def getIfcOpenShellStatus(self, refresh=False):
+        """Return operation-specific IfcOpenShell health information."""
 
-                                    _stringio = io.BytesIO
-                                zfile = _stringio()
-                                zfile.write(u.read())
-                                zfile = zipfile.ZipFile(zfile)
-                                zfile.extractall(fp)
-                                u.close()
-                                zfile.close()
-                                print("Successfully installed IfcOpenShell to", fp)
-                                break
-                    else:
-                        FreeCAD.Console.PrintWarning(
-                            "Unable to find a build for this version, therefore falling back to a pip install"
-                        )
-                        try:
-                            import pip
-                        except ModuleNotFoundError:
-                            FreeCAD.Console.PrintError(
-                                "Pnstall pip on your system, restart FreeCAD,"
-                                " change to the BIM workbench and navigate the menu: Utils > ifcOpenShell Update"
-                            )
-                            return
-                        from nativeifc import ifc_openshell
+        if refresh:
+            backend.invalidate()
+        return {
+            "Single-process import": backend.get_status(capability=backend.IMPORT),
+            "Multicore import": backend.get_status(capability=backend.MULTICORE_IMPORT),
+            "NativeIFC export": backend.get_status(capability=backend.EXPORT),
+        }
 
-                        FreeCADGui.runCommand("IFC_UpdateIOS", 1)
+    def formatIfcOpenShellStatus(self, statuses):
+        """Format capability health for the setup dialog."""
+
+        available = [status for status in statuses.values() if status.available]
+        version = next((status.version for status in available if status.version), "")
+        title = "IfcOpenShell" + (f" {html.escape(version)}" if version else "")
+        lines = [f"<b>{title}</b>"]
+        labels = {
+            "Single-process import": translate("BIM", "Single-process import"),
+            "Multicore import": translate("BIM", "Multicore import"),
+            "NativeIFC export": translate("BIM", "NativeIFC export"),
+        }
+        for name, status in statuses.items():
+            state = (
+                translate("BIM", "available")
+                if status.available
+                else translate("BIM", "unavailable")
+            )
+            detail = f": {html.escape(status.error)}" if status.error else ""
+            lines.append(f"{labels.get(name, name)}: {state}{detail}")
+        if len(available) != len(statuses):
+            lines.append(
+                '<a href="#install">' + translate("BIM", "Install or update IfcOpenShell") + "</a>"
+            )
+        return "<br>".join(lines)
 
 
 FreeCADGui.addCommand("BIM_Setup", BIM_Setup())

--- a/src/Mod/BIM/bimtests/TestArchReference.py
+++ b/src/Mod/BIM/bimtests/TestArchReference.py
@@ -22,11 +22,37 @@
 # *                                                                         *
 # ***************************************************************************
 
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
 import Arch
+import ArchReference
 from bimtests import TestArchBase
+from nativeifc import backend
 
 
 class TestArchReference(TestArchBase.TestArchBase):
+
+    def test_ifc_reference_uses_validated_backend(self):
+        proxy = object.__new__(ArchReference.ArchReference)
+        expected = object()
+        ifcopenshell = SimpleNamespace(open=Mock(return_value=expected))
+
+        with patch.object(backend, "get_backend", return_value=ifcopenshell) as get_backend:
+            result = proxy.getIfcFile("reference.ifc")
+
+        self.assertIs(result, expected)
+        get_backend.assert_called_once_with(capability=backend.READ)
+        ifcopenshell.open.assert_called_once_with("reference.ifc")
+
+    def test_ifc_reference_handles_unavailable_backend(self):
+        proxy = object.__new__(ArchReference.ArchReference)
+        error = backend.IfcOpenShellUnavailable("missing required API")
+
+        with patch.object(backend, "get_backend", side_effect=error):
+            result = proxy.getIfcFile("reference.ifc")
+
+        self.assertIsNone(result)
 
     def test_makeReference(self):
         """Test the makeReference function."""

--- a/src/Mod/BIM/bimtests/TestBimClassification.py
+++ b/src/Mod/BIM/bimtests/TestBimClassification.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Tests for classification preset access through the runtime backend."""
+
+import ast
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+import FreeCADGui
+
+if not hasattr(FreeCADGui, "addCommand"):
+    FreeCADGui.addCommand = Mock()
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "bimcommands"))
+
+from BimClassification import BIM_Classification
+from nativeifc import backend
+
+
+class TestBimClassification(unittest.TestCase):
+    def test_classification_loading_uses_read_backend(self):
+        command = BIM_Classification()
+        expected = object()
+        ifcopenshell = Mock()
+        ifcopenshell.open.return_value = expected
+
+        with patch.object(backend, "get_backend", return_value=ifcopenshell) as get_backend:
+            result = command.loadIfcClassification("classification.ifc")
+
+        get_backend.assert_called_once_with(capability=backend.READ)
+        ifcopenshell.open.assert_called_once_with("classification.ifc")
+        self.assertIs(result, expected)
+
+    def test_command_has_no_direct_ifcopenshell_imports(self):
+        path = Path(__file__).resolve().parents[1] / "bimcommands" / "BimClassification.py"
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        violations = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                names = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                names = [node.module]
+            else:
+                continue
+            if any(name == "ifcopenshell" or name.startswith("ifcopenshell.") for name in names):
+                violations.append(node.lineno)
+        self.assertEqual(violations, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/BIM/bimtests/TestBimIfcExplorer.py
+++ b/src/Mod/BIM/bimtests/TestBimIfcExplorer.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Tests for IFC Explorer access through the runtime backend."""
+
+import ast
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+import FreeCADGui
+
+if not hasattr(FreeCADGui, "addCommand"):
+    FreeCADGui.addCommand = Mock()
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "bimcommands"))
+
+from BimIfcExplorer import BIM_IfcExplorer
+from nativeifc import backend
+
+
+class TestBimIfcExplorer(unittest.TestCase):
+    def test_file_loading_uses_explorer_backend(self):
+        explorer = BIM_IfcExplorer()
+        expected = object()
+        ifcopenshell = Mock()
+        ifcopenshell.open.return_value = expected
+
+        with patch.object(backend, "get_backend", return_value=ifcopenshell) as get_backend:
+            result = explorer.loadIfcFile("model.ifc")
+
+        get_backend.assert_called_once_with(capability=backend.EXPLORER)
+        ifcopenshell.open.assert_called_once_with("model.ifc")
+        self.assertIs(result, expected)
+
+    def test_command_has_no_direct_ifcopenshell_imports(self):
+        path = Path(__file__).resolve().parents[1] / "bimcommands" / "BimIfcExplorer.py"
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        violations = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                names = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                names = [node.module]
+            else:
+                continue
+            if any(name == "ifcopenshell" or name.startswith("ifcopenshell.") for name in names):
+                violations.append(node.lineno)
+        self.assertEqual(violations, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/BIM/bimtests/TestBimSetup.py
+++ b/src/Mod/BIM/bimtests/TestBimSetup.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Tests for IfcOpenShell health reporting in BIM Setup."""
+
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import Mock, call, patch
+
+import FreeCADGui
+
+if not hasattr(FreeCADGui, "addCommand"):
+    FreeCADGui.addCommand = Mock()
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "bimcommands"))
+
+from BimSetup import BIM_Setup
+from nativeifc import backend
+
+
+def _status(available, *, version="", error=""):
+    return backend.BackendStatus(available=available, version=version, error=error)
+
+
+class TestBimSetup(unittest.TestCase):
+    def setUp(self):
+        self.setup = BIM_Setup()
+
+    def test_status_refreshes_all_capability_profiles(self):
+        healthy = _status(True, version="0.8.5")
+        with (
+            patch.object(backend, "invalidate") as invalidate,
+            patch.object(backend, "get_status", return_value=healthy) as get_status,
+        ):
+            statuses = self.setup.getIfcOpenShellStatus(refresh=True)
+
+        invalidate.assert_called_once_with()
+        self.assertEqual(len(statuses), 3)
+        self.assertEqual(
+            get_status.call_args_list,
+            [
+                call(capability=backend.IMPORT),
+                call(capability=backend.MULTICORE_IMPORT),
+                call(capability=backend.EXPORT),
+            ],
+        )
+
+    def test_health_text_reports_partial_installation(self):
+        statuses = {
+            "Single-process import": _status(True, version="0.8.5"),
+            "Multicore import": _status(False, error="missing geometry iterator"),
+            "NativeIFC export": _status(False, error="missing API"),
+        }
+
+        text = self.setup.formatIfcOpenShellStatus(statuses)
+
+        self.assertIn("IfcOpenShell 0.8.5", text)
+        self.assertIn("Single-process import: available", text)
+        self.assertIn("missing geometry iterator", text)
+        self.assertIn('href="#install"', text)
+
+    def test_healthy_installation_does_not_open_updater(self):
+        statuses = {"operation": _status(True)}
+        with (
+            patch.object(self.setup, "getIfcOpenShellStatus", return_value=statuses),
+            patch("BimSetup.FreeCADGui.runCommand", create=True) as run_command,
+        ):
+            result = self.setup.getIfcOpenShell()
+
+        self.assertIs(result, statuses)
+        run_command.assert_not_called()
+
+    def test_updater_result_is_revalidated(self):
+        unavailable = {"operation": _status(False)}
+        healthy = {"operation": _status(True)}
+        with (
+            patch.object(
+                self.setup,
+                "getIfcOpenShellStatus",
+                side_effect=(unavailable, healthy),
+            ) as get_status,
+            patch("BimSetup.FreeCADGui.runCommand", create=True) as run_command,
+        ):
+            result = self.setup.getIfcOpenShell()
+
+        run_command.assert_called_once_with("IFC_UpdateIOS", 1)
+        self.assertEqual(get_status.call_args_list, [call(), call(refresh=True)])
+        self.assertIs(result, healthy)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/BIM/bimtests/TestIfcImportBackend.py
+++ b/src/Mod/BIM/bimtests/TestIfcImportBackend.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Integration tests for IFC importer access through the runtime backend."""
+
+from pathlib import Path
+import unittest
+
+import FreeCAD
+
+from importers import importIFC
+from importers import importIFCHelper
+from nativeifc import backend
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+class TestIfcImportBackend(unittest.TestCase):
+    document_name = "IfcBackendMulticoreImport"
+
+    def setUp(self):
+        backend.invalidate()
+        status = backend.get_status(capability=backend.MULTICORE_IMPORT)
+        if not status.available:
+            self.skipTest(f"IfcOpenShell multicore import is unavailable: {status.error}")
+        if self.document_name in FreeCAD.listDocuments():
+            FreeCAD.closeDocument(self.document_name)
+
+    def tearDown(self):
+        if self.document_name in FreeCAD.listDocuments():
+            FreeCAD.closeDocument(self.document_name)
+        backend.invalidate()
+
+    def test_primary_importer_dispatches_to_multicore_backend(self):
+        preferences = importIFCHelper.getPreferences()
+        preferences["MULTICORE"] = max(2, preferences["MULTICORE"])
+        document = FreeCAD.newDocument(self.document_name)
+
+        result = importIFC.insert(
+            str(FIXTURES / "roundtrip_ifc4.ifc"),
+            document.Name,
+            preferences=preferences,
+        )
+
+        self.assertIs(result, document)
+        shaped_objects = [obj for obj in document.Objects if hasattr(obj, "Shape")]
+        self.assertTrue(shaped_objects)
+        self.assertTrue(any(not obj.Shape.isNull() for obj in shaped_objects))
+
+    def test_explorer_backend_opens_and_previews_fixture(self):
+        status = backend.get_status(capability=backend.EXPLORER)
+        if not status.available:
+            self.skipTest(f"IfcOpenShell Explorer support is unavailable: {status.error}")
+        ifcopenshell = backend.get_backend(capability=backend.EXPLORER)
+        geom = backend.get_module("ifcopenshell.geom", capability=backend.EXPLORER)
+        model = ifcopenshell.open(FIXTURES / "roundtrip_ifc4.ifc")
+
+        shape = geom.create_shape(backend.create_mesh_settings(), model.by_type("IfcWall")[0])
+
+        self.assertGreater(len(shape.geometry.verts), 0)
+        self.assertGreater(len(shape.geometry.faces), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/BIM/bimtests/TestIfcLegacyExport.py
+++ b/src/Mod/BIM/bimtests/TestIfcLegacyExport.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Regression tests for legacy IFC export through the runtime backend."""
+
+import ast
+from pathlib import Path
+import tempfile
+import unittest
+
+import FreeCAD
+import Part
+
+from importers import exportIFC
+from importers import exportIFCHelper
+from nativeifc import backend
+
+
+class TestIfcLegacyExport(unittest.TestCase):
+    document_name = "IfcLegacyBackendExport"
+
+    def setUp(self):
+        backend.invalidate()
+        status = backend.get_status(capability=backend.EXPORT)
+        if not status.available:
+            self.skipTest(f"IfcOpenShell export is unavailable: {status.error}")
+        if self.document_name in FreeCAD.listDocuments():
+            FreeCAD.closeDocument(self.document_name)
+        self.document = FreeCAD.newDocument(self.document_name)
+        self.obj = self.document.addObject("Part::Feature", "LegacyBox")
+        self.obj.Label = "Legacy Box"
+        self.obj.Shape = Part.makeBox(1000, 200, 300)
+        self.document.recompute()
+
+    def tearDown(self):
+        if self.document_name in FreeCAD.listDocuments():
+            FreeCAD.closeDocument(self.document_name)
+        backend.invalidate()
+
+    def test_legacy_export_writes_ifc2x3_and_ifc4(self):
+        with tempfile.TemporaryDirectory() as directory:
+            for schema in ("IFC2X3", "IFC4"):
+                with self.subTest(schema=schema):
+                    preferences = exportIFC.getPreferences()
+                    preferences["SCHEMA"] = schema
+                    output = Path(directory) / f"legacy-{schema}.ifc"
+
+                    exportIFC.export([self.obj], str(output), preferences=preferences)
+
+                    self.assertTrue(output.exists())
+                    model = backend.get_backend(capability=backend.READ).open(output)
+                    self.assertEqual(model.schema, schema)
+                    self.assertTrue(model.by_type("IfcProduct"))
+
+    def test_legacy_exporters_have_no_direct_ifcopenshell_imports(self):
+        violations = []
+        for module in (exportIFC, exportIFCHelper):
+            path = Path(module.__file__).resolve()
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    names = [alias.name for alias in node.names]
+                elif isinstance(node, ast.ImportFrom) and node.module:
+                    names = [node.module]
+                else:
+                    continue
+                if any(
+                    name == "ifcopenshell" or name.startswith("ifcopenshell.") for name in names
+                ):
+                    violations.append(f"{path.name}:{node.lineno}")
+        self.assertEqual(violations, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/BIM/bimtests/TestIfcOpenShellBackend.py
+++ b/src/Mod/BIM/bimtests/TestIfcOpenShellBackend.py
@@ -25,6 +25,7 @@ def _modules(*, serialized=True, iterator=True, version="0.8.5"):
     root.ifcopenshell_wrapper = SimpleNamespace(**wrapper_values)
 
     result = {name: ModuleType(name) for name in backend.REQUIRED_MODULES}
+    result["ifcopenshell.guid"] = ModuleType("ifcopenshell.guid")
     result["ifcopenshell"] = root
     result["ifcopenshell.api"].run = lambda *args, **kwargs: None
     result["ifcopenshell.api.aggregate"].assign_object = lambda *args, **kwargs: None
@@ -52,6 +53,7 @@ def _modules(*, serialized=True, iterator=True, version="0.8.5"):
     result["ifcopenshell.geom"].settings = lambda *args, **kwargs: None
     result["ifcopenshell.geom"].create_shape = lambda *args, **kwargs: None
     result["ifcopenshell.entity_instance"].entity_instance = EntityInstance
+    result["ifcopenshell.guid"].new = lambda: "0" * 22
     if iterator:
         result["ifcopenshell.geom"].iterator = lambda *args, **kwargs: None
     return result
@@ -137,6 +139,27 @@ class TestIfcOpenShellBackend(unittest.TestCase):
 
         self.assertFalse(status.available)
         self.assertIn("ifcopenshell.open", status.error)
+
+    def test_guid_does_not_require_file_or_geometry_apis(self):
+        modules = _modules()
+        del modules["ifcopenshell"].open
+        guid_modules = {name: modules[name] for name in backend.GUID_MODULES}
+        with patch.object(backend.importlib, "import_module", side_effect=guid_modules.__getitem__):
+            status = backend.get_status(capability=backend.GUID)
+            guid = backend.new_guid()
+
+        self.assertTrue(status.available)
+        self.assertEqual(guid, "0" * 22)
+
+    def test_guid_requires_generator_api(self):
+        modules = _modules()
+        del modules["ifcopenshell.guid"].new
+        guid_modules = {name: modules[name] for name in backend.GUID_MODULES}
+        with patch.object(backend.importlib, "import_module", side_effect=guid_modules.__getitem__):
+            status = backend.get_status(capability=backend.GUID)
+
+        self.assertFalse(status.available)
+        self.assertIn("ifcopenshell.guid.new", status.error)
 
     def test_partial_installation_is_unavailable(self):
         modules = _modules()

--- a/src/Mod/BIM/bimtests/TestIfcOpenShellBackend.py
+++ b/src/Mod/BIM/bimtests/TestIfcOpenShellBackend.py
@@ -2,6 +2,8 @@
 
 """Hermetic tests for the IfcOpenShell runtime boundary."""
 
+import ast
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 import unittest
 from unittest.mock import patch
@@ -10,6 +12,9 @@ from nativeifc import backend
 
 
 def _modules(*, serialized=True, iterator=True, version="0.8.5"):
+    class EntityInstance:
+        pass
+
     root = ModuleType("ifcopenshell")
     root.version = version
     root.open = lambda _filename: None
@@ -22,6 +27,31 @@ def _modules(*, serialized=True, iterator=True, version="0.8.5"):
     result = {name: ModuleType(name) for name in backend.REQUIRED_MODULES}
     result["ifcopenshell"] = root
     result["ifcopenshell.api"].run = lambda *args, **kwargs: None
+    result["ifcopenshell.api.aggregate"].assign_object = lambda *args, **kwargs: None
+    result["ifcopenshell.api.feature"].add_feature = lambda *args, **kwargs: None
+    result["ifcopenshell.api.feature"].add_filling = lambda *args, **kwargs: None
+    result["ifcopenshell.api.geometry"].add_wall_representation = lambda *args, **kwargs: None
+    result["ifcopenshell.api.geometry"].add_profile_representation = lambda *args, **kwargs: None
+    result["ifcopenshell.api.group"].add_group = lambda *args, **kwargs: None
+    result["ifcopenshell.api.group"].assign_group = lambda *args, **kwargs: None
+    result["ifcopenshell.api.material"].add_material = lambda *args, **kwargs: None
+    result["ifcopenshell.api.material"].add_material_set = lambda *args, **kwargs: None
+    result["ifcopenshell.api.material"].add_layer = lambda *args, **kwargs: None
+    result["ifcopenshell.api.material"].edit_layer = lambda *args, **kwargs: None
+    result["ifcopenshell.api.material"].add_profile = lambda *args, **kwargs: None
+    result["ifcopenshell.api.material"].assign_material = lambda *args, **kwargs: None
+    result["ifcopenshell.api.pset"].add_pset = lambda *args, **kwargs: None
+    result["ifcopenshell.api.pset"].edit_pset = lambda *args, **kwargs: None
+    result["ifcopenshell.api.pset"].add_qto = lambda *args, **kwargs: None
+    result["ifcopenshell.api.pset"].edit_qto = lambda *args, **kwargs: None
+    result["ifcopenshell.api.spatial"].assign_container = lambda *args, **kwargs: None
+    result["ifcopenshell.api.style"].add_style = lambda *args, **kwargs: None
+    result["ifcopenshell.api.style"].add_surface_style = lambda *args, **kwargs: None
+    result["ifcopenshell.api.style"].assign_item_style = lambda *args, **kwargs: None
+    result["ifcopenshell.api.type"].assign_type = lambda *args, **kwargs: None
+    result["ifcopenshell.geom"].settings = lambda *args, **kwargs: None
+    result["ifcopenshell.geom"].create_shape = lambda *args, **kwargs: None
+    result["ifcopenshell.entity_instance"].entity_instance = EntityInstance
     if iterator:
         result["ifcopenshell.geom"].iterator = lambda *args, **kwargs: None
     return result
@@ -30,6 +60,49 @@ def _modules(*, serialized=True, iterator=True, version="0.8.5"):
 class TestIfcOpenShellBackend(unittest.TestCase):
     def tearDown(self):
         backend.invalidate()
+
+    def test_invalidate_refreshes_python_import_caches(self):
+        with patch.object(backend.importlib, "invalidate_caches") as invalidate_caches:
+            backend.invalidate()
+        invalidate_caches.assert_called_once_with()
+
+    def test_nativeifc_has_no_direct_ifcopenshell_imports(self):
+        nativeifc = Path(__file__).resolve().parents[1] / "nativeifc"
+        violations = []
+        for path in nativeifc.glob("*.py"):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    names = [alias.name for alias in node.names]
+                elif isinstance(node, ast.ImportFrom) and node.module:
+                    names = [node.module]
+                else:
+                    continue
+                if any(
+                    name == "ifcopenshell" or name.startswith("ifcopenshell.") for name in names
+                ):
+                    violations.append(f"{path.name}:{node.lineno}")
+        self.assertEqual(violations, [])
+
+    def test_primary_importers_use_backend_boundary(self):
+        bim = Path(__file__).resolve().parents[1]
+        violations = []
+        for name in ("importIFC.py", "importIFCmulticore.py"):
+            path = bim / "importers" / name
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    names = [alias.name for alias in node.names]
+                elif isinstance(node, ast.ImportFrom) and node.module:
+                    names = [node.module]
+                else:
+                    continue
+                if any(
+                    module == "ifcopenshell" or module.startswith("ifcopenshell.")
+                    for module in names
+                ):
+                    violations.append(f"{path.name}:{node.lineno}")
+        self.assertEqual(violations, [])
 
     def test_missing_package_is_unavailable(self):
         with patch.object(
@@ -43,6 +116,27 @@ class TestIfcOpenShellBackend(unittest.TestCase):
         self.assertIn("ModuleNotFoundError", status.error)
         with self.assertRaises(backend.IfcOpenShellUnavailable):
             backend.get_backend()
+
+    def test_read_does_not_require_geometry_or_export_apis(self):
+        modules = _modules(serialized=False)
+        read_modules = {name: modules[name] for name in backend.READ_MODULES}
+        with patch.object(backend.importlib, "import_module", side_effect=read_modules.__getitem__):
+            status = backend.get_status(capability=backend.READ)
+            loaded = backend.get_backend(capability=backend.READ)
+
+        self.assertTrue(status.available)
+        self.assertFalse(status.geometry_iterator)
+        self.assertIs(loaded, modules["ifcopenshell"])
+
+    def test_read_requires_file_opening_api(self):
+        modules = _modules()
+        del modules["ifcopenshell"].open
+        read_modules = {name: modules[name] for name in backend.READ_MODULES}
+        with patch.object(backend.importlib, "import_module", side_effect=read_modules.__getitem__):
+            status = backend.get_status(capability=backend.READ)
+
+        self.assertFalse(status.available)
+        self.assertIn("ifcopenshell.open", status.error)
 
     def test_partial_installation_is_unavailable(self):
         modules = _modules()
@@ -87,6 +181,89 @@ class TestIfcOpenShellBackend(unittest.TestCase):
 
         self.assertFalse(status.available)
         self.assertIn("ifcopenshell.geom.iterator", status.error)
+
+    def test_import_does_not_require_export_apis(self):
+        modules = _modules()
+        import_modules = {name: modules[name] for name in backend.IMPORT_MODULES}
+        with patch.object(
+            backend.importlib, "import_module", side_effect=import_modules.__getitem__
+        ):
+            status = backend.get_status(capability=backend.IMPORT)
+            loaded = backend.get_backend(capability=backend.IMPORT)
+            geom = backend.get_module("ifcopenshell.geom", capability=backend.IMPORT)
+
+        self.assertTrue(status.available)
+        self.assertIs(loaded, modules["ifcopenshell"])
+        self.assertIs(geom, modules["ifcopenshell.geom"])
+
+    def test_import_requires_geometry_creation_api(self):
+        modules = _modules()
+        del modules["ifcopenshell.geom"].create_shape
+        import_modules = {name: modules[name] for name in backend.IMPORT_MODULES}
+        with patch.object(
+            backend.importlib, "import_module", side_effect=import_modules.__getitem__
+        ):
+            status = backend.get_status(capability=backend.IMPORT)
+
+        self.assertFalse(status.available)
+        self.assertIn("ifcopenshell.geom.create_shape", status.error)
+
+    def test_import_requires_serialized_geometry_output(self):
+        modules = _modules(serialized=False)
+        import_modules = {name: modules[name] for name in backend.IMPORT_MODULES}
+        with patch.object(
+            backend.importlib, "import_module", side_effect=import_modules.__getitem__
+        ):
+            status = backend.get_status(capability=backend.IMPORT)
+
+        self.assertFalse(status.available)
+        self.assertIn("serialized geometry output", status.error)
+
+    def test_multicore_import_does_not_require_export_apis(self):
+        modules = _modules()
+        import_modules = {name: modules[name] for name in backend.IMPORT_MODULES}
+        with patch.object(
+            backend.importlib, "import_module", side_effect=import_modules.__getitem__
+        ):
+            status = backend.get_status(capability=backend.MULTICORE_IMPORT)
+            geom = backend.get_module("ifcopenshell.geom", capability=backend.MULTICORE_IMPORT)
+
+        self.assertTrue(status.available)
+        self.assertIs(geom, modules["ifcopenshell.geom"])
+
+    def test_multicore_import_requires_geometry_iterator(self):
+        modules = _modules(iterator=False)
+        import_modules = {name: modules[name] for name in backend.IMPORT_MODULES}
+        with patch.object(
+            backend.importlib, "import_module", side_effect=import_modules.__getitem__
+        ):
+            status = backend.get_status(capability=backend.MULTICORE_IMPORT)
+
+        self.assertFalse(status.available)
+        self.assertIn("ifcopenshell.geom.iterator", status.error)
+
+    def test_explorer_does_not_require_serialized_or_export_apis(self):
+        modules = _modules(serialized=False)
+        explorer_modules = {name: modules[name] for name in backend.EXPLORER_MODULES}
+        with patch.object(
+            backend.importlib, "import_module", side_effect=explorer_modules.__getitem__
+        ):
+            status = backend.get_status(capability=backend.EXPLORER)
+
+        self.assertTrue(status.available)
+        self.assertFalse(status.serialized_brep)
+
+    def test_explorer_requires_entity_instance_type(self):
+        modules = _modules()
+        del modules["ifcopenshell.entity_instance"].entity_instance
+        explorer_modules = {name: modules[name] for name in backend.EXPLORER_MODULES}
+        with patch.object(
+            backend.importlib, "import_module", side_effect=explorer_modules.__getitem__
+        ):
+            status = backend.get_status(capability=backend.EXPLORER)
+
+        self.assertFalse(status.available)
+        self.assertIn("ifcopenshell.entity_instance.entity_instance", status.error)
 
     def test_refresh_revalidates_after_environment_change(self):
         modules = _modules()

--- a/src/Mod/BIM/bimtests/TestIfcOpenShellBackend.py
+++ b/src/Mod/BIM/bimtests/TestIfcOpenShellBackend.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Hermetic tests for the IfcOpenShell runtime boundary."""
+
+from types import ModuleType, SimpleNamespace
+import unittest
+from unittest.mock import patch
+
+from nativeifc import backend
+
+
+def _modules(*, serialized=True, iterator=True, version="0.8.5"):
+    root = ModuleType("ifcopenshell")
+    root.version = version
+    root.open = lambda _filename: None
+    root.file = lambda *args, **kwargs: None
+    wrapper_values = {"schema_names": lambda: ("IFC2X3", "IFC4")}
+    if serialized:
+        wrapper_values["SERIALIZED"] = object()
+    root.ifcopenshell_wrapper = SimpleNamespace(**wrapper_values)
+
+    result = {name: ModuleType(name) for name in backend.REQUIRED_MODULES}
+    result["ifcopenshell"] = root
+    result["ifcopenshell.api"].run = lambda *args, **kwargs: None
+    if iterator:
+        result["ifcopenshell.geom"].iterator = lambda *args, **kwargs: None
+    return result
+
+
+class TestIfcOpenShellBackend(unittest.TestCase):
+    def tearDown(self):
+        backend.invalidate()
+
+    def test_missing_package_is_unavailable(self):
+        with patch.object(
+            backend.importlib,
+            "import_module",
+            side_effect=ModuleNotFoundError("No module named 'ifcopenshell'"),
+        ):
+            status = backend.get_status()
+
+        self.assertFalse(status.available)
+        self.assertIn("ModuleNotFoundError", status.error)
+        with self.assertRaises(backend.IfcOpenShellUnavailable):
+            backend.get_backend()
+
+    def test_partial_installation_is_unavailable(self):
+        modules = _modules()
+
+        def load(name):
+            if name == "ifcopenshell.geom":
+                raise ImportError("native geometry wrapper failed to load")
+            return modules[name]
+
+        with patch.object(backend.importlib, "import_module", side_effect=load):
+            status = backend.get_status()
+
+        self.assertFalse(status.available)
+        self.assertIn("native geometry wrapper failed", status.error)
+
+    def test_reports_validated_capabilities(self):
+        modules = _modules()
+        with patch.object(backend.importlib, "import_module", side_effect=modules.__getitem__):
+            status = backend.get_status()
+            loaded = backend.get_backend()
+
+        self.assertTrue(status.available)
+        self.assertEqual(status.version, "0.8.5")
+        self.assertTrue(status.geometry_iterator)
+        self.assertTrue(status.serialized_brep)
+        self.assertTrue(status.schema_names)
+        self.assertIs(loaded, modules["ifcopenshell"])
+
+    def test_optional_capabilities_are_not_assumed(self):
+        modules = _modules(serialized=False)
+        with patch.object(backend.importlib, "import_module", side_effect=modules.__getitem__):
+            status = backend.get_status()
+
+        self.assertTrue(status.available)
+        self.assertTrue(status.geometry_iterator)
+        self.assertFalse(status.serialized_brep)
+
+    def test_missing_required_api_is_unavailable(self):
+        modules = _modules(iterator=False)
+        with patch.object(backend.importlib, "import_module", side_effect=modules.__getitem__):
+            status = backend.get_status()
+
+        self.assertFalse(status.available)
+        self.assertIn("ifcopenshell.geom.iterator", status.error)
+
+    def test_refresh_revalidates_after_environment_change(self):
+        modules = _modules()
+        attempts = iter(
+            (
+                ModuleNotFoundError("not installed"),
+                *(modules[name] for name in backend.REQUIRED_MODULES),
+            )
+        )
+
+        def load(_name):
+            value = next(attempts)
+            if isinstance(value, Exception):
+                raise value
+            return value
+
+        with patch.object(backend.importlib, "import_module", side_effect=load):
+            self.assertFalse(backend.get_status().available)
+            self.assertTrue(backend.get_status(refresh=True).available)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/BIM/bimtests/TestIfcStructuralExport.py
+++ b/src/Mod/BIM/bimtests/TestIfcStructuralExport.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Tests for structural IFC GUID generation through the runtime backend."""
+
+import ast
+from pathlib import Path
+import unittest
+from unittest.mock import Mock, patch
+
+from importers import exportIFCStructuralTools
+from nativeifc import backend
+
+
+class TestIfcStructuralExport(unittest.TestCase):
+    def tearDown(self):
+        backend.invalidate()
+
+    def test_structural_entities_receive_unique_guids_in_supported_schemas(self):
+        status = backend.get_status(capability=backend.GUID)
+        if not status.available:
+            self.skipTest(f"IfcOpenShell GUID generation is unavailable: {status.error}")
+        ifcopenshell = backend.get_backend(capability=backend.GUID)
+
+        identifiers = set()
+        for schema in ("IFC2X3", "IFC4"):
+            model = ifcopenshell.file(schema=schema)
+            identifier = backend.new_guid()
+            entity = model.create_entity(
+                "IfcStructuralPointConnection",
+                GlobalId=identifier,
+            )
+            self.assertEqual(entity.GlobalId, identifier)
+            self.assertEqual(len(identifier), 22)
+            identifiers.add(identifier)
+
+        self.assertEqual(len(identifiers), 2)
+
+    def test_structural_relationship_uses_backend_guid(self):
+        ifcfile = Mock()
+        owner_history = object()
+        ifcfile.by_type.return_value = [owner_history]
+        aobj = object()
+        sobj = object()
+
+        with patch.object(backend, "new_guid", return_value="structural-guid"):
+            exportIFCStructuralTools.associates(ifcfile, aobj, sobj)
+
+        ifcfile.createIfcRelAssignsToProduct.assert_called_once_with(
+            "structural-guid", owner_history, None, None, [sobj], None, aobj
+        )
+
+    def test_structural_tools_have_no_direct_ifcopenshell_imports(self):
+        path = Path(exportIFCStructuralTools.__file__).resolve()
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        violations = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                names = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                names = [node.module]
+            else:
+                continue
+            if any(name == "ifcopenshell" or name.startswith("ifcopenshell.") for name in names):
+                violations.append(node.lineno)
+        self.assertEqual(violations, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/BIM/importers/exportIFC.py
+++ b/src/Mod/BIM/importers/exportIFC.py
@@ -59,6 +59,7 @@ from draftutils.messages import _msg, _err
 from importers import exportIFCHelper
 from importers import exportIFCStructuralTools
 from importers.importIFCHelper import dd2dms
+from nativeifc import backend
 
 PARAMS = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/BIM")
 
@@ -168,7 +169,7 @@ def _prepare_export_list_skipping_std_groups(initial_export_list, preferences_di
 def getPreferences():
     """Retrieve the IFC preferences available in import and export."""
 
-    import ifcopenshell
+    ifcopenshell = backend.get_backend(capability=backend.EXPORT)
 
     ifcunit = params.get_param_arch("ifcUnit")
 
@@ -258,16 +259,14 @@ def export(exportList, filename, colors=None, preferences=None):
     """
     try:
         global ifcopenshell
-        import ifcopenshell
-    except ModuleNotFoundError:
+        ifcopenshell = backend.get_backend(capability=backend.EXPORT)
+    except backend.IfcOpenShellUnavailable as exc:
         _err(
-            "IfcOpenShell was not found on this system. "
-            "IFC support is disabled.\n"
+            f"IfcOpenShell is unavailable or cannot export IFC files: {exc}\n"
             "Visit https://wiki.freecad.org/IfcOpenShell "
             "to learn about installing it."
         )
         return
-    from ifcopenshell import guid
 
     if str(filename).lower().endswith("json"):
         import json
@@ -761,7 +760,7 @@ def export(exportList, filename, colors=None, preferences=None):
             else:
                 aname = "Assembly"
             ifcfile.createIfcRelAggregates(
-                ifcopenshell.guid.new(), history, aname, "", products[obj.Name], assemblyElements
+                backend.new_guid(), history, aname, "", products[obj.Name], assemblyElements
             )
             if preferences["DEBUG"]:
                 print("      aggregating", len(assemblyElements), "object(s)")
@@ -777,11 +776,11 @@ def export(exportList, filename, colors=None, preferences=None):
                     print("      adding ", c2, " : ", o.Label)
                 l = o.Label
                 prod2 = ifcfile.createIfcBuildingElementProxy(
-                    ifcopenshell.guid.new(), history, l, None, None, p2, r2, None, "ELEMENT"
+                    backend.new_guid(), history, l, None, None, p2, r2, None, "ELEMENT"
                 )
                 subproducts[o.Name] = prod2
                 ifcfile.createIfcRelAggregates(
-                    ifcopenshell.guid.new(), history, "Addition", "", product, [prod2]
+                    backend.new_guid(), history, "Addition", "", product, [prod2]
                 )
 
         # subtractions
@@ -802,11 +801,11 @@ def export(exportList, filename, colors=None, preferences=None):
                     print("      subtracting ", c2, " : ", o.Label)
                 l = o.Label
                 prod2 = ifcfile.createIfcOpeningElement(
-                    ifcopenshell.guid.new(), history, l, None, None, p2, r2, None
+                    backend.new_guid(), history, l, None, None, p2, r2, None
                 )
                 subproducts[o.Name] = prod2
                 ifcfile.createIfcRelVoidsElement(
-                    ifcopenshell.guid.new(), history, "Subtraction", "", product, prod2
+                    backend.new_guid(), history, "Subtraction", "", product, prod2
                 )
 
         # properties
@@ -833,10 +832,10 @@ def export(exportList, filename, colors=None, preferences=None):
                         psets.setdefault(pset, []).append(p)
                     for pname, props in psets.items():
                         pset = ifcfile.createIfcPropertySet(
-                            ifcopenshell.guid.new(), history, pname, None, props
+                            backend.new_guid(), history, pname, None, props
                         )
                         ifcfile.createIfcRelDefinesByProperties(
-                            ifcopenshell.guid.new(), history, None, None, [product], pset
+                            backend.new_guid(), history, None, None, [product], pset
                         )
 
                 elif obj.IfcProperties.TypeId == "Spreadsheet::Sheet":
@@ -906,10 +905,10 @@ def export(exportList, filename, colors=None, preferences=None):
                                 print("Unable to create a property of type:", tp)
                         if props:
                             pset = ifcfile.createIfcPropertySet(
-                                ifcopenshell.guid.new(), history, cat, None, props
+                                backend.new_guid(), history, cat, None, props
                             )
                             ifcfile.createIfcRelDefinesByProperties(
-                                ifcopenshell.guid.new(), history, None, None, [product], pset
+                                backend.new_guid(), history, None, None, [product], pset
                             )
 
         if hasattr(obj, "IfcData"):
@@ -966,10 +965,10 @@ def export(exportList, filename, colors=None, preferences=None):
                         props.append(ifcbin.createIfcPropertySingleValue(str(key), str(tp), val))
                 if props:
                     pset = ifcfile.createIfcPropertySet(
-                        ifcopenshell.guid.new(), history, "PropertySet", None, props
+                        backend.new_guid(), history, "PropertySet", None, props
                     )
                     ifcfile.createIfcRelDefinesByProperties(
-                        ifcopenshell.guid.new(), history, None, None, [product], pset
+                        backend.new_guid(), history, None, None, [product], pset
                     )
 
         if not ifcprop:
@@ -1085,17 +1084,17 @@ def export(exportList, filename, colors=None, preferences=None):
                                     )
             if FreeCADProps:
                 pset = ifcfile.createIfcPropertySet(
-                    ifcopenshell.guid.new(), history, "FreeCADPropertySet", None, FreeCADProps
+                    backend.new_guid(), history, "FreeCADPropertySet", None, FreeCADProps
                 )
                 ifcfile.createIfcRelDefinesByProperties(
-                    ifcopenshell.guid.new(), history, None, None, [product], pset
+                    backend.new_guid(), history, None, None, [product], pset
                 )
             if FreeCADGuiProps:
                 pset = ifcfile.createIfcPropertySet(
-                    ifcopenshell.guid.new(), history, "FreeCADGuiPropertySet", None, FreeCADGuiProps
+                    backend.new_guid(), history, "FreeCADGuiPropertySet", None, FreeCADGuiProps
                 )
                 ifcfile.createIfcRelDefinesByProperties(
-                    ifcopenshell.guid.new(), history, None, None, [product], pset
+                    backend.new_guid(), history, None, None, [product], pset
                 )
 
         # Classifications
@@ -1118,7 +1117,7 @@ def export(exportList, filename, colors=None, preferences=None):
                 rel.RelatedObjects = rel.RelatedObjects + [product]
             else:
                 rel = ifcfile.createIfcRelAssociatesClassification(
-                    ifcopenshell.guid.new(),
+                    backend.new_guid(),
                     history,
                     "FreeCADClassificationRel",
                     None,
@@ -1154,7 +1153,7 @@ def export(exportList, filename, colors=None, preferences=None):
                         treated.append(c.Name)
                 if subs:
                     ifcfile.createIfcRelAggregates(
-                        ifcopenshell.guid.new(), history, "Assembly", "", products[bp.Name], subs
+                        backend.new_guid(), history, "Assembly", "", products[bp.Name], subs
                     )
 
     # storeys
@@ -1185,11 +1184,11 @@ def export(exportList, filename, colors=None, preferences=None):
                     treated.append(c.Name)
             if buildingelements:
                 ifcfile.createIfcRelContainedInSpatialStructure(
-                    ifcopenshell.guid.new(), history, "StoreyLink", "", buildingelements, f
+                    backend.new_guid(), history, "StoreyLink", "", buildingelements, f
                 )
             if spaces:
                 ifcfile.createIfcRelAggregates(
-                    ifcopenshell.guid.new(), history, "StoreyLink", "", f, spaces
+                    backend.new_guid(), history, "StoreyLink", "", f, spaces
                 )
 
     # buildings
@@ -1221,11 +1220,11 @@ def export(exportList, filename, colors=None, preferences=None):
                         treated.append(c.Name)
             if children:
                 ifcfile.createIfcRelContainedInSpatialStructure(
-                    ifcopenshell.guid.new(), history, "BuildingLink", "", children, b
+                    backend.new_guid(), history, "BuildingLink", "", children, b
                 )
             if childfloors:
                 ifcfile.createIfcRelAggregates(
-                    ifcopenshell.guid.new(), history, "BuildingLink", "", b, childfloors
+                    backend.new_guid(), history, "BuildingLink", "", b, childfloors
                 )
 
     # sites
@@ -1253,7 +1252,7 @@ def export(exportList, filename, colors=None, preferences=None):
                 print("No site found. Adding default site")
             sites = [
                 ifcfile.createIfcSite(
-                    ifcopenshell.guid.new(),
+                    backend.new_guid(),
                     history,
                     "Default Site",
                     "",
@@ -1271,7 +1270,7 @@ def export(exportList, filename, colors=None, preferences=None):
             ]
     if sites:
         ifcfile.createIfcRelAggregates(
-            ifcopenshell.guid.new(), history, "ProjectLink", "", project, sites
+            backend.new_guid(), history, "ProjectLink", "", project, sites
         )
     if not buildings:
         if preferences["ADD_DEFAULT_BUILDING"] and not existing_file:
@@ -1279,7 +1278,7 @@ def export(exportList, filename, colors=None, preferences=None):
                 print("No building found. Adding default building")
             buildings = [
                 ifcfile.createIfcBuilding(
-                    ifcopenshell.guid.new(),
+                    backend.new_guid(),
                     history,
                     "Default Building",
                     "",
@@ -1295,15 +1294,15 @@ def export(exportList, filename, colors=None, preferences=None):
             ]
     if buildings and (not sites):
         ifcfile.createIfcRelAggregates(
-            ifcopenshell.guid.new(), history, "ProjectLink", "", project, buildings
+            backend.new_guid(), history, "ProjectLink", "", project, buildings
         )
     if floors and buildings:
         ifcfile.createIfcRelAggregates(
-            ifcopenshell.guid.new(), history, "BuildingLink", "", buildings[0], floors
+            backend.new_guid(), history, "BuildingLink", "", buildings[0], floors
         )
     if sites and buildings:
         ifcfile.createIfcRelAggregates(
-            ifcopenshell.guid.new(), history, "SiteLink", "", sites[0], buildings
+            backend.new_guid(), history, "SiteLink", "", sites[0], buildings
         )
 
     # treat objects that are not related to any site, building or storey
@@ -1330,7 +1329,7 @@ def export(exportList, filename, colors=None, preferences=None):
                 if preferences["DEBUG"]:
                     print("No floor found. Adding default floor")
                 defaulthost = ifcfile.createIfcBuildingStorey(
-                    ifcopenshell.guid.new(),
+                    backend.new_guid(),
                     history,
                     "Default Storey",
                     "",
@@ -1348,7 +1347,7 @@ def export(exportList, filename, colors=None, preferences=None):
                         print("No building found. Adding default building")
                     buildings = [
                         ifcfile.createIfcBuilding(
-                            ifcopenshell.guid.new(),
+                            backend.new_guid(),
                             history,
                             "Default Building",
                             "",
@@ -1364,14 +1363,14 @@ def export(exportList, filename, colors=None, preferences=None):
                     ]
                     if sites:
                         ifcfile.createIfcRelAggregates(
-                            ifcopenshell.guid.new(), history, "SiteLink", "", sites[0], buildings
+                            backend.new_guid(), history, "SiteLink", "", sites[0], buildings
                         )
                     else:
                         ifcfile.createIfcRelAggregates(
-                            ifcopenshell.guid.new(), history, "ProjectLink", "", project, buildings
+                            backend.new_guid(), history, "ProjectLink", "", project, buildings
                         )
                 ifcfile.createIfcRelAggregates(
-                    ifcopenshell.guid.new(),
+                    backend.new_guid(),
                     history,
                     "DefaultStoreyLink",
                     "",
@@ -1389,7 +1388,7 @@ def export(exportList, filename, colors=None, preferences=None):
                     buildingelements.append(entity)
             if spaces:
                 ifcfile.createIfcRelAggregates(
-                    ifcopenshell.guid.new(),
+                    backend.new_guid(),
                     history,
                     "UnassignedObjectsLink",
                     "",
@@ -1398,7 +1397,7 @@ def export(exportList, filename, colors=None, preferences=None):
                 )
             if buildingelements:
                 ifcfile.createIfcRelContainedInSpatialStructure(
-                    ifcopenshell.guid.new(),
+                    backend.new_guid(),
                     history,
                     "UnassignedObjectsLink",
                     "",
@@ -1412,7 +1411,7 @@ def export(exportList, filename, colors=None, preferences=None):
                     "WARNING - Default building generation is disabled. You are producing a non-standard file."
                 )
             ifcfile.createIfcRelAggregates(
-                ifcopenshell.guid.new(), history, "ProjectLink", "", project, untreated
+                backend.new_guid(), history, "ProjectLink", "", project, untreated
             )
 
     # materials
@@ -1454,7 +1453,7 @@ def export(exportList, filename, colors=None, preferences=None):
                 isr = ifcfile.createIfcStyledRepresentation(context, "Style", "Material", [isi])
                 imd = ifcfile.createIfcMaterialDefinitionRepresentation(None, None, [isr], mat)
             ifcfile.createIfcRelAssociatesMaterial(
-                ifcopenshell.guid.new(), history, "MaterialLink", "", relobjs, mat
+                backend.new_guid(), history, "MaterialLink", "", relobjs, mat
             )
 
     # 2D objects
@@ -1508,11 +1507,11 @@ def export(exportList, filename, colors=None, preferences=None):
                     swallowed.append(annos[o])
             if children:
                 name = FreeCAD.ActiveDocument.getObject(g[0]).Label
-                grp = ifcfile.createIfcGroup(ifcopenshell.guid.new(), history, name, "", None)
+                grp = ifcfile.createIfcGroup(backend.new_guid(), history, name, "", None)
                 products[g[0]] = grp
                 spatialelements[g[0]] = grp
                 ass = ifcfile.createIfcRelAssignsToGroup(
-                    ifcopenshell.guid.new(), history, "GroupLink", "", children, None, grp
+                    backend.new_guid(), history, "GroupLink", "", children, None, grp
                 )
 
     # stack groups inside containers
@@ -1526,7 +1525,7 @@ def export(exportList, filename, colors=None, preferences=None):
                     stack.setdefault(parent.Name, []).append(spatialelements[g[0]])
     for k, v in stack.items():
         ifcfile.createIfcRelAggregates(
-            ifcopenshell.guid.new(), history, "GroupStackLink", "", spatialelements[k], v
+            backend.new_guid(), history, "GroupStackLink", "", spatialelements[k], v
         )
 
     # add remaining 2D objects to default host
@@ -1539,7 +1538,7 @@ def export(exportList, filename, colors=None, preferences=None):
                     if preferences["DEBUG"]:
                         print("No floor found. Adding default floor")
                     defaulthost = ifcfile.createIfcBuildingStorey(
-                        ifcopenshell.guid.new(),
+                        backend.new_guid(),
                         history,
                         "Default Storey",
                         "",
@@ -1556,7 +1555,7 @@ def export(exportList, filename, colors=None, preferences=None):
                     if not buildings:
                         buildings = [
                             ifcfile.createIfcBuilding(
-                                ifcopenshell.guid.new(),
+                                backend.new_guid(),
                                 history,
                                 "Default Building",
                                 "",
@@ -1572,7 +1571,7 @@ def export(exportList, filename, colors=None, preferences=None):
                         ]
                         if sites:
                             ifcfile.createIfcRelAggregates(
-                                ifcopenshell.guid.new(),
+                                backend.new_guid(),
                                 history,
                                 "SiteLink",
                                 "",
@@ -1581,7 +1580,7 @@ def export(exportList, filename, colors=None, preferences=None):
                             )
                         else:
                             ifcfile.createIfcRelAggregates(
-                                ifcopenshell.guid.new(),
+                                backend.new_guid(),
                                 history,
                                 "ProjectLink",
                                 "",
@@ -1589,7 +1588,7 @@ def export(exportList, filename, colors=None, preferences=None):
                                 buildings,
                             )
                     ifcfile.createIfcRelAggregates(
-                        ifcopenshell.guid.new(),
+                        backend.new_guid(),
                         history,
                         "DefaultStoreyLink",
                         "",
@@ -1599,7 +1598,7 @@ def export(exportList, filename, colors=None, preferences=None):
                 elif preferences["ADD_DEFAULT_BUILDING"]:
                     if not buildings:
                         defaulthost = ifcfile.createIfcBuilding(
-                            ifcopenshell.guid.new(),
+                            backend.new_guid(),
                             history,
                             "Default Building",
                             "",
@@ -1614,7 +1613,7 @@ def export(exportList, filename, colors=None, preferences=None):
                         )
                         if sites:
                             ifcfile.createIfcRelAggregates(
-                                ifcopenshell.guid.new(),
+                                backend.new_guid(),
                                 history,
                                 "SiteLink",
                                 "",
@@ -1623,7 +1622,7 @@ def export(exportList, filename, colors=None, preferences=None):
                             )
                         else:
                             ifcfile.createIfcRelAggregates(
-                                ifcopenshell.guid.new(),
+                                backend.new_guid(),
                                 history,
                                 "ProjectLink",
                                 "",
@@ -1632,11 +1631,11 @@ def export(exportList, filename, colors=None, preferences=None):
                             )
             if defaulthost:
                 ifcfile.createIfcRelContainedInSpatialStructure(
-                    ifcopenshell.guid.new(), history, "AnnotationsLink", "", remaining, defaulthost
+                    backend.new_guid(), history, "AnnotationsLink", "", remaining, defaulthost
                 )
             else:
                 ifcfile.createIfcRelAggregates(
-                    ifcopenshell.guid.new(), history, "ProjectLink", "", project, remaining
+                    backend.new_guid(), history, "ProjectLink", "", project, remaining
                 )
 
     if not existing_file:
@@ -2295,7 +2294,9 @@ def getRepresentation(
 
                     # new ifcopenshell serializer
 
-                    from ifcopenshell import geom
+                    geom = getattr(ifcopenshell, "geom", None)
+                    if geom is None:
+                        geom = backend.get_module("ifcopenshell.geom", capability=backend.EXPORT)
 
                     serialized = False
                     if (
@@ -2607,7 +2608,7 @@ def getUID(obj, preferences):
                 # this UID  has already been used in another object
                 uid = None
     if not uid:
-        uid = ifcopenshell.guid.new()
+        uid = backend.new_guid()
         # storing the uid for further use
         if preferences["STORE_UID"]:
             if hasattr(obj, "IfcData"):
@@ -2866,6 +2867,6 @@ def create_annotation(anno, ifcfile, context, history, preferences):
     label = anno.Label
     description = getattr(anno, "Description", "")
     ann = ifcfile.createIfcAnnotation(
-        ifcopenshell.guid.new(), history, label, description, objectType, placement, rep
+        backend.new_guid(), history, label, description, objectType, placement, rep
     )
     return ann

--- a/src/Mod/BIM/importers/exportIFCHelper.py
+++ b/src/Mod/BIM/importers/exportIFCHelper.py
@@ -25,10 +25,8 @@
 import json
 import math
 
-import ifcopenshell
-from ifcopenshell import guid
-
 import FreeCAD
+from nativeifc import backend
 
 # import Draft
 
@@ -121,10 +119,10 @@ def writeQuantities(ifcfile, obj, product, history, scale, ifctype=None):
             )
         if quantities:
             eltq = ifcfile.createIfcElementQuantity(
-                ifcopenshell.guid.new(), history, "ElementQuantities", None, "FreeCAD", quantities
+                backend.new_guid(), history, "ElementQuantities", None, "FreeCAD", quantities
             )
             ifcfile.createIfcRelDefinesByProperties(
-                ifcopenshell.guid.new(), history, None, None, [product], eltq
+                backend.new_guid(), history, None, None, [product], eltq
             )
 
 
@@ -302,7 +300,7 @@ class ContextCreator:
     def getProjectGUID(self):
         # TODO: Do not generate a new one each time, but at least this one
         # conforms to the community consensus on how a GUID is generated.
-        return ifcopenshell.guid.new()
+        return backend.new_guid()
 
     def getProjectObject(self):
         try:

--- a/src/Mod/BIM/importers/exportIFCStructuralTools.py
+++ b/src/Mod/BIM/importers/exportIFCStructuralTools.py
@@ -22,6 +22,7 @@
 # *                                                                         *
 # ***************************************************************************
 
+from nativeifc import backend
 
 __title__ = "FreeCAD structural IFC export tools"
 __author__ = "Yorik van Havre"
@@ -40,9 +41,7 @@ def setup(ifcfile, ifcbin, scale):
     global structural_nodes, scaling
     structural_nodes = {}
     scaling = scale
-    import ifcopenshell
-
-    uid = ifcopenshell.guid.new
+    uid = backend.new_guid
     ownerHistory = ifcfile.by_type("IfcOwnerHistory")[0]
     project = ifcfile.by_type("IfcProject")[0]
     structContext = createStructuralContext(ifcfile)
@@ -100,9 +99,7 @@ def getStructuralContext(ifcfile):
 def createStructuralNode(ifcfile, ifcbin, point):
     """Creates a connection node at the given point"""
 
-    import ifcopenshell
-
-    uid = ifcopenshell.guid.new
+    uid = backend.new_guid
     ownerHistory = ifcfile.by_type("IfcOwnerHistory")[0]
     structContext = getStructuralContext(ifcfile)
     cartPoint = ifcbin.createIfcCartesianPoint(tuple(point))
@@ -147,9 +144,7 @@ def createStructuralNode(ifcfile, ifcbin, point):
 def createStructuralCurve(ifcfile, ifcbin, curve):
     """Creates a structural connection for a curve"""
 
-    import ifcopenshell
-
-    uid = ifcopenshell.guid.new
+    uid = backend.new_guid
     ownerHistory = ifcfile.by_type("IfcOwnerHistory")[0]
     structContext = getStructuralContext(ifcfile)
 
@@ -191,10 +186,9 @@ def createStructuralMember(ifcfile, ifcbin, obj):
     structuralMember = None
     import Draft
     import Part
-    import ifcopenshell
     import FreeCAD
 
-    uid = ifcopenshell.guid.new
+    uid = backend.new_guid
     ownerHistory = ifcfile.by_type("IfcOwnerHistory")[0]
     structContext = getStructuralContext(ifcfile)
 
@@ -412,9 +406,7 @@ def createStructuralMember(ifcfile, ifcbin, obj):
 def createStructuralGroup(ifcfile):
     """Assigns all structural objects found in the file to the structural model"""
 
-    import ifcopenshell
-
-    uid = ifcopenshell.guid.new
+    uid = backend.new_guid
     ownerHistory = ifcfile.by_type("IfcOwnerHistory")[0]
     structSrfMember = ifcfile.by_type("IfcStructuralSurfaceMember")
     structCrvMember = ifcfile.by_type("IfcStructuralCurveMember")
@@ -435,8 +427,6 @@ def associates(ifcfile, aobj, sobj):
     # This is probably not the right way to do this, ie. relate a structural
     # object with an IfcProduct. Needs to investigate more....
 
-    import ifcopenshell
-
-    uid = ifcopenshell.guid.new
+    uid = backend.new_guid
     ownerHistory = ifcfile.by_type("IfcOwnerHistory")[0]
     ifcfile.createIfcRelAssignsToProduct(uid(), ownerHistory, None, None, [sobj], None, aobj)

--- a/src/Mod/BIM/importers/importIFC.py
+++ b/src/Mod/BIM/importers/importIFC.py
@@ -53,12 +53,14 @@ from draftutils.messages import _msg, _err
 
 from importers import importIFCHelper
 from importers import importIFCmulticore
+from nativeifc import backend
 
 if FreeCAD.GuiUp:
     import FreeCADGui as Gui
 
 DEBUG = False  # Set to True to see debug messages. Otherwise, totally silent
 ZOOMOUT = True  # Set to False to not zoom extents after import
+
 
 # Templates and other definitions ****
 # which IFC type must create which FreeCAD type
@@ -161,20 +163,11 @@ def insert(srcfile, docname, skip=[], only=[], root=None, preferences=None):
         for example, `'ifcProduct'
     """
     try:
-        import ifcopenshell
-        from ifcopenshell import geom
-
-        # Sometimes there is an error importing `geom` in this way
-        # import ifcopenshell.geom
-        #
-        # therefore we must use the `from x import y` way.
-        #
-        # For some reason this works; see the bug report
-        # https://github.com/IfcOpenShell/IfcOpenShell/issues/689
-    except ModuleNotFoundError:
+        ifcopenshell = backend.get_backend(capability=backend.IMPORT)
+        geom = backend.get_module("ifcopenshell.geom", capability=backend.IMPORT)
+    except backend.IfcOpenShellUnavailable as exc:
         _err(
-            "IfcOpenShell was not found on this system. "
-            "IFC support is disabled.\n"
+            f"IfcOpenShell is unavailable or cannot import IFC geometry: {exc}\n"
             "Visit https://wiki.freecad.org/IfcOpenShell "
             "to learn about installing it."
         )
@@ -238,14 +231,11 @@ def insert(srcfile, docname, skip=[], only=[], root=None, preferences=None):
     #         ctx.Precision = ctx.Precision/100
 
     # Set default ifcopenshell options to work in brep mode
-    settings = geom.settings()
-    settings.set(settings.USE_BREP_DATA, True)
-    settings.set(settings.SEW_SHELLS, True)
-    settings.set(settings.USE_WORLD_COORDS, True)
-    if preferences["SEPARATE_OPENINGS"]:
-        settings.set(settings.DISABLE_OPENING_SUBTRACTIONS, True)
-    if preferences["SPLIT_LAYERS"] and hasattr(settings, "APPLY_LAYERSETS"):
-        settings.set(settings.APPLY_LAYERSETS, True)
+    settings = backend.create_geometry_settings(
+        backend.IMPORT,
+        disable_opening_subtractions=preferences["SEPARATE_OPENINGS"],
+        apply_layersets=preferences["SPLIT_LAYERS"],
+    )
 
     # build all needed tables
     if preferences["DEBUG"]:

--- a/src/Mod/BIM/importers/importIFCmulticore.py
+++ b/src/Mod/BIM/importers/importIFCmulticore.py
@@ -36,6 +36,7 @@ import Draft
 from FreeCAD import Base
 
 from importers import importIFCHelper
+from nativeifc import backend
 
 # global dicts to store ifc object/freecad object relationships
 
@@ -56,8 +57,14 @@ def open(filename):
 def insert(filename, docname=None, preferences=None):
     """imports the contents of an IFC file in the given document"""
 
-    import ifcopenshell
-    from ifcopenshell import geom
+    try:
+        ifcopenshell = backend.get_backend(capability=backend.MULTICORE_IMPORT)
+        geom = backend.get_module("ifcopenshell.geom", capability=backend.MULTICORE_IMPORT)
+    except backend.IfcOpenShellUnavailable as exc:
+        FreeCAD.Console.PrintError(
+            f"IfcOpenShell is unavailable or cannot iterate IFC geometry: {exc}\n"
+        )
+        return None
 
     # reset global values
     global layers
@@ -79,14 +86,11 @@ def insert(filename, docname=None, preferences=None):
     # setup ifcopenshell
     if not preferences:
         preferences = importIFCHelper.getPreferences()
-    settings = ifcopenshell.geom.settings()
-    settings.set(settings.USE_BREP_DATA, True)
-    settings.set(settings.SEW_SHELLS, True)
-    settings.set(settings.USE_WORLD_COORDS, True)
-    if preferences["SEPARATE_OPENINGS"]:
-        settings.set(settings.DISABLE_OPENING_SUBTRACTIONS, True)
-    if preferences["SPLIT_LAYERS"] and hasattr(settings, "APPLY_LAYERSETS"):
-        settings.set(settings.APPLY_LAYERSETS, True)
+    settings = backend.create_geometry_settings(
+        backend.MULTICORE_IMPORT,
+        disable_opening_subtractions=preferences["SEPARATE_OPENINGS"],
+        apply_layersets=preferences["SPLIT_LAYERS"],
+    )
 
     # setup document
     if not FreeCAD.ActiveDocument:
@@ -102,7 +106,7 @@ def insert(filename, docname=None, preferences=None):
     productscount = len(ifcfile.by_type("IfcProduct"))
     progressbar.start("Importing " + str(productscount) + " products...", productscount)
     cores = preferences["MULTICORE"]
-    iterator = ifcopenshell.geom.iterator(settings, ifcfile, cores)
+    iterator = geom.iterator(settings, ifcfile, cores)
     iterator.initialize()
     count = 0
 

--- a/src/Mod/BIM/nativeifc/__init__.py
+++ b/src/Mod/BIM/nativeifc/__init__.py
@@ -1,31 +1,30 @@
 """Shared NativeIFC availability helpers."""
 
-import importlib.util
-
 import FreeCAD
+
+from . import backend
 
 translate = FreeCAD.Qt.translate
 
-_ifcopenshell_state = {"available": None, "reported_missing": False}
+_ifcopenshell_state = {"reported_missing": False}
 
 
 def invalidate_ifcopenshell_cache():
     """Clears the cached ifcopenshell availability state."""
 
-    _ifcopenshell_state["available"] = None
+    backend.invalidate()
     _ifcopenshell_state["reported_missing"] = False
 
 
 def has_ifcopenshell(report=False):
     """Returns True when ifcopenshell is importable in this runtime."""
 
-    if _ifcopenshell_state["available"] is None:
-        _ifcopenshell_state["available"] = importlib.util.find_spec("ifcopenshell") is not None
+    available = backend.get_status().available
 
-    if report and not _ifcopenshell_state["available"]:
+    if report and not available:
         report_missing_ifcopenshell()
 
-    return _ifcopenshell_state["available"]
+    return available
 
 
 def report_missing_ifcopenshell():

--- a/src/Mod/BIM/nativeifc/__init__.py
+++ b/src/Mod/BIM/nativeifc/__init__.py
@@ -33,11 +33,12 @@ def report_missing_ifcopenshell():
     if _ifcopenshell_state["reported_missing"]:
         return
 
-    FreeCAD.Console.PrintError(
-        translate(
-            "BIM",
-            "IfcOpenShell was not found on this system. IFC support is disabled",
-        )
-        + "\n"
+    status = backend.get_status()
+    message = translate(
+        "BIM",
+        "IfcOpenShell is unavailable or does not provide the APIs required by FreeCAD",
     )
+    if status.error:
+        message += f": {status.error}"
+    FreeCAD.Console.PrintError(message + "\n")
     _ifcopenshell_state["reported_missing"] = True

--- a/src/Mod/BIM/nativeifc/backend.py
+++ b/src/Mod/BIM/nativeifc/backend.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""IfcOpenShell loading and capability detection for FreeCAD BIM.
+
+This module intentionally has no FreeCAD dependency. It is the runtime
+boundary between BIM code and the native IfcOpenShell Python package and can
+therefore be exercised in isolation, including when IfcOpenShell is absent.
+"""
+
+from dataclasses import dataclass
+import importlib
+from types import ModuleType
+
+REQUIRED_MODULES = (
+    "ifcopenshell",
+    "ifcopenshell.api",
+    "ifcopenshell.geom",
+    "ifcopenshell.entity_instance",
+    "ifcopenshell.util.attribute",
+    "ifcopenshell.util.element",
+    "ifcopenshell.util.placement",
+    "ifcopenshell.util.schema",
+    "ifcopenshell.util.unit",
+)
+
+
+class IfcOpenShellUnavailable(ImportError):
+    """Raised when FreeCAD's required IfcOpenShell surface cannot be loaded."""
+
+
+@dataclass(frozen=True)
+class BackendStatus:
+    """Result of validating the installed IfcOpenShell backend."""
+
+    available: bool
+    version: str = ""
+    geometry_iterator: bool = False
+    serialized_brep: bool = False
+    schema_names: bool = False
+    error: str = ""
+
+
+_module: ModuleType | None = None
+_status: BackendStatus | None = None
+
+
+def _version(module: ModuleType) -> str:
+    """Return a normalized display version across IfcOpenShell releases."""
+
+    return str(getattr(module, "version", getattr(module, "__version__", "")))
+
+
+def _load() -> tuple[ModuleType, BackendStatus]:
+    modules = {name: importlib.import_module(name) for name in REQUIRED_MODULES}
+    module = modules["ifcopenshell"]
+    geom = modules["ifcopenshell.geom"]
+    api = modules["ifcopenshell.api"]
+    wrapper = getattr(module, "ifcopenshell_wrapper", None)
+
+    required_callables = {
+        "ifcopenshell.open": getattr(module, "open", None),
+        "ifcopenshell.file": getattr(module, "file", None),
+        "ifcopenshell.api.run": getattr(api, "run", None),
+        "ifcopenshell.geom.iterator": getattr(geom, "iterator", None),
+    }
+    missing = [name for name, value in required_callables.items() if not callable(value)]
+    if missing:
+        raise IfcOpenShellUnavailable("missing required API: " + ", ".join(missing))
+
+    status = BackendStatus(
+        available=True,
+        version=_version(module),
+        geometry_iterator=True,
+        serialized_brep=wrapper is not None and hasattr(wrapper, "SERIALIZED"),
+        schema_names=wrapper is not None and callable(getattr(wrapper, "schema_names", None)),
+    )
+    return module, status
+
+
+def get_status(refresh: bool = False) -> BackendStatus:
+    """Validate and describe the backend without raising import errors."""
+
+    global _module, _status
+    if refresh:
+        invalidate()
+    if _status is None:
+        try:
+            _module, _status = _load()
+        except Exception as exc:
+            _module = None
+            _status = BackendStatus(
+                available=False,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+    return _status
+
+
+def get_backend(refresh: bool = False) -> ModuleType:
+    """Return a validated IfcOpenShell module or raise a stable exception."""
+
+    status = get_status(refresh=refresh)
+    if not status.available or _module is None:
+        detail = f" ({status.error})" if status.error else ""
+        raise IfcOpenShellUnavailable(f"IfcOpenShell is unavailable{detail}")
+    return _module
+
+
+def invalidate() -> None:
+    """Forget cached validation after the Python package environment changes."""
+
+    global _module, _status
+    _module = None
+    _status = None

--- a/src/Mod/BIM/nativeifc/backend.py
+++ b/src/Mod/BIM/nativeifc/backend.py
@@ -18,6 +18,7 @@ IMPORT_MODULES = (
 
 EXPLORER_MODULES = (*IMPORT_MODULES, "ifcopenshell.entity_instance")
 READ_MODULES = ("ifcopenshell",)
+GUID_MODULES = ("ifcopenshell", "ifcopenshell.guid")
 
 REQUIRED_MODULES = (
     "ifcopenshell",
@@ -41,11 +42,12 @@ REQUIRED_MODULES = (
 )
 
 READ = "read"
+GUID = "guid"
 IMPORT = "import"
 MULTICORE_IMPORT = "multicore_import"
 EXPLORER = "explorer"
 EXPORT = "export"
-_CAPABILITIES = (READ, IMPORT, MULTICORE_IMPORT, EXPLORER, EXPORT)
+_CAPABILITIES = (READ, GUID, IMPORT, MULTICORE_IMPORT, EXPLORER, EXPORT)
 
 
 class IfcOpenShellUnavailable(ImportError):
@@ -84,6 +86,8 @@ def _load(capability: str) -> tuple[dict[str, ModuleType], BackendStatus]:
         required_modules = EXPLORER_MODULES
     elif capability == READ:
         required_modules = READ_MODULES
+    elif capability == GUID:
+        required_modules = GUID_MODULES
     else:
         required_modules = IMPORT_MODULES
     modules = {name: importlib.import_module(name) for name in required_modules}
@@ -96,9 +100,13 @@ def _load(capability: str) -> tuple[dict[str, ModuleType], BackendStatus]:
         or hasattr(legacy_settings, "USE_BREP_DATA")
     )
 
-    required_callables = {
-        "ifcopenshell.open": getattr(module, "open", None),
-    }
+    required_callables = {}
+    if capability == GUID:
+        required_callables["ifcopenshell.guid.new"] = getattr(
+            modules["ifcopenshell.guid"], "new", None
+        )
+    else:
+        required_callables["ifcopenshell.open"] = getattr(module, "open", None)
     if capability in (IMPORT, MULTICORE_IMPORT, EXPLORER):
         required_callables.update(
             {
@@ -227,6 +235,13 @@ def get_module(name: str, capability: str = EXPORT) -> ModuleType:
         return _modules[capability][name]
     except KeyError as exc:
         raise ValueError(f"module {name!r} is not part of the {capability!r} capability") from exc
+
+
+def new_guid() -> str:
+    """Return a compressed IFC globally unique identifier."""
+
+    guid = get_module("ifcopenshell.guid", capability=GUID)
+    return guid.new()
 
 
 def create_geometry_settings(

--- a/src/Mod/BIM/nativeifc/backend.py
+++ b/src/Mod/BIM/nativeifc/backend.py
@@ -11,9 +11,26 @@ from dataclasses import dataclass
 import importlib
 from types import ModuleType
 
+IMPORT_MODULES = (
+    "ifcopenshell",
+    "ifcopenshell.geom",
+)
+
+EXPLORER_MODULES = (*IMPORT_MODULES, "ifcopenshell.entity_instance")
+READ_MODULES = ("ifcopenshell",)
+
 REQUIRED_MODULES = (
     "ifcopenshell",
     "ifcopenshell.api",
+    "ifcopenshell.api.aggregate",
+    "ifcopenshell.api.feature",
+    "ifcopenshell.api.geometry",
+    "ifcopenshell.api.group",
+    "ifcopenshell.api.material",
+    "ifcopenshell.api.pset",
+    "ifcopenshell.api.spatial",
+    "ifcopenshell.api.style",
+    "ifcopenshell.api.type",
     "ifcopenshell.geom",
     "ifcopenshell.entity_instance",
     "ifcopenshell.util.attribute",
@@ -22,6 +39,13 @@ REQUIRED_MODULES = (
     "ifcopenshell.util.schema",
     "ifcopenshell.util.unit",
 )
+
+READ = "read"
+IMPORT = "import"
+MULTICORE_IMPORT = "multicore_import"
+EXPLORER = "explorer"
+EXPORT = "export"
+_CAPABILITIES = (READ, IMPORT, MULTICORE_IMPORT, EXPLORER, EXPORT)
 
 
 class IfcOpenShellUnavailable(ImportError):
@@ -40,8 +64,8 @@ class BackendStatus:
     error: str = ""
 
 
-_module: ModuleType | None = None
-_status: BackendStatus | None = None
+_modules: dict[str, dict[str, ModuleType]] = {}
+_statuses: dict[str, BackendStatus] = {}
 
 
 def _version(module: ModuleType) -> str:
@@ -50,64 +74,215 @@ def _version(module: ModuleType) -> str:
     return str(getattr(module, "version", getattr(module, "__version__", "")))
 
 
-def _load() -> tuple[ModuleType, BackendStatus]:
-    modules = {name: importlib.import_module(name) for name in REQUIRED_MODULES}
+def _load(capability: str) -> tuple[dict[str, ModuleType], BackendStatus]:
+    if capability not in _CAPABILITIES:
+        raise ValueError(f"unknown IfcOpenShell capability: {capability}")
+
+    if capability == EXPORT:
+        required_modules = REQUIRED_MODULES
+    elif capability == EXPLORER:
+        required_modules = EXPLORER_MODULES
+    elif capability == READ:
+        required_modules = READ_MODULES
+    else:
+        required_modules = IMPORT_MODULES
+    modules = {name: importlib.import_module(name) for name in required_modules}
     module = modules["ifcopenshell"]
-    geom = modules["ifcopenshell.geom"]
-    api = modules["ifcopenshell.api"]
+    geom = modules.get("ifcopenshell.geom")
     wrapper = getattr(module, "ifcopenshell_wrapper", None)
+    legacy_settings = getattr(geom, "settings", lambda: None)() if geom else None
+    serialized_brep = geom is not None and (
+        (wrapper is not None and hasattr(wrapper, "SERIALIZED"))
+        or hasattr(legacy_settings, "USE_BREP_DATA")
+    )
 
     required_callables = {
         "ifcopenshell.open": getattr(module, "open", None),
-        "ifcopenshell.file": getattr(module, "file", None),
-        "ifcopenshell.api.run": getattr(api, "run", None),
-        "ifcopenshell.geom.iterator": getattr(geom, "iterator", None),
     }
+    if capability in (IMPORT, MULTICORE_IMPORT, EXPLORER):
+        required_callables.update(
+            {
+                "ifcopenshell.geom.settings": getattr(geom, "settings", None),
+            }
+        )
+        if capability in (IMPORT, EXPLORER):
+            required_callables["ifcopenshell.geom.create_shape"] = getattr(
+                geom, "create_shape", None
+            )
+        if capability == MULTICORE_IMPORT:
+            required_callables["ifcopenshell.geom.iterator"] = getattr(geom, "iterator", None)
+        if capability == EXPLORER:
+            entity_module = modules["ifcopenshell.entity_instance"]
+            if not isinstance(getattr(entity_module, "entity_instance", None), type):
+                raise IfcOpenShellUnavailable(
+                    "missing required API: ifcopenshell.entity_instance.entity_instance"
+                )
+    elif capability == EXPORT:
+        api = modules["ifcopenshell.api"]
+        api_aggregate = modules["ifcopenshell.api.aggregate"]
+        api_feature = modules["ifcopenshell.api.feature"]
+        api_geometry = modules["ifcopenshell.api.geometry"]
+        api_group = modules["ifcopenshell.api.group"]
+        api_material = modules["ifcopenshell.api.material"]
+        api_pset = modules["ifcopenshell.api.pset"]
+        api_spatial = modules["ifcopenshell.api.spatial"]
+        api_style = modules["ifcopenshell.api.style"]
+        api_type = modules["ifcopenshell.api.type"]
+        required_callables.update(
+            {
+                "ifcopenshell.file": getattr(module, "file", None),
+                "ifcopenshell.api.run": getattr(api, "run", None),
+                "ifcopenshell.api.aggregate.assign_object": getattr(
+                    api_aggregate, "assign_object", None
+                ),
+                "ifcopenshell.api.feature.add_feature": getattr(api_feature, "add_feature", None),
+                "ifcopenshell.api.feature.add_filling": getattr(api_feature, "add_filling", None),
+                "ifcopenshell.api.geometry.add_wall_representation": getattr(
+                    api_geometry, "add_wall_representation", None
+                ),
+                "ifcopenshell.api.geometry.add_profile_representation": getattr(
+                    api_geometry, "add_profile_representation", None
+                ),
+                "ifcopenshell.api.group.add_group": getattr(api_group, "add_group", None),
+                "ifcopenshell.api.group.assign_group": getattr(api_group, "assign_group", None),
+                "ifcopenshell.api.material.add_material": getattr(
+                    api_material, "add_material", None
+                ),
+                "ifcopenshell.api.material.add_material_set": getattr(
+                    api_material, "add_material_set", None
+                ),
+                "ifcopenshell.api.material.add_layer": getattr(api_material, "add_layer", None),
+                "ifcopenshell.api.material.edit_layer": getattr(api_material, "edit_layer", None),
+                "ifcopenshell.api.material.add_profile": getattr(api_material, "add_profile", None),
+                "ifcopenshell.api.material.assign_material": getattr(
+                    api_material, "assign_material", None
+                ),
+                "ifcopenshell.api.pset.add_pset": getattr(api_pset, "add_pset", None),
+                "ifcopenshell.api.pset.edit_pset": getattr(api_pset, "edit_pset", None),
+                "ifcopenshell.api.pset.add_qto": getattr(api_pset, "add_qto", None),
+                "ifcopenshell.api.pset.edit_qto": getattr(api_pset, "edit_qto", None),
+                "ifcopenshell.api.spatial.assign_container": getattr(
+                    api_spatial, "assign_container", None
+                ),
+                "ifcopenshell.api.style.add_style": getattr(api_style, "add_style", None),
+                "ifcopenshell.api.style.add_surface_style": getattr(
+                    api_style, "add_surface_style", None
+                ),
+                "ifcopenshell.api.style.assign_item_style": getattr(
+                    api_style, "assign_item_style", None
+                ),
+                "ifcopenshell.api.type.assign_type": getattr(api_type, "assign_type", None),
+                "ifcopenshell.geom.iterator": getattr(geom, "iterator", None),
+            }
+        )
     missing = [name for name, value in required_callables.items() if not callable(value)]
+    if capability in (IMPORT, MULTICORE_IMPORT) and not serialized_brep:
+        missing.append("serialized geometry output")
     if missing:
         raise IfcOpenShellUnavailable("missing required API: " + ", ".join(missing))
 
     status = BackendStatus(
         available=True,
         version=_version(module),
-        geometry_iterator=True,
-        serialized_brep=wrapper is not None and hasattr(wrapper, "SERIALIZED"),
+        geometry_iterator=callable(getattr(geom, "iterator", None)) if geom else False,
+        serialized_brep=serialized_brep,
         schema_names=wrapper is not None and callable(getattr(wrapper, "schema_names", None)),
     )
-    return module, status
+    return modules, status
 
 
-def get_status(refresh: bool = False) -> BackendStatus:
+def get_status(refresh: bool = False, capability: str = EXPORT) -> BackendStatus:
     """Validate and describe the backend without raising import errors."""
 
-    global _module, _status
     if refresh:
         invalidate()
-    if _status is None:
+    if capability not in _statuses:
         try:
-            _module, _status = _load()
+            _modules[capability], _statuses[capability] = _load(capability)
         except Exception as exc:
-            _module = None
-            _status = BackendStatus(
+            _modules.pop(capability, None)
+            _statuses[capability] = BackendStatus(
                 available=False,
                 error=f"{type(exc).__name__}: {exc}",
             )
-    return _status
+    return _statuses[capability]
 
 
-def get_backend(refresh: bool = False) -> ModuleType:
+def get_backend(refresh: bool = False, capability: str = EXPORT) -> ModuleType:
     """Return a validated IfcOpenShell module or raise a stable exception."""
 
-    status = get_status(refresh=refresh)
-    if not status.available or _module is None:
+    status = get_status(refresh=refresh, capability=capability)
+    modules = _modules.get(capability)
+    if not status.available or modules is None:
         detail = f" ({status.error})" if status.error else ""
         raise IfcOpenShellUnavailable(f"IfcOpenShell is unavailable{detail}")
-    return _module
+    return modules["ifcopenshell"]
+
+
+def get_module(name: str, capability: str = EXPORT) -> ModuleType:
+    """Return a validated submodule belonging to a capability profile."""
+
+    get_backend(capability=capability)
+    try:
+        return _modules[capability][name]
+    except KeyError as exc:
+        raise ValueError(f"module {name!r} is not part of the {capability!r} capability") from exc
+
+
+def create_geometry_settings(
+    capability: str,
+    *,
+    disable_opening_subtractions: bool = False,
+    apply_layersets: bool = False,
+):
+    """Create serialized BRep settings across old and current IfcOpenShell APIs."""
+
+    module = get_backend(capability=capability)
+    geom = get_module("ifcopenshell.geom", capability=capability)
+    settings = geom.settings()
+
+    if hasattr(settings, "USE_BREP_DATA"):
+        settings.set(settings.USE_BREP_DATA, True)
+        if hasattr(settings, "SEW_SHELLS"):
+            settings.set(settings.SEW_SHELLS, True)
+    else:
+        settings.set("iterator-output", module.ifcopenshell_wrapper.SERIALIZED)
+
+    _set_geometry_setting(settings, "use-world-coords", True, "USE_WORLD_COORDS")
+    if disable_opening_subtractions:
+        _set_geometry_setting(
+            settings,
+            "disable-opening-subtractions",
+            True,
+            "DISABLE_OPENING_SUBTRACTIONS",
+        )
+    if apply_layersets:
+        if hasattr(settings, "APPLY_LAYERSETS"):
+            settings.set(settings.APPLY_LAYERSETS, True)
+        elif "enable-layerset-slicing" in settings.setting_names():
+            settings.set("enable-layerset-slicing", True)
+    return settings
+
+
+def create_mesh_settings():
+    """Create world-coordinate triangulation settings for IFC previews."""
+
+    geom = get_module("ifcopenshell.geom", capability=EXPLORER)
+    settings = geom.settings()
+    _set_geometry_setting(settings, "use-world-coords", True, "USE_WORLD_COORDS")
+    return settings
+
+
+def _set_geometry_setting(settings, name, value, legacy_name):
+    if hasattr(settings, legacy_name):
+        settings.set(getattr(settings, legacy_name), value)
+    else:
+        settings.set(name, value)
 
 
 def invalidate() -> None:
     """Forget cached validation after the Python package environment changes."""
 
-    global _module, _status
-    _module = None
-    _status = None
+    importlib.invalidate_caches()
+    _modules.clear()
+    _statuses.clear()

--- a/src/Mod/BIM/nativeifc/ifc_diff.py
+++ b/src/Mod/BIM/nativeifc/ifc_diff.py
@@ -26,13 +26,14 @@
 
 import difflib
 
-import ifcopenshell
-
 import FreeCAD
 import FreeCADGui
 import Arch_rc
 
+from . import backend
 from . import ifc_tools
+
+ifcopenshell = backend.get_backend()
 
 translate = FreeCAD.Qt.translate
 

--- a/src/Mod/BIM/nativeifc/ifc_export.py
+++ b/src/Mod/BIM/nativeifc/ifc_export.py
@@ -24,8 +24,6 @@
 
 import tempfile
 
-import ifcopenshell
-
 import FreeCAD
 import Draft
 
@@ -33,12 +31,14 @@ from importers import exportIFC
 from importers import exportIFCHelper
 from importers import importIFCHelper
 
+from . import backend
 from . import ifc_import
 from . import ifc_layers
 from . import ifc_materials
 from . import ifc_psets
 from . import ifc_tools
 
+ifcopenshell = backend.get_backend()
 PARAMS = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/NativeIFC")
 
 

--- a/src/Mod/BIM/nativeifc/ifc_generator.py
+++ b/src/Mod/BIM/nativeifc/ifc_generator.py
@@ -29,8 +29,6 @@ used by the execute() method of ifc_objects"""
 import multiprocessing
 import re
 
-import ifcopenshell
-import ifcopenshell.util.element
 from pivy import coin
 from PySide import QtCore
 
@@ -40,8 +38,11 @@ import Part
 
 from FreeCAD import Base
 
+from . import backend
 from . import ifc_tools
 from . import ifc_export
+
+ifcopenshell = backend.get_backend()
 
 
 def generate_geometry(obj, cached=False):

--- a/src/Mod/BIM/nativeifc/ifc_geometry.py
+++ b/src/Mod/BIM/nativeifc/ifc_geometry.py
@@ -24,12 +24,12 @@
 
 """This module contains geometry editing and geometry properties-related tools"""
 
-import ifcopenshell
-import ifcopenshell.util.unit
-
 import FreeCAD
 
+from . import backend
 from . import ifc_tools
+
+ifcopenshell = backend.get_backend()
 
 
 def add_geom_properties(obj):

--- a/src/Mod/BIM/nativeifc/ifc_layers.py
+++ b/src/Mod/BIM/nativeifc/ifc_layers.py
@@ -24,10 +24,10 @@
 
 """This NativeIFC module deals with layers"""
 
-import ifcopenshell
-import ifcopenshell.util.element
-
+from . import backend
 from . import ifc_tools
+
+ifcopenshell = backend.get_backend()
 
 
 def load_layers(obj):

--- a/src/Mod/BIM/nativeifc/ifc_materials.py
+++ b/src/Mod/BIM/nativeifc/ifc_materials.py
@@ -24,12 +24,12 @@
 
 """This NativeIFC module deals with materials"""
 
-import ifcopenshell
-import ifcopenshell.util.element
-
 import FreeCAD
 
+from . import backend
 from . import ifc_tools
+
+ifcopenshell = backend.get_backend()
 
 
 def create_material(element, parent, recursive=False):

--- a/src/Mod/BIM/nativeifc/ifc_openshell.py
+++ b/src/Mod/BIM/nativeifc/ifc_openshell.py
@@ -29,6 +29,8 @@ from packaging.version import Version
 import FreeCAD
 import FreeCADGui
 from addonmanager_utilities import create_pip_call
+
+from . import backend
 from . import has_ifcopenshell
 from . import invalidate_ifcopenshell_cache
 
@@ -158,19 +160,17 @@ class IFC_UpdateIOS:
     def get_current_version(self):
         """Retrieves the current ifcopenshell version"""
 
-        import addonmanager_utilities as utils
         from packaging.version import InvalidVersion
 
-        try:
-            import ifcopenshell
-
-            version = ifcopenshell.version
+        status = backend.get_status()
+        if status.available:
+            version = status.version
             try:
                 Version(version)
             except InvalidVersion:
                 FreeCAD.Console.PrintWarning(f"Invalid IfcOpenShell version: {version}\n")
                 version = ""
-        except:
+        else:
             version = ""
 
         return version

--- a/src/Mod/BIM/nativeifc/ifc_selftest.py
+++ b/src/Mod/BIM/nativeifc/ifc_selftest.py
@@ -29,13 +29,11 @@ import os
 import tempfile
 import unittest
 
-import ifcopenshell
-from ifcopenshell.util import element
-
 import FreeCAD
 import Arch
 import Draft
 
+from . import backend
 from . import ifc_import
 from . import ifc_tools
 from . import ifc_export
@@ -46,6 +44,9 @@ from . import ifc_psets
 from . import ifc_objects
 from . import ifc_generator
 from . import ifc_types
+
+ifcopenshell = backend.get_backend()
+element = ifcopenshell.util.element
 
 IFC_FILE_PATH = None  # downloaded IFC file path
 FCSTD_FILE_PATH = None  # saved FreeCAD file

--- a/src/Mod/BIM/nativeifc/ifc_tools.py
+++ b/src/Mod/BIM/nativeifc/ifc_tools.py
@@ -32,6 +32,7 @@ import FreeCAD
 import Arch
 import ArchBuildingPart
 import Draft
+from . import backend
 from . import report_missing_ifcopenshell
 
 from draftviewproviders import view_layer
@@ -41,15 +42,7 @@ translate = FreeCAD.Qt.translate
 # heavyweight libraries - ifc_tools should always be lazy loaded
 
 try:
-    import ifcopenshell
-    import ifcopenshell.api
-    import ifcopenshell.geom
-    import ifcopenshell.util.attribute
-    import ifcopenshell.util.element
-    import ifcopenshell.util.placement
-    import ifcopenshell.util.schema
-    import ifcopenshell.util.unit
-    import ifcopenshell.entity_instance
+    ifcopenshell = backend.get_backend()
 except ImportError:
     report_missing_ifcopenshell()
     raise

--- a/src/Mod/BIM/utils/ifctree.py
+++ b/src/Mod/BIM/utils/ifctree.py
@@ -37,9 +37,11 @@ my ryzen9 machine, for 2700 objects. Larger files like the King Arch file
 
 import time
 
-import ifcopenshell
-
 from PySide import QtWidgets
+
+from nativeifc import backend
+
+ifcopenshell = backend.get_backend(capability=backend.READ)
 
 
 class ViewProvider:


### PR DESCRIPTION
## Context

FreeCAD's IFC support has grown through several generations of code. Import, setup, exploration, NativeIFC, and the compatibility exporters imported different parts of IfcOpenShell directly and performed independent availability checks. A partial installation could therefore make unrelated features fail, and each consumer had to understand IfcOpenShell packaging and API details.

The traditional IFC path remains important: it converts between IFC entities and ordinary FreeCAD BIM objects and contains years of compatibility behavior. This change does not remove it. It gives both traditional and NativeIFC code one explicit integration boundary.

## What this changes

This PR introduces a FreeCAD-independent runtime backend with named capability profiles for reading, GUID generation, regular and multicore import, IFC Explorer, legacy export, and NativeIFC export. Each consumer requests only the capability it needs. Legacy export remains available without NativeIFC's high-level APIs. The backend caches validated modules, reports stable diagnostics, and can refresh discovery after runtime installation.

The primary consumers are migrated to that boundary, including:

- BIM setup and preflight;
- regular and multicore import;
- IFC Explorer and Arch references;
- classifications and NativeIFC utility modules;
- legacy and structural exporters;
- GUID generation and geometry serializer access.

This makes dependency behavior consistent without changing which IFC workflow users choose.

## Why this matters

IfcOpenShell evolves independently from FreeCAD, and its Python packages can expose only part of the API surface FreeCAD expects. Centralizing the contract reduces upgrade risk, gives users actionable failures, and allows lightweight features to work even when heavier geometry or export capabilities are unavailable.

This is also the foundation for later NativeIFC and Strict IFC work: those workflows need a reliable IfcOpenShell boundary, but do not need to be reviewed as part of establishing it.

### Validation

- Full debug build with Clang and ccache
- Backend capability and partial-installation tests
- Setup, explorer, reference, import, legacy-export, and structural-export tests, registered in the BIM test suites
- IFC2X3 and IFC4 legacy export with NativeIFC API imports blocked
- IfcOpenShell 0.8.5 runtime coverage

### Review notes

- The IFC4 fixture used by import and preview tests is included in this PR.
- The backend deliberately has no FreeCAD dependency, allowing hermetic tests of missing and partial installations.
- Existing IFC2X3, IFC4, legacy, and NativeIFC entry points remain available.

<!-- AUTOGEN:BEGIN -->
### Patch Set

> [!IMPORTANT]
> Part `1/3` of a stacked series. Depends on `main`; review and merge in order.

<!-- DEVSTACK:REVIEWSTACK {"version":2,"current":32520,"stack":[{"number":32537,"commits":["6969172d25b34506cb12846e1ff11ee07b69cf89"]},{"number":32536,"commits":["d9f8162e916b71ba8dab1079b60d3ff266f1fbe7"]},{"number":32520,"commits":["d50ced4271ee6b83ab47ab825e64df28b872fe8d","223f377a9fdf9bc11d2b55e3f97d75088af13123","51cd6706014a69bb95af6967b38815f2db31a402"]}]} -->

<!-- AUTOGEN:END -->
