### PR TITLE
LinkArrays: add circular link arrays

### DIFF
--- a/src/Mod/Part/App/AppPart.cpp
+++ b/src/Mod/Part/App/AppPart.cpp
@@ -98,6 +98,7 @@
 #include "CircularPatternExtension.h"
 #include "LinearPatternExtension.h"
 #include "LinkArray.h"
+#include "LinkArrayCircular.h"
 #include "PolarPatternExtension.h"
 #include "Geometry.h"
 #include "Geometry2d.h"
@@ -457,6 +458,7 @@ PyMOD_INIT_FUNC(Part)
     Part::LinearPatternExtension::init();
     Part::PolarPatternExtension ::init();
     Part::LinkArray             ::init();
+    Part::LinkArrayCircular     ::init();
 
     Part::Feature               ::init();
     Part::FeatureExt            ::init();

--- a/src/Mod/Part/App/CMakeLists.txt
+++ b/src/Mod/Part/App/CMakeLists.txt
@@ -219,6 +219,8 @@ SET(Features_SRCS
     LinearPatternExtension.h
     LinkArray.cpp
     LinkArray.h
+    LinkArrayCircular.cpp
+    LinkArrayCircular.h
     PolarPatternExtension.cpp
     PolarPatternExtension.h
     OCCTMessagePrinter.cpp

--- a/src/Mod/Part/App/LinkArrayCircular.cpp
+++ b/src/Mod/Part/App/LinkArrayCircular.cpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2026 FreeCAD Project Association                         *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Lesser General Public             *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2.1 of the License, or (at your option) any later version.     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,        *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA 02111-1307, USA                                  *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "LinkArrayCircular.h"
+
+using namespace Part;
+
+PROPERTY_SOURCE_WITH_EXTENSIONS(Part::LinkArrayCircular, Part::LinkArray)
+
+LinkArrayCircular::LinkArrayCircular()
+{
+    Part::CircularPatternExtension::initExtension(this);
+    setAxisLinkScope();
+}
+
+void LinkArrayCircular::onDocumentRestored()
+{
+    inherited::onDocumentRestored();
+    setAxisLinkScope();
+}
+
+void LinkArrayCircular::setAxisLinkScope()
+{
+    Axis.setScope(App::LinkScope::Global);
+}
+
+std::vector<Base::Placement> LinkArrayCircular::getElementPlacements()
+{
+    return placementsFromTransforms(calculateTransformations());
+}

--- a/src/Mod/Part/App/LinkArrayCircular.h
+++ b/src/Mod/Part/App/LinkArrayCircular.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2026 FreeCAD Project Association                         *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Lesser General Public             *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2.1 of the License, or (at your option) any later version.     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,        *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA 02111-1307, USA                                  *
+ *                                                                         *
+ ***************************************************************************/
+
+#pragma once
+
+#include "CircularPatternExtension.h"
+#include "LinkArray.h"
+
+namespace Part
+{
+
+class PartExport LinkArrayCircular: public Part::LinkArray, public Part::CircularPatternExtension
+{
+    PROPERTY_HEADER_WITH_EXTENSIONS(Part::LinkArrayCircular);
+    using inherited = Part::LinkArray;
+
+public:
+    LinkArrayCircular();
+
+    void onDocumentRestored() override;
+
+protected:
+    std::vector<Base::Placement> getElementPlacements() override;
+
+private:
+    void setAxisLinkScope();
+};
+
+}  // namespace Part

--- a/src/Mod/Part/CMakeLists.txt
+++ b/src/Mod/Part/CMakeLists.txt
@@ -83,6 +83,7 @@ set(Part_tests
     parttests/TaskFaceAppearancesTest.py
     parttests/TopoShapeTest.py
     parttests/TestTangentMode3-0.21.FCStd
+    parttests/TestLinkArrayCircular.py
     parttests/TestPartMirror.py
     parttests/TestFaceMakerUnifiedPlanar.py
     parttests/TestFaceMakerUnifiedNonPlanar.py

--- a/src/Mod/Part/TestPartApp.py
+++ b/src/Mod/Part/TestPartApp.py
@@ -36,6 +36,7 @@ from parttests.Geom2d_tests import Geom2dTests
 from parttests.regression_tests import RegressionTests
 from parttests.TopoShapeListTest import TopoShapeListTest
 from parttests.TopoShapeTest import TopoShapeTest
+from parttests.TestLinkArrayCircular import TestLinkArrayCircular
 from parttests.TestPartMirror import TestPartMirroringRegression
 from parttests.TestFaceMakerUnifiedPlanar import *
 from parttests.TestFaceMakerUnifiedNonPlanar import *

--- a/src/Mod/Part/parttests/TestLinkArrayCircular.py
+++ b/src/Mod/Part/parttests/TestLinkArrayCircular.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# ***************************************************************************
+#   Copyright (c) 2026 FreeCAD Project Association
+#
+#   This file is part of the FreeCAD CAx development system.
+#
+#   This library is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU Lesser General Public License
+#   as published by the Free Software Foundation; either version 2.1 of
+#   the License, or (at your option) any later version.
+#
+#   This library is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU Lesser General Public
+#   License along with this library; see the file COPYING.LIB. If not,
+#   write to the Free Software Foundation, Inc., 59 Temple Place,
+#   Suite 330, Boston, MA 02111-1307, USA
+# ***************************************************************************
+
+import unittest
+
+import FreeCAD as App
+import Part
+
+
+class TestLinkArrayCircular(unittest.TestCase):
+    def setUp(self):
+        self.doc = App.newDocument("TestLinkArrayCircular")
+        source = self.doc.addObject("Part::Box", "Source")
+        self.array = self.doc.addObject("Part::LinkArrayCircular", "Array")
+        self.array.LinkedObject = source
+        self.array.ShowElement = False
+        self.array.RadialDistance = 10
+        self.array.TangentialDistance = 10
+        self.array.NumberCircles = 3
+        self.array.Symmetry = 4
+
+    def tearDown(self):
+        App.closeDocument(self.doc.Name)
+
+    def testExcessiveOccurrenceCountIsRejected(self):
+        self.array.NumberCircles = 2
+        self.array.RadialDistance = 1000000
+        self.array.TangentialDistance = 0.001
+        self.doc.recompute()
+        self.assertIn("10000", self.array.getStatusString())
+
+    def testRingPopulationIsRoundedToSymmetry(self):
+        self.assertEqual(self.array.getTypeIdOfProperty("RadialDistance"), "App::PropertyLength")
+        self.assertEqual(
+            self.array.getTypeIdOfProperty("TangentialDistance"), "App::PropertyLength"
+        )
+        self.doc.recompute()
+
+        self.assertEqual(self.array.getStatusString(), "Valid")
+        # floor(2*pi*10/10) -> 6 -> 4, floor(2*pi*20/10) -> 12.
+        self.assertEqual(self.array.ElementCount, 1 + 4 + 12)
+        self.assertEqual(len(self.array.PlacementList), self.array.ElementCount)
+        self.assertEqual(self.array.PlacementList[0], App.Placement())
+        self.assertAlmostEqual(self.array.PlacementList[1].Base.Length, 10)
+        self.assertAlmostEqual(self.array.PlacementList[5].Base.Length, 20)
+
+    def testAxisReferenceOrientsTheCircles(self):
+        axis = self.doc.addObject("Part::Feature", "Axis")
+        axis.Shape = Part.makeLine(App.Vector(5, 0, 0), App.Vector(5, 10, 0))
+        self.array.Axis = (axis, ["Edge1"])
+
+        self.doc.recompute()
+
+        self.assertEqual(self.array.getStatusString(), "Valid")
+        for placement in self.array.PlacementList:
+            self.assertAlmostEqual(placement.Base.y, 0)
+
+        # The selected edge supplies the center as well as the axis direction.
+        self.assertAlmostEqual(self.array.PlacementList[2].Base.x, -5)


### PR DESCRIPTION
Add Part::LinkArrayCircular using the merged circular pattern extension. Generate concentric rings with symmetry-adjusted populations and an optional reference axis.

Part of #30840. Based directly on main and independent of the other open LinkArrays PRs. This introduces the core object and its tests; GUI commands remain in the later series. 