### PR TITLE
BIM: stop creating deprecated CutDistance property on Arch SectionPlane

### DIFF
--- a/src/Mod/BIM/ArchSectionPlane.py
+++ b/src/Mod/BIM/ArchSectionPlane.py
@@ -1222,14 +1222,6 @@ class _ViewProviderSectionPlane:
                 locked=True,
             )
             vobj.LineWidth = 1
-        if not "CutDistance" in pl:
-            vobj.addProperty(
-                "App::PropertyLength",
-                "CutDistance",
-                "SectionPlane",
-                QT_TRANSLATE_NOOP("App::Property", "Show the cut in the 3D view"),
-                locked=True,
-            )
         if not "LineColor" in pl:
             vobj.addProperty(
                 "App::PropertyColor",


### PR DESCRIPTION
Fixes #28909

Removes the creation of the deprecated `CutDistance` property in `ArchSectionPlane` (src/Mod/BIM/ArchSectionPlane.py). The property is deprecated per the [Arch SectionPlane wiki](https://wiki.freecad.org/Arch_SectionPlane#View) and does nothing; new section planes will no longer carry it. Existing documents that already have the property are untouched.

Verified with `python -m py_compile` on the modified file. A full local FreeCAD build is not feasible in this environment, so CI is expected to run the BIM workbench tests.