### PR TITLE
[TD]Fix positioning of locked views on load

### DIFF
--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
@@ -257,16 +257,19 @@ void ViewProviderDrawingView::updateData(const App::Property* prop)
 
     App::PropertyLink* ownerProp = obj->getOwnerProperty();
 
+
     //only move the view on X, Y change
     if (prop == &obj->X ||
         prop == &obj->Y) {
-
-        if (qgiv->isSnapping() ||
-            obj->LockPosition.getValue()) {
+        // there was an attempt to prevent X/Y changes for Locked views here, but the
+        // property value has already been changed by this point.  Not moving the graphic
+        // will leave X,Y and scene position out of sync.  At load time, preventing
+        // repositioning of locked views will cause them to be loaded at (0,0).
+        if (qgiv->isSnapping()) {
+            // wait for snap movements to finish
             Gui::ViewProviderDocumentObject::updateData(prop);
             return;
         }
-
         qgiv->updatePositionFromFeatureXY();
 
         // Update also the owner/parent view, if there is any


### PR DESCRIPTION
This PR implements a fix for issue #30723.  When a document containing a view whose LockPostiion property is true, the view will be positioned at the (0,0) point
in the scene.  Unlocking the view, saving and reloading will sometimes correct the issue.

The problem is caused by a check in ViewProviderDrawingView that prevents applying the view's X&Y properties to the
view's scene position. 

From the changed ViewProviderDrawingView::updateData() code:
```
        // there was an attempt to prevent X/Y changes for Locked views here, but the
        // property value has already been changed by this point.  Not moving the graphic
        // will leave X,Y and scene position out of sync.  At load time, preventing
        // repositioning of locked views will cause them to be loaded at (0,0).

```
Result before fix:
<img width="1133" height="721" alt="WD-CA-8m_beforeFix" src="https://github.com/user-attachments/assets/d526ac87-d074-43c3-a63b-c815b2cd7367" />

Result after fix:
<img width="1246" height="753" alt="WD-CA-8M_lockedPositionFixed" src="https://github.com/user-attachments/assets/8b1f8c53-887c-4bfc-ab29-1a55f6b1e603" />


- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

File showing the issue:
[WD-CA-8m Ausleger.FCStd.not.zip](https://github.com/user-attachments/files/32019282/WD-CA-8m.Ausleger.FCStd.not.zip)
