### PR TITLE
CAM: Fix 3+2 Axis Transform Shape

### DIFF
--- a/src/Mod/CAM/Path/Op/Base.py
+++ b/src/Mod/CAM/Path/Op/Base.py
@@ -124,6 +124,10 @@ def _transform_shape_with_arc_fix(shape, matrix):
     Returns the (possibly fixed) transformed ``Part.Shape``.
     """
     transformed = shape.copy().transformShape(matrix, False, False)
+
+    if transformed.Faces:
+        return transformed
+
     fixed_edges = []
     any_converted = False
     for edge in transformed.Edges:


### PR DESCRIPTION

The transformshape_with_arc_fix(), beside the shape transformation, attempts to fix converted arcs for operations like Deburr (operations that work with edges).

The issue is that attempts to fix arcs for all operations, not only Deburr etc., and at the end returns a Compound of fixed Edges.

We call the same transformshape_with_arc_fix() for stock transformation also.

An easy fix is to check if the transformed shape has Faces and return just the transformed shape, without fixing anything.

I don't recall having operations that use Faces and Edges at the same time. If we have, we should find another solution.



