### PR TITLE
LinkArrays: add linear link arrays with persistent suppression

### DIFF
--- a/src/Mod/Part/App/AppPart.cpp
+++ b/src/Mod/Part/App/AppPart.cpp
@@ -99,6 +99,7 @@
 #include "LinearPatternExtension.h"
 #include "LinkArray.h"
 #include "LinkArrayCircular.h"
+#include "LinkArrayLinear.h"
 #include "PolarPatternExtension.h"
 #include "PathPatternExtension.h"
 #include "Geometry.h"
@@ -461,6 +462,7 @@ PyMOD_INIT_FUNC(Part)
     Part::PathPatternExtension  ::init();
     Part::LinkArray             ::init();
     Part::LinkArrayCircular     ::init();
+    Part::LinkArrayLinear       ::init();
 
     Part::Feature               ::init();
     Part::FeatureExt            ::init();

--- a/src/Mod/Part/App/CMakeLists.txt
+++ b/src/Mod/Part/App/CMakeLists.txt
@@ -221,6 +221,8 @@ SET(Features_SRCS
     LinkArray.h
     LinkArrayCircular.cpp
     LinkArrayCircular.h
+    LinkArrayLinear.cpp
+    LinkArrayLinear.h
     PolarPatternExtension.cpp
     PolarPatternExtension.h
     PathPatternExtension.cpp

--- a/src/Mod/Part/App/LinkArrayLinear.cpp
+++ b/src/Mod/Part/App/LinkArrayLinear.cpp
@@ -69,25 +69,23 @@ void LinkArrayLinear::connectElementSuppression()
         if (!elements[i]) {
             continue;
         }
-        suppressionConnections.emplace_back(
-            elements[i]->signalChanged.connect([this,
-                                                i](const App::DocumentObject& obj,
+        const auto handleElementChange = [this, i](const App::DocumentObject& obj,
                                                    const App::Property& prop) {
-                if (syncingSuppression || isRestoring()
-                    || (getDocument() && getDocument()->isPerformingTransaction())) {
-                    return;
-                }
-                const auto* suppressible = obj.getExtensionByType<App::SuppressibleExtension>(true);
-                if (!suppressible || &prop != &suppressible->Suppressed) {
-                    return;
-                }
-                const auto stride = static_cast<size_t>(std::max(1L, GeneratedOccurrences2.getValue()));
-                setPositionSuppressed(
-                    {static_cast<long>(i / stride), static_cast<long>(i % stride)},
-                    suppressible->Suppressed.getValue()
-                );
-            })
-        );
+            if (syncingSuppression || isRestoring()
+                || (getDocument() && getDocument()->isPerformingTransaction())) {
+                return;
+            }
+            const auto* suppressible = obj.getExtensionByType<App::SuppressibleExtension>(true);
+            if (!suppressible || &prop != &suppressible->Suppressed) {
+                return;
+            }
+            const auto stride = static_cast<size_t>(std::max(1L, GeneratedOccurrences2.getValue()));
+            setPositionSuppressed(
+                {static_cast<long>(i / stride), static_cast<long>(i % stride)},
+                suppressible->Suppressed.getValue()
+            );
+        };
+        suppressionConnections.emplace_back(elements[i]->signalChanged.connect(handleElementChange));
     }
 }
 
@@ -168,13 +166,11 @@ gp_Dir LinkArrayLinear::getDirectionFromProperty(const App::PropertyLinkSub& dir
 {
     const auto datumDirection = [](App::DocumentObject* obj) -> std::optional<gp_Dir> {
         if (auto* line = freecad_cast<App::Line*>(obj)) {
-            Base::Vector3d d = line->getDirection();
-            return Base::convertTo<gp_Dir>(d);
+            return Base::convertTo<gp_Dir>(line->getDirection());
         }
 
         if (auto* plane = freecad_cast<App::Plane*>(obj)) {
-            Base::Vector3d d = plane->getDirection();
-            return Base::convertTo<gp_Dir>(d);
+            return Base::convertTo<gp_Dir>(plane->getDirection());
         }
 
         return {};
@@ -236,15 +232,13 @@ gp_Dir LinkArrayLinear::getDirectionFromProperty(const App::PropertyLinkSub& dir
     if (role == App::LocalCoordinateSystem::AxisRoles[0]
         || role == App::LocalCoordinateSystem::AxisRoles[1]
         || role == App::LocalCoordinateSystem::AxisRoles[2]) {
-        Base::Vector3d d = lcs->getAxis(role.c_str())->getDirection();
-        return Base::convertTo<gp_Dir>(d);
+        return Base::convertTo<gp_Dir>(lcs->getAxis(role.c_str())->getDirection());
     }
 
     if (role == App::LocalCoordinateSystem::PlaneRoles[0]
         || role == App::LocalCoordinateSystem::PlaneRoles[1]
         || role == App::LocalCoordinateSystem::PlaneRoles[2]) {
-        Base::Vector3d d = lcs->getPlane(role.c_str())->getDirection();
-        return Base::convertTo<gp_Dir>(d);
+        return Base::convertTo<gp_Dir>(lcs->getPlane(role.c_str())->getDirection());
     }
 
     return LinearPatternExtension::getDirectionFromProperty(dirProp);

--- a/src/Mod/Part/App/LinkArrayLinear.cpp
+++ b/src/Mod/Part/App/LinkArrayLinear.cpp
@@ -69,8 +69,9 @@ void LinkArrayLinear::connectElementSuppression()
         if (!elements[i]) {
             continue;
         }
-        const auto handleElementChange = [this, i](const App::DocumentObject& obj,
-                                                   const App::Property& prop) {
+        const auto handleElementChange = [this,
+                                          i](const App::DocumentObject& obj,
+                                             const App::Property& prop) {
             if (syncingSuppression || isRestoring()
                 || (getDocument() && getDocument()->isPerformingTransaction())) {
                 return;

--- a/src/Mod/Part/App/LinkArrayLinear.cpp
+++ b/src/Mod/Part/App/LinkArrayLinear.cpp
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/****************************************************************************
+ *   Copyright (c) 2026 Boyer Pierre-Louis <pierrelouis.boyer@gmail.com>    *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include "LinkArrayLinear.h"
+
+#include <Mod/Part/App/Tools.h>
+
+#include <optional>
+#include <algorithm>
+
+#include <App/Document.h>
+#include <App/Datums.h>
+#include <App/PropertyLinks.h>
+#include <App/SuppressibleExtension.h>
+#include <Base/Tools.h>
+#include <Precision.hxx>
+#include <gp_Trsf.hxx>
+
+using namespace Part;
+
+PROPERTY_SOURCE_WITH_EXTENSIONS(Part::LinkArrayLinear, Part::LinkArray)
+
+LinkArrayLinear::LinkArrayLinear()
+{
+    Part::LinearPatternExtension::initExtension(this);
+    ADD_PROPERTY_TYPE(
+        GeneratedOccurrences2,
+        (0),
+        "Pattern",
+        static_cast<App::PropertyType>(App::Prop_Hidden | App::Prop_ReadOnly | App::Prop_Output),
+        "Second-direction occurrence count used to generate the current elements"
+    );
+    setDirectionLinkScopes();
+}
+
+App::DocumentObjectExecReturn* LinkArrayLinear::execute()
+{
+    Base::StateLocker guard(syncingSuppression);
+    auto* result = inherited::execute();
+    applyElementSuppression();
+    return result;
+}
+
+void LinkArrayLinear::connectElementSuppression()
+{
+    suppressionConnections.clear();
+    const auto& elements = ElementList.getValues();
+    for (size_t i = 0; i < elements.size(); ++i) {
+        if (!elements[i]) {
+            continue;
+        }
+        suppressionConnections.emplace_back(
+            elements[i]->signalChanged.connect([this,
+                                                i](const App::DocumentObject& obj,
+                                                   const App::Property& prop) {
+                if (syncingSuppression || isRestoring()
+                    || (getDocument() && getDocument()->isPerformingTransaction())) {
+                    return;
+                }
+                const auto* suppressible = obj.getExtensionByType<App::SuppressibleExtension>(true);
+                if (!suppressible || &prop != &suppressible->Suppressed) {
+                    return;
+                }
+                const auto stride = static_cast<size_t>(std::max(1L, GeneratedOccurrences2.getValue()));
+                setPositionSuppressed(
+                    {static_cast<long>(i / stride), static_cast<long>(i % stride)},
+                    suppressible->Suppressed.getValue()
+                );
+            })
+        );
+    }
+}
+
+void LinkArrayLinear::restoreElementSuppression()
+{
+    // Legacy files only store Suppressed on the generated links.
+    if (GeneratedOccurrences2.getValue() == 0) {
+        GeneratedOccurrences2.setValue(Occurrences2.getValue());
+        const auto& elements = ElementList.getValues();
+        for (size_t i = 0; i < elements.size(); ++i) {
+            const auto* suppressible = elements[i]
+                ? elements[i]->getExtensionByType<App::SuppressibleExtension>(true)
+                : nullptr;
+            if (suppressible && suppressible->Suppressed.getValue()) {
+                setInstanceSuppressed(static_cast<long>(i), true);
+            }
+        }
+    }
+    connectElementSuppression();
+}
+
+void LinkArrayLinear::applyElementSuppression()
+{
+    Base::StateLocker guard(syncingSuppression);
+    const auto& positions = SuppressedPositions.getValues();
+    const auto& elements = ElementList.getValues();
+    const auto stride = static_cast<size_t>(std::max(1L, GeneratedOccurrences2.getValue()));
+    for (size_t i = 0; i < elements.size(); ++i) {
+        auto* suppressible = elements[i]
+            ? elements[i]->getExtensionByType<App::SuppressibleExtension>(true)
+            : nullptr;
+        if (!suppressible) {
+            continue;
+        }
+        const App::PropertyIntPairList::IntPair position {
+            static_cast<long>(i / stride),
+            static_cast<long>(i % stride)
+        };
+        const bool suppressed = std::ranges::find(positions, position) != positions.end();
+        if (suppressible->Suppressed.getValue() != suppressed) {
+            suppressible->Suppressed.setValue(suppressed);
+        }
+    }
+}
+
+void LinkArrayLinear::onChanged(const App::Property* prop)
+{
+    inherited::onChanged(prop);
+    if (isRestoring()) {
+        return;
+    }
+    if (prop == &ElementList) {
+        connectElementSuppression();
+    }
+    else if (
+        prop == &SuppressedPositions && !syncingSuppression
+        && !(getDocument() && getDocument()->isPerformingTransaction())
+    ) {
+        applyElementSuppression();
+    }
+}
+
+void LinkArrayLinear::onDocumentRestored()
+{
+    inherited::onDocumentRestored();
+    setDirectionLinkScopes();
+    Base::StateLocker guard(syncingSuppression);
+    restoreElementSuppression();
+}
+
+void LinkArrayLinear::setDirectionLinkScopes()
+{
+    Direction.setScope(App::LinkScope::Global);
+    Direction2.setScope(App::LinkScope::Global);
+}
+
+gp_Dir LinkArrayLinear::getDirectionFromProperty(const App::PropertyLinkSub& dirProp) const
+{
+    const auto datumDirection = [](App::DocumentObject* obj) -> std::optional<gp_Dir> {
+        if (auto* line = freecad_cast<App::Line*>(obj)) {
+            Base::Vector3d d = line->getDirection();
+            return Base::convertTo<gp_Dir>(d);
+        }
+
+        if (auto* plane = freecad_cast<App::Plane*>(obj)) {
+            Base::Vector3d d = plane->getDirection();
+            return Base::convertTo<gp_Dir>(d);
+        }
+
+        return {};
+    };
+
+    auto* refObject = dirProp.getValue();
+    auto* lcs = freecad_cast<App::LocalCoordinateSystem*>(refObject);
+
+    std::vector<std::string> subStrings = dirProp.getSubValues();
+    if (!lcs && !subStrings.empty() && !subStrings.front().empty()) {
+        std::string sub = subStrings.front();
+        if (sub.back() != '.') {
+            sub += '.';
+        }
+
+        App::DocumentObject* resolved = nullptr;
+        try {
+            resolved = refObject->getSubObject(sub.c_str());
+        }
+        catch (const Base::Exception&) {
+            resolved = nullptr;
+        }
+
+        if (!resolved && refObject->getDocument()) {
+            std::string role = subStrings.front();
+            const auto dot = role.rfind('.');
+            if (dot != std::string::npos) {
+                role = role.substr(dot + 1);
+            }
+            resolved = refObject->getDocument()->getObject(role.c_str());
+        }
+
+        if (resolved && resolved != refObject) {
+            if (auto direction = datumDirection(resolved)) {
+                return *direction;
+            }
+
+            lcs = freecad_cast<App::LocalCoordinateSystem*>(resolved);
+        }
+    }
+
+    if (!lcs) {
+        if (auto direction = datumDirection(refObject)) {
+            return *direction;
+        }
+        return LinearPatternExtension::getDirectionFromProperty(dirProp);
+    }
+
+    if (subStrings.empty() || subStrings.front().empty()) {
+        throw Base::ValueError("No direction reference specified");
+    }
+
+    std::string role = subStrings.front();
+    const auto dot = role.rfind('.');
+    if (dot != std::string::npos) {
+        role = role.substr(dot + 1);
+    }
+
+    if (role == App::LocalCoordinateSystem::AxisRoles[0]
+        || role == App::LocalCoordinateSystem::AxisRoles[1]
+        || role == App::LocalCoordinateSystem::AxisRoles[2]) {
+        Base::Vector3d d = lcs->getAxis(role.c_str())->getDirection();
+        return Base::convertTo<gp_Dir>(d);
+    }
+
+    if (role == App::LocalCoordinateSystem::PlaneRoles[0]
+        || role == App::LocalCoordinateSystem::PlaneRoles[1]
+        || role == App::LocalCoordinateSystem::PlaneRoles[2]) {
+        Base::Vector3d d = lcs->getPlane(role.c_str())->getDirection();
+        return Base::convertTo<gp_Dir>(d);
+    }
+
+    return LinearPatternExtension::getDirectionFromProperty(dirProp);
+}
+
+std::vector<Base::Placement> LinkArrayLinear::getElementPlacements()
+{
+    int occurrences = Occurrences.getValue();
+    int occurrences2 = Occurrences2.getValue();
+    if (occurrences < 1 || occurrences2 < 1) {
+        throw Base::ValueError("At least one occurrence required");
+    }
+
+    updateSpacings();
+
+    gp_Vec offset1 = calculateOffsetVectorWithDefault(LinearPatternDirection::First);
+    std::vector<gp_Vec> steps1 = calculateSteps(LinearPatternDirection::First, offset1);
+
+    gp_Vec offset2 = calculateOffsetVectorWithDefault(LinearPatternDirection::Second);
+    std::vector<gp_Vec> steps2 = calculateSteps(LinearPatternDirection::Second, offset2);
+
+    std::list<gp_Trsf> transformations;
+    for (const auto& step1 : steps1) {
+        for (const auto& step2 : steps2) {
+            gp_Trsf trans;
+            trans.SetTranslation(step1 + step2);
+            transformations.push_back(trans);
+        }
+    }
+
+    auto placements = placementsFromTransforms(transformations);
+    if (GeneratedOccurrences2.getValue() != occurrences2) {
+        GeneratedOccurrences2.setValue(occurrences2);
+    }
+    return placements;
+}
+
+gp_Vec LinkArrayLinear::calculateOffsetVectorWithDefault(LinearPatternDirection dir) const
+{
+    const auto objectAxisDirection = [](const std::string& role) -> std::optional<gp_Vec> {
+        if (role == "X_Axis") {
+            return gp_Vec(1.0, 0.0, 0.0);
+        }
+        if (role == "Y_Axis") {
+            return gp_Vec(0.0, 1.0, 0.0);
+        }
+        if (role == "Z_Axis") {
+            return gp_Vec(0.0, 0.0, 1.0);
+        }
+
+        return {};
+    };
+
+    const bool isSecondDir = dir == LinearPatternDirection::Second;
+    const auto& directionProp = isSecondDir ? Direction2 : Direction;
+    if (directionProp.getValue()) {
+        return calculateOffsetVector(dir);
+    }
+
+    std::vector<std::string> subStrings = directionProp.getSubValues();
+    gp_Vec offset;
+    if (!subStrings.empty()) {
+        std::string role = subStrings.front();
+        const auto dot = role.rfind('.');
+        if (dot != std::string::npos) {
+            role = role.substr(dot + 1);
+        }
+        if (auto direction = objectAxisDirection(role)) {
+            offset = *direction;
+        }
+    }
+    if (offset.Magnitude() <= Precision::Confusion()) {
+        offset = isSecondDir ? gp_Vec(0.0, 1.0, 0.0) : gp_Vec(1.0, 0.0, 0.0);
+    }
+
+    const auto& occurrencesProp = isSecondDir ? Occurrences2 : Occurrences;
+    int occurrences = occurrencesProp.getValue();
+    if (occurrences <= 1) {
+        return gp_Vec();
+    }
+
+    const auto& reversedProp = isSecondDir ? Reversed2 : Reversed;
+    if (reversedProp.getValue()) {
+        offset.Reverse();
+    }
+
+    const auto& modeProp = isSecondDir ? Mode2 : Mode;
+    if (static_cast<LinearPatternMode>(modeProp.getValue()) == LinearPatternMode::Extent) {
+        const auto& lengthProp = isSecondDir ? Length2 : Length;
+        double distance = lengthProp.getValue();
+        if (distance < Precision::Confusion()) {
+            throw Base::ValueError("Pattern length too small");
+        }
+        offset *= distance / (occurrences - 1);
+    }
+
+    return offset;
+}

--- a/src/Mod/Part/App/LinkArrayLinear.h
+++ b/src/Mod/Part/App/LinkArrayLinear.h
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/****************************************************************************
+ *   Copyright (c) 2026 Boyer Pierre-Louis <pierrelouis.boyer@gmail.com>    *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#pragma once
+
+#include "LinearPatternExtension.h"
+#include "LinkArray.h"
+
+namespace Part
+{
+
+class PartExport LinkArrayLinear: public Part::LinkArray, public Part::LinearPatternExtension
+{
+    PROPERTY_HEADER_WITH_EXTENSIONS(Part::LinkArrayLinear);
+    using inherited = Part::LinkArray;
+
+public:
+    LinkArrayLinear();
+
+    gp_Dir getDirectionFromProperty(const App::PropertyLinkSub& dirProp) const override;
+    void onDocumentRestored() override;
+    App::DocumentObjectExecReturn* execute() override;
+
+protected:
+    void onChanged(const App::Property* prop) override;
+    std::vector<Base::Placement> getElementPlacements() override;
+
+private:
+    // The stride of the existing elements may differ from Occurrences2 until recompute.
+    App::PropertyInteger GeneratedOccurrences2;
+    bool syncingSuppression = false;
+    std::vector<fastsignals::scoped_connection> suppressionConnections;
+
+    void connectElementSuppression();
+    void restoreElementSuppression();
+    void applyElementSuppression();
+    gp_Vec calculateOffsetVectorWithDefault(LinearPatternDirection dir) const;
+    void setDirectionLinkScopes();
+};
+
+}  // namespace Part

--- a/src/Mod/Part/CMakeLists.txt
+++ b/src/Mod/Part/CMakeLists.txt
@@ -84,6 +84,7 @@ set(Part_tests
     parttests/TopoShapeTest.py
     parttests/TestTangentMode3-0.21.FCStd
     parttests/TestLinkArrayCircular.py
+    parttests/TestLinkArrayLinear.py
     parttests/TestPartMirror.py
     parttests/TestFaceMakerUnifiedPlanar.py
     parttests/TestFaceMakerUnifiedNonPlanar.py

--- a/src/Mod/Part/TestPartApp.py
+++ b/src/Mod/Part/TestPartApp.py
@@ -37,6 +37,7 @@ from parttests.regression_tests import RegressionTests
 from parttests.TopoShapeListTest import TopoShapeListTest
 from parttests.TopoShapeTest import TopoShapeTest
 from parttests.TestLinkArrayCircular import TestLinkArrayCircular
+from parttests.TestLinkArrayLinear import TestLinkArrayLinear
 from parttests.TestPartMirror import TestPartMirroringRegression
 from parttests.TestFaceMakerUnifiedPlanar import *
 from parttests.TestFaceMakerUnifiedNonPlanar import *

--- a/src/Mod/Part/parttests/TestLinkArrayLinear.py
+++ b/src/Mod/Part/parttests/TestLinkArrayLinear.py
@@ -3,8 +3,6 @@
 import os
 import tempfile
 import unittest
-import xml.etree.ElementTree as ET
-import zipfile
 
 import FreeCAD as App
 import Part
@@ -30,25 +28,11 @@ class TestLinkArrayLinear(unittest.TestCase):
             indices,
         )
 
-    def reload(self, legacy=False):
+    def reload(self):
         with tempfile.TemporaryDirectory(prefix="freecad_linear_array_") as directory:
             path = os.path.join(directory, "array.FCStd")
             self.doc.saveAs(path)
             App.closeDocument(self.doc.Name)
-            if legacy:
-                # Reproduce a file written before coordinate-based suppression existed.
-                with zipfile.ZipFile(path) as archive:
-                    entries = {name: archive.read(name) for name in archive.namelist()}
-                root = ET.fromstring(entries["Document.xml"])
-                for properties in root.iter("Properties"):
-                    for prop in list(properties):
-                        if prop.get("name") in ("SuppressedPositions", "GeneratedOccurrences2"):
-                            properties.remove(prop)
-                    properties.set("Count", str(len(properties.findall("Property"))))
-                entries["Document.xml"] = ET.tostring(root)
-                with zipfile.ZipFile(path, "w") as archive:
-                    for name, data in entries.items():
-                        archive.writestr(name, data)
             self.doc = App.openDocument(path)
             self.array = self.doc.getObject("Array")
 
@@ -85,10 +69,10 @@ class TestLinkArrayLinear(unittest.TestCase):
         self.doc.recompute()
         self.assertSuppressed([6])
 
-    def testLegacySuppressionIsMigrated(self):
+    def testSuppressionSurvivesReloadInsideGrid(self):
         self.array.ElementList[5].Suppressed = True
         self.doc.recompute()
-        self.reload(legacy=True)
+        self.reload()
         self.array.Occurrences2 = 4
         self.doc.recompute()
         self.assertSuppressed([6])

--- a/src/Mod/Part/parttests/TestLinkArrayLinear.py
+++ b/src/Mod/Part/parttests/TestLinkArrayLinear.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+import zipfile
+
+import FreeCAD as App
+import Part
+
+
+class TestLinkArrayLinear(unittest.TestCase):
+    def setUp(self):
+        self.doc = App.newDocument("TestLinkArrayLinear")
+        source = self.doc.addObject("Part::Box", "Source")
+        self.array = self.doc.addObject("Part::LinkArrayLinear", "Array")
+        self.array.LinkedObject = source
+        self.array.Occurrences = 3
+        self.array.Occurrences2 = 3
+        self.doc.recompute()
+
+    def tearDown(self):
+        App.closeDocument(self.doc.Name)
+
+    def assertSuppressed(self, indices):
+        self.assertEqual(self.array.getStatusString(), "Valid")
+        self.assertEqual(
+            [i for i, element in enumerate(self.array.ElementList) if element.Suppressed],
+            indices,
+        )
+
+    def reload(self, legacy=False):
+        with tempfile.TemporaryDirectory(prefix="freecad_linear_array_") as directory:
+            path = os.path.join(directory, "array.FCStd")
+            self.doc.saveAs(path)
+            App.closeDocument(self.doc.Name)
+            if legacy:
+                # Reproduce a file written before coordinate-based suppression existed.
+                with zipfile.ZipFile(path) as archive:
+                    entries = {name: archive.read(name) for name in archive.namelist()}
+                root = ET.fromstring(entries["Document.xml"])
+                for properties in root.iter("Properties"):
+                    for prop in list(properties):
+                        if prop.get("name") in ("SuppressedPositions", "GeneratedOccurrences2"):
+                            properties.remove(prop)
+                    properties.set("Count", str(len(properties.findall("Property"))))
+                entries["Document.xml"] = ET.tostring(root)
+                with zipfile.ZipFile(path, "w") as archive:
+                    for name, data in entries.items():
+                        archive.writestr(name, data)
+            self.doc = App.openDocument(path)
+            self.array = self.doc.getObject("Array")
+
+    def testSuppressionFollowsBothDirections(self):
+        self.array.ElementList[0].Suppressed = True
+        self.array.ElementList[5].Suppressed = True  # (1, 2)
+        self.array.ElementList[8].Suppressed = True  # (2, 2)
+        self.array.Occurrences2 = 5
+        self.array.Occurrences = 4
+        self.doc.recompute()
+        self.assertSuppressed([0, 7, 12])
+
+        self.array.Occurrences = 1
+        self.array.Occurrences2 = 2
+        self.doc.recompute()
+        self.assertSuppressed([0])
+        self.array.ElementList[0].Suppressed = False
+
+        self.array.Occurrences = 3
+        self.array.Occurrences2 = 3
+        self.doc.recompute()
+        self.assertSuppressed([5, 8])
+        self.array.ElementList[5].Suppressed = False
+        self.array.Occurrences2 = 4
+        self.doc.recompute()
+        self.assertSuppressed([10])
+
+    def testSuppressionSurvivesReloadOutsideGrid(self):
+        self.array.ElementList[5].Suppressed = True
+        self.array.Occurrences2 = 1
+        self.doc.recompute()
+        self.reload()
+        self.array.Occurrences2 = 4
+        self.doc.recompute()
+        self.assertSuppressed([6])
+
+    def testLegacySuppressionIsMigrated(self):
+        self.array.ElementList[5].Suppressed = True
+        self.doc.recompute()
+        self.reload(legacy=True)
+        self.array.Occurrences2 = 4
+        self.doc.recompute()
+        self.assertSuppressed([6])
+
+    def testPendingResizeUsesExistingElementCoordinates(self):
+        self.array.Occurrences2 = 4
+        self.array.ElementList[5].Suppressed = True  # Still the old (1, 2) element.
+        self.reload()
+        self.doc.recompute()
+        self.assertSuppressed([6])
+
+    def testCannotCollapseSuppressedInstances(self):
+        self.array.ElementList[5].Suppressed = True
+        # Also protect the interval before the array is recomputed.
+        with self.assertRaises((RuntimeError, ValueError)):
+            self.array.ShowElement = False
+        self.assertTrue(self.array.ShowElement)
+        self.doc.recompute()
+        self.assertSuppressed([5])
+        self.array.ElementList[5].Suppressed = False
+        self.doc.recompute()
+        self.array.ShowElement = False
+        self.doc.recompute()
+        self.assertFalse(self.array.ShowElement)
+        self.array.ShowElement = True
+        self.doc.recompute()
+        self.assertSuppressed([])
+
+    def testFailedResizeKeepsExistingElementCoordinates(self):
+        self.array.Occurrences2 = 4
+        self.array.Length2 = 0
+        self.doc.recompute()
+        self.array.ElementList[5].Suppressed = True
+        self.array.Length2 = 100
+        self.doc.recompute()
+        self.assertSuppressed([6])
+
+    def testResizeUndoRedo(self):
+        self.doc.UndoMode = 1
+        self.array.ElementList[5].Suppressed = True
+        self.doc.recompute()
+        self.doc.openTransaction("Resize array")
+        self.array.Occurrences2 = 4
+        self.doc.recompute()
+        self.doc.commitTransaction()
+        self.assertSuppressed([6])
+        self.doc.undo()
+        self.doc.recompute()
+        self.assertSuppressed([5])
+        self.doc.redo()
+        self.doc.recompute()
+        self.assertSuppressed([6])
+
+    def testSuppressionUndoRedo(self):
+        self.doc.UndoMode = 1
+        self.doc.openTransaction("Suppress instance")
+        self.array.ElementList[5].Suppressed = True
+        self.doc.recompute()
+        self.doc.commitTransaction()
+        self.doc.undo()
+        self.doc.recompute()
+        self.assertSuppressed([])
+        self.doc.redo()
+        self.doc.recompute()
+        self.assertSuppressed([5])


### PR DESCRIPTION
Add Part::LinkArrayLinear using the merged link-array base and linear pattern extension. Suppression follows grid positions across resizing, save/reload, and undo/redo.

Part of #30840. Based directly on main; independent of the other open LinkArrays PRs. 