### PR TITLE
PartDesign: Use common color for common previews

### DIFF
--- a/src/Mod/PartDesign/App/FeatureAddSub.cpp
+++ b/src/Mod/PartDesign/App/FeatureAddSub.cpp
@@ -180,8 +180,7 @@ void FeatureAddSub::updatePreviewShape()
                            "removed or a problem with the model.")
                     );
                 }
-                // Common keeps the overlap, so its removed-volume preview is outside the tool.
-                PreviewShape.setValue(keepCommon ? cut : common);
+                PreviewShape.setValue(common);
                 return;
             }
             catch (Standard_Failure& e) {

--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -76,16 +76,43 @@ void ViewProvider::attach(App::DocumentObject* pcObject)
 {
     ViewProviderPart::attach(pcObject);
 
+    updatePreviewColor();
+}
+
+void ViewProvider::updatePreviewColor()
+{
+    auto* addSubFeature = getObject<PartDesign::FeatureAddSub>();
+    if (!addSubFeature) {
+        return;
+    }
+
     auto* styleParameterManager = Base::provideService<Gui::StyleParameters::ParameterManager>();
 
-    if (auto addSubFeature = getObject<PartDesign::FeatureAddSub>()) {
-        bool isAdditive = addSubFeature->getAddSubType() == PartDesign::FeatureAddSub::Type::Additive;
-
-        PreviewColor.setValue(
-            isAdditive ? styleParameterManager->resolve(StyleParameters::PreviewAdditiveColor)
-                       : styleParameterManager->resolve(StyleParameters::PreviewSubtractiveColor)
-        );
+    switch (addSubFeature->getBooleanOperation()) {
+        case PartDesign::FeatureAddSub::BooleanOperation::Subtraction:
+            PreviewColor.setValue(
+                styleParameterManager->resolve(StyleParameters::PreviewSubtractiveColor)
+            );
+            break;
+        case PartDesign::FeatureAddSub::BooleanOperation::Common:
+            PreviewColor.setValue(styleParameterManager->resolve(StyleParameters::PreviewCommonColor));
+            break;
+        case PartDesign::FeatureAddSub::BooleanOperation::Union:
+            PreviewColor.setValue(
+                styleParameterManager->resolve(StyleParameters::PreviewAdditiveColor)
+            );
+            break;
     }
+}
+
+void ViewProvider::updateData(const App::Property* prop)
+{
+    if (auto* addSubFeature = getObject<PartDesign::FeatureAddSub>();
+        addSubFeature && prop == &addSubFeature->Operation) {
+        updatePreviewColor();
+    }
+
+    ViewProviderPart::updateData(prop);
 }
 
 bool ViewProvider::doubleClicked()

--- a/src/Mod/PartDesign/Gui/ViewProvider.h
+++ b/src/Mod/PartDesign/Gui/ViewProvider.h
@@ -101,6 +101,7 @@ protected:
     void setupContextMenu(QMenu* menu, QObject* receiver, const char* member) override;
     bool setEdit(int ModNum) override;
     void unsetEdit(int ModNum) override;
+    void updateData(const App::Property* prop) override;
 
     void attachPreview() override;
     void updatePreview() override;
@@ -120,6 +121,8 @@ protected:
     bool isSetTipIcon {false};
 
 private:
+    void updatePreviewColor();
+
     Gui::CoinPtr<PartGui::SoPreviewShape> pcToolPreview;
 };
 


### PR DESCRIPTION
Recently, common mode was introduced to PD subtractive features.
The preview was red like the subtractive preview. PD boolean uses yellow as common color, this PR aligns it for common operation mode to be consistent.
They now use the existing yellow PreviewCommonColor and subtraction remains red.
Assisted-by: GPT-5.5-Terra

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!--
FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
Please check the following box:
-->

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

<!--
If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:

Assisted-by [Model-Family] ([Version/ID])

Examples:

Assisted-by: gemini-2.5-pro (rev-1)
Assisted-by: GPT-4o-2024-08-06

The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
-->
## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->


https://github.com/user-attachments/assets/f7588bed-e868-4289-9740-f21a7c27096c




<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
