### PR TITLE
Build: Add node cap to MSBuild of experimental releases

### DIFF
--- a/.github/workflows/sub_releaseWindowsLibpack.yml
+++ b/.github/workflows/sub_releaseWindowsLibpack.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Compiling sources
         run: |
           cd $env:builddir
-          msbuild ALL_BUILD.vcxproj /m /p:Configuration=Release /p:TrackFileAccess=false
+          msbuild ALL_BUILD.vcxproj /m:3 /p:Configuration=Release /p:TrackFileAccess=false
 
       - name: Installing to staging tree
         run: |


### PR DESCRIPTION
This week's x86 experimental LibPack weekly [failed to build](https://github.com/FreeCAD/FreeCAD/actions/runs/34296562299/job/102296177480), probably due to memory exhaustion on the runner (though GitHub reports it as "lost communication with the server" instead of a build error). Cap the number of simultaneous nodes at 3 (instead of the 4 it was using): the build will be slower, but should succeed eventually.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.