### PR TITLE
fixes #32516 properly populate build type when set via cli using cmake

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -2760,11 +2760,14 @@ void Application::initConfig(int argc, char ** argv)
         Application::Config()["BuildRevision"      ] = FCRevision;
         Application::Config()["BuildRepositoryURL" ] = FCRepositoryURL;
         Application::Config()["BuildRevisionDate"  ] = FCRevisionDate;
-#if defined(FCRepositoryHash)
+#ifdef FCRepositoryHash
         Application::Config()["BuildRevisionHash"  ] = FCRepositoryHash;
 #endif
-#if defined(FCRepositoryBranch)
+#ifdef FCRepositoryBranch
         Application::Config()["BuildRevisionBranch"] = FCRepositoryBranch;
+#endif
+#ifdef CMAKE_BUILD_TYPE
+        Application::Config()["BuildType"          ] = CMAKE_BUILD_TYPE;
 #endif
     }
 

--- a/src/App/ProgramInformation.cpp
+++ b/src/App/ProgramInformation.cpp
@@ -249,15 +249,9 @@ void ProgramInformation::getBuildInformation(
     const auto buildDate = getValueOrEmpty(mConfig, "BuildRevisionDate");
     str << "Build date: " << buildDate << "\n";
 
-#if defined(_DEBUG) || defined(DEBUG)
-    str << "Build type: Debug\n";
-#elif defined(NDEBUG)
-    str << "Build type: Release\n";
-#elif defined(CMAKE_BUILD_TYPE)
-    str << "Build type: " << CMAKE_BUILD_TYPE << '\n';
-#else
-    str << "Build type: Unknown\n";
-#endif
+    const auto buildType = getValueOrEmpty(mConfig, "BuildType");
+    str << "Build type: " << (buildType.empty() ? "Unknown" : buildType) << '\n';
+
     const auto buildRevisionBranch = getValueOrEmpty(mConfig, "BuildRevisionBranch");
     if (!buildRevisionBranch.empty()) {
         str << "Branch: " << buildRevisionBranch << '\n';


### PR DESCRIPTION
this PR addresses the issue opened by me ie. #32516

with this PR merged, when a user clicks the `Copy to Clipboard` from the about dialogue box from the help menu. the correct build type will be printed ie.

```
OS: Fedora Linux Asahi Remix 44 (Forty Four) (xcb)
Architecture: arm64
Version: 26.3.0dev.48503 (Git)
Build date: 2026/09/08 16:53:58
Build type: RelWithDebInfo
Branch: main
Hash: 82c7a09b35127dfeb894b859640d97d9c259c68a
Python 3.13.15, Qt 6.11.1, Coin 4.0.10 (bundled), Pivy 0.6.11 (bundled), Vtk 9.5.2, boost 1_92, Eigen3 5.0.1, PySide 6.11.1
shiboken 6.11.1, SMESH 7.7.1.0, xerces-c 3.3.0, Clipper2 , IfcOpenShell 0.8.4.post1, OCC 7.9.3
Locale: English/United States (en_US)
Stylesheet/Theme/QtStyle: FreeCAD.qss/FreeCAD Light/
QPA/File dialog/Color dialog: xcb/non-native/non-native
Navigation Style/Orbit Style/Rotation Mode: Blender/Rounded Arcball/Window center
Logical DPI/Physical DPI/Pixel Ratio: 96/95.958/1
OpenGL version/vendor/renderer: 4.6 (Compatibility Profile) Mesa 26.2.1/Mesa/Apple M1 (G13G B1)
```

as seen above that thats the arg i defined via the cli, see below snippet.

```
-DCMAKE_BUILD_TYPE="RelWithDebInfo"
```

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by: claude opus v5

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->


## Issues

- https://github.com/FreeCAD/FreeCAD/issues/32516

## Before and After Images

see the formatted output pasted above.

