### PR TITLE
CI: Update experimental builds to LibPack 3.5.5

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -306,14 +306,14 @@ jobs:
             runner: windows-2022
             cmakeArchitecture: ""
             makeInstaller: "true"
-            libpackDownloadUrl: https://github.com/FreeCAD/FreeCAD-LibPack/releases/download/3.5.3/LibPack-26.3.0-v3.5.3-x64-Release.7z
-            libpackName: LibPack-26.3.0-v3.5.3-x64-Release
+            libpackDownloadUrl: https://github.com/FreeCAD/FreeCAD-LibPack/releases/download/3.5.5/LibPack-26.3.0-v3.5.5-x64-Release.7z
+            libpackName: LibPack-26.3.0-v3.5.5-x64-Release
           - arch: arm64
             runner: windows-11-arm
             cmakeArchitecture: ARM64
             makeInstaller: "false"
-            libpackDownloadUrl: https://github.com/FreeCAD/FreeCAD-LibPack/releases/download/3.5.3/LibPack-26.3.0-v3.5.3-ARM64-Release.7z
-            libpackName: LibPack-26.3.0-v3.5.3-ARM64-Release
+            libpackDownloadUrl: https://github.com/FreeCAD/FreeCAD-LibPack/releases/download/3.5.5/LibPack-26.3.0-v3.5.5-ARM64-Release.7z
+            libpackName: LibPack-26.3.0-v3.5.5-ARM64-Release
     uses: ./.github/workflows/sub_releaseWindowsLibpack.yml
     with:
       build_tag: ${{ needs.upload_src.outputs.build_tag }}

--- a/.github/workflows/sub_releaseWindowsLibpack.yml
+++ b/.github/workflows/sub_releaseWindowsLibpack.yml
@@ -32,11 +32,11 @@ on:
       libpackDownloadUrl:
         required: false
         type: string
-        default: "https://github.com/FreeCAD/FreeCAD-LibPack/releases/download/3.5.3/LibPack-26.3.0-v3.5.3-x64-Release.7z"
+        default: "https://github.com/FreeCAD/FreeCAD-LibPack/releases/download/3.5.5/LibPack-26.3.0-v3.5.5-x64-Release.7z"
       libpackName:
         required: false
         type: string
-        default: "LibPack-26.3.0-v3.5.3-x64-Release"
+        default: "LibPack-26.3.0-v3.5.5-x64-Release"
       makeInstaller:
         description: "Whether to also build the NSIS installer (x64 only for now)"
         required: false


### PR DESCRIPTION
The most notable update here is from OCCT 8.0.0 to 8.0.1. This is expected to be the last LibPack release on Python 3.14 and Qt 6.11.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
