### PR TITLE
fixes #32526 fix cmake to find py runtime deps and properly report finding ifcopenshell

### DIFF
--- a/cMake/FreeCadMacros.cmake
+++ b/cMake/FreeCadMacros.cmake
@@ -411,6 +411,9 @@ endmacro()
 
 # check that the python interpreter FreeCAD will use at runtime can actually
 # import a required module, and get its version.
+# NOTE: see the below link for why the python exe is used instead of
+# `find_pip_package(${PIP_NAME})`
+# https://github.com/FreeCAD/FreeCAD/pull/32554#pullrequestreview-5159207504
 macro(find_python_runtime_dep PIP_NAME IMPORT_NAME VERSION_VAR MISSING_MESSAGE)
     execute_process(
         COMMAND ${Python3_EXECUTABLE} -c

--- a/cMake/FreeCadMacros.cmake
+++ b/cMake/FreeCadMacros.cmake
@@ -414,7 +414,7 @@ endmacro()
 macro(find_python_runtime_dep PIP_NAME IMPORT_NAME VERSION_VAR MISSING_MESSAGE)
     execute_process(
         COMMAND ${Python3_EXECUTABLE} -c
-            "import ${IMPORT_NAME} as _m; print(getattr(_m, '__version__', '') or getattr(_m, 'version', 'unknown'), end='')"
+            "import ${IMPORT_NAME} as _m; print(getattr(_m, '__version__', 'unknown'), end='')"
         RESULT_VARIABLE _fc_import_failed
         OUTPUT_VARIABLE ${VERSION_VAR}
         ERROR_VARIABLE _fc_import_error)

--- a/cMake/FreeCadMacros.cmake
+++ b/cMake/FreeCadMacros.cmake
@@ -409,18 +409,25 @@ macro(find_pip_package PACKAGE)
 	endif()
 endmacro()
 
+# check that the python interpreter FreeCAD will use at runtime can actually
+# import a required module, and get its version.
 macro(find_python_runtime_dep PIP_NAME IMPORT_NAME VERSION_VAR MISSING_MESSAGE)
-    find_pip_package(${PIP_NAME})
-    if(${PIP_NAME}_FOUND)
-        execute_process(
-            COMMAND ${Python3_EXECUTABLE} -c "import ${IMPORT_NAME};print(${IMPORT_NAME}.__version__, end='')"
-            RESULT_VARIABLE FAILURE OUTPUT_VARIABLE ${VERSION_VAR})
-        if(FAILURE)
-            message(WARNING "Could not import ${IMPORT_NAME} Python package.")
-            set(${PIP_NAME}_FOUND OFF)
+    execute_process(
+        COMMAND ${Python3_EXECUTABLE} -c
+            "import ${IMPORT_NAME} as _m; print(getattr(_m, '__version__', '') or getattr(_m, 'version', 'unknown'), end='')"
+        RESULT_VARIABLE _fc_import_failed
+        OUTPUT_VARIABLE ${VERSION_VAR}
+        ERROR_VARIABLE _fc_import_error)
+    if(_fc_import_failed)
+        set(${PIP_NAME}_FOUND OFF)
+        unset(${VERSION_VAR})
+        message(WARNING "Could not import the ${IMPORT_NAME} Python package using ${Python3_EXECUTABLE}. ${MISSING_MESSAGE}")
+        if(_fc_import_error)
+            message(STATUSE " ${IMPORT_NAME} import error: ${_fc_import_error}")
         endif()
     else()
-        message(WARNING "Could not find ${PIP_NAME} Python package runtime dependency. ${MISSING_MESSAGE}")
+        set(${PIP_NAME}_FOUND ON)
+        message(STATUS "Found ${IMPORT_NAME}: version ${${VERSION_VAR}}")
     endif()
 endmacro()
 


### PR DESCRIPTION
this PR fixes a false positive where cmake was printing / outputting that it could not find the py runtime dep / module `ifcopenshell` as mentioned in the below linked issue. however it was reporting ifcopenshell not being found seems to be strictly a comestic error from what i can tell, as i rebuilt / installed freecad with and without this fix, and seemed to able to import and export `.ifc` files with and without this fix. i do think this fix is worth merging just for the fact that properly reports finding ifcopenshell. not sure if this will help others when distributing freecad distro packages.


- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

Assisted-by: claude opus 5

## Issues

- https://github.com/FreeCAD/FreeCAD/issues/32526