### PR TITLE
Expand licensing information of files with exceptions

### DIFF
--- a/data/examples/osifont.license
+++ b/data/examples/osifont.license
@@ -1,3 +1,5 @@
+SPDX-License-Identifier: GPL-2.0-only WITH Font-exception-2.0 OR GPL-3.0-only WITH Font-exception-2.0 OR LGPL-3.0-only WITH Font-exception-2.0
+
 osifont license:
 
 osifont-lgpl3fe.ttf is used under one or more of the following licenses:

--- a/src/App/Expression.tab.c
+++ b/src/App/Expression.tab.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: LGPL-2.1-or-later AND GPL-3.0-or-later WITH Bison-exception-2.2
 
 // clang-format off
 /* A Bison parser, made by GNU Bison 3.8.2.  */

--- a/src/App/Expression.tab.h
+++ b/src/App/Expression.tab.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: LGPL-2.1-or-later AND GPL-3.0-or-later WITH Bison-exception-2.2
 
 // clang-format off
 /* A Bison parser, made by GNU Bison 3.8.2.  */

--- a/src/Base/Parser.sh
+++ b/src/Base/Parser.sh
@@ -3,6 +3,6 @@
 (cd "$(dirname "$0")" && \
   flex -oQuantity.lex.c Quantity.l && \
   bison -oQuantity.tab.c Quantity.y && \
-  sed -i '1s|^|// SPDX-License-Identifier: LGPL-2.1-or-later\n\n// clang-format off\n|' Quantity.tab.c && \
+  sed -i '1s|^|// SPDX-License-Identifier: LGPL-2.1-or-later AND GPL-3.0-or-later WITH Bison-exception-2.2\n\n// clang-format off\n|' Quantity.tab.c && \
   sed -i '1s|^|// SPDX-License-Identifier: LGPL-2.1-or-later\n\n// clang-format off\n|' Quantity.lex.c \
 )

--- a/src/Base/Quantity.tab.c
+++ b/src/Base/Quantity.tab.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: LGPL-2.1-or-later AND GPL-3.0-or-later WITH Bison-exception-2.2
 
 // clang-format off
 /* A Bison parser, made by GNU Bison 3.8.2.  */

--- a/src/Gui/Dialogs/DlgCheckableMessageBox.cpp
+++ b/src/Gui/Dialogs/DlgCheckableMessageBox.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: LGPL-2.1-only
 
 /**************************************************************************
 **

--- a/src/Gui/Dialogs/DlgCheckableMessageBox.h
+++ b/src/Gui/Dialogs/DlgCheckableMessageBox.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: LGPL-2.1-only
 
 /**************************************************************************
 **

--- a/src/Gui/Quarter/QuarterWidget.cpp
+++ b/src/Gui/Quarter/QuarterWidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: BSD-3-Clause AND LGPL-2.1-or-later
 // SPDX-FileCopyrightText: Kongsberg Oil & Gas Technologies AS
 // SPDX-FileCopyrightText: 2026 Joao Matos
 // SPDX-FileNotice: Part of the FreeCAD project.

--- a/src/Gui/Selection/SelectionFilter.tab.c
+++ b/src/Gui/Selection/SelectionFilter.tab.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: LGPL-2.1-or-later AND GPL-3.0-or-later WITH Bison-exception-2.2
 /* A Bison parser, made by GNU Bison 2.4.2.  */
 
 /* Skeleton implementation for Bison's Yacc-like parsers in C

--- a/src/Mod/TechDraw/Gui/Resources/fonts/osifont.license
+++ b/src/Mod/TechDraw/Gui/Resources/fonts/osifont.license
@@ -1,3 +1,5 @@
+SPDX-License-Identifier: GPL-2.0-only WITH Font-exception-2.0 OR GPL-3.0-only WITH Font-exception-2.0 OR LGPL-3.0-only WITH Font-exception-2.0
+
 osifont license:
 
 osifont-lgpl3fe.ttf is used under one or more of the following licenses:


### PR DESCRIPTION
Expand and correct licensing metadata:
1) Add machine-readable SPDX font license information
2) Fully list all licenses in multi-license files
3) Correct `DlgCheckableMessageBox` to LGPL-2.1-only (it does not include the "or later" clause)

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
