### PR TITLE
LinkArrays: add the PartDesign circular pattern feature

### DIFF
--- a/src/Mod/PartDesign/App/AppPartDesign.cpp
+++ b/src/Mod/PartDesign/App/AppPartDesign.cpp
@@ -43,6 +43,7 @@
 #include "FeatureGroove.h"
 #include "FeatureHelix.h"
 #include "FeatureHole.h"
+#include "FeatureCircularPattern.h"
 #include "FeatureLinearPattern.h"
 #include "FeatureLoft.h"
 #include "FeatureMirrored.h"
@@ -101,6 +102,7 @@ PyMOD_INIT_FUNC(_PartDesign)
     PartDesign::ProfileBased                ::init();
     PartDesign::Transformed                 ::init();
     PartDesign::Mirrored                    ::init();
+    PartDesign::CircularPattern             ::init();
     PartDesign::LinearPattern               ::init();
     PartDesign::PolarPattern                ::init();
     PartDesign::Scaled                      ::init();

--- a/src/Mod/PartDesign/App/CMakeLists.txt
+++ b/src/Mod/PartDesign/App/CMakeLists.txt
@@ -49,6 +49,8 @@ SET(FeaturesTransformed_SRCS
     FeatureMirrored.cpp
     FeatureLinearPattern.h
     FeatureLinearPattern.cpp
+    FeatureCircularPattern.h
+    FeatureCircularPattern.cpp
     FeaturePolarPattern.h
     FeaturePolarPattern.cpp
     FeatureScaled.h

--- a/src/Mod/PartDesign/App/FeatureCircularPattern.cpp
+++ b/src/Mod/PartDesign/App/FeatureCircularPattern.cpp
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "FeatureCircularPattern.h"
+
+#include <Mod/Part/App/Tools.h>
+
+#include <gp_Dir.hxx>
+
+#include "DatumLine.h"
+
+using namespace PartDesign;
+
+PROPERTY_SOURCE_WITH_EXTENSIONS(PartDesign::CircularPattern, PartDesign::Transformed)
+
+CircularPattern::CircularPattern()
+{
+    Part::CircularPatternExtension::initExtension(this);
+}
+
+const std::list<gp_Trsf> CircularPattern::getTransformations(const std::vector<App::DocumentObject*>)
+{
+    return calculateTransformations();
+}
+
+gp_Ax2 CircularPattern::getRotation() const
+{
+    if (auto* line = freecad_cast<PartDesign::Line*>(Axis.getValue())) {
+        const Base::Vector3d point = line->getBasePoint();
+        const Base::Vector3d vector = line->getDirection();
+        gp_Pnt base = Base::convertTo<gp_Pnt>(point);
+        gp_Dir direction = Base::convertTo<gp_Dir>(vector);
+
+        const TopLoc_Location inverse = getLocation().Inverted();
+        base.Transform(inverse.Transformation());
+        direction.Transform(inverse.Transformation());
+        return gp_Ax2(base, direction);
+    }
+
+    return Part::CircularPatternExtension::getRotation();
+}

--- a/src/Mod/PartDesign/App/FeatureCircularPattern.h
+++ b/src/Mod/PartDesign/App/FeatureCircularPattern.h
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <Mod/Part/App/CircularPatternExtension.h>
+
+#include "FeatureTransformed.h"
+
+namespace PartDesign
+{
+
+class PartDesignExport CircularPattern: public PartDesign::Transformed,
+                                        public Part::CircularPatternExtension
+{
+    PROPERTY_HEADER_WITH_EXTENSIONS(PartDesign::CircularPattern);
+
+public:
+    CircularPattern();
+
+    const char* getViewProviderName() const override
+    {
+        return "PartDesignGui::ViewProviderCircularPattern";
+    }
+
+    const std::list<gp_Trsf> getTransformations(const std::vector<App::DocumentObject*>) override;
+    gp_Ax2 getRotation() const override;
+};
+
+}  // namespace PartDesign

--- a/src/Mod/PartDesign/CMakeLists.txt
+++ b/src/Mod/PartDesign/CMakeLists.txt
@@ -50,6 +50,7 @@ set(PartDesign_TestScripts
     PartDesignTests/TestPrimitive.py
     PartDesignTests/TestMirrored.py
     PartDesignTests/TestLinearPattern.py
+    PartDesignTests/TestCircularPattern.py
     PartDesignTests/TestPolarPattern.py
     PartDesignTests/TestMultiTransform.py
     PartDesignTests/TestBoolean.py

--- a/src/Mod/PartDesign/PartDesignTests/TestCircularPattern.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestCircularPattern.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+import FreeCAD
+
+
+class TestCircularPattern(unittest.TestCase):
+    def setUp(self):
+        self.doc = FreeCAD.newDocument("PartDesignTestCircularPattern")
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.doc.Name)
+
+    def testCircularPatternProperties(self):
+        pattern = self.doc.addObject("PartDesign::CircularPattern", "CircularPattern")
+
+        self.assertEqual(pattern.RadialDistance, 50)
+        self.assertEqual(pattern.TangentialDistance, 25)
+        self.assertEqual(pattern.getTypeIdOfProperty("RadialDistance"), "App::PropertyLength")
+        self.assertEqual(pattern.getTypeIdOfProperty("TangentialDistance"), "App::PropertyLength")
+        pattern.RadialDistance = 0.00054
+        self.assertAlmostEqual(pattern.RadialDistance, 0.00054)
+        self.assertEqual(pattern.NumberCircles, 3)
+        self.assertEqual(pattern.Symmetry, 1)
+        self.assertNotIn("Angle", pattern.PropertiesList)
+        self.assertNotIn("Occurrences", pattern.PropertiesList)
+
+    def testCircularPatternCreatesConcentricCopies(self):
+        body = self.doc.addObject("PartDesign::Body", "Body")
+        box = self.doc.addObject("PartDesign::AdditiveBox", "Box")
+        body.addObject(box)
+        box.Length = 10
+        box.Width = 10
+        box.Height = 10
+        self.doc.recompute()
+
+        pattern = self.doc.addObject("PartDesign::CircularPattern", "CircularPattern")
+        pattern.Originals = [box]
+        pattern.Axis = (self.doc.Z_Axis, [""])
+        pattern.RadialDistance = 10
+        pattern.TangentialDistance = 15
+        pattern.NumberCircles = 2
+        pattern.Symmetry = 4
+        body.addObject(pattern)
+        self.doc.recompute()
+
+        self.assertEqual(pattern.getStatusString(), "Valid")
+        self.assertFalse(pattern.Shape.isNull())
+        self.assertGreater(pattern.Shape.Volume, box.Shape.Volume)
+
+    def testCircularPatternInMultiTransform(self):
+        body = self.doc.addObject("PartDesign::Body", "Body")
+        box = self.doc.addObject("PartDesign::AdditiveBox", "Box")
+        body.addObject(box)
+        box.Length = 10
+        box.Width = 10
+        box.Height = 10
+        self.doc.recompute()
+
+        multi = self.doc.addObject("PartDesign::MultiTransform", "MultiTransform")
+        multi.Originals = [box]
+        multi.Shape = box.Shape
+        body.addObject(multi)
+
+        circular = self.doc.addObject("PartDesign::CircularPattern", "CircularPattern")
+        circular.Axis = (self.doc.Z_Axis, [""])
+        circular.RadialDistance = 20
+        circular.TangentialDistance = 20
+        circular.NumberCircles = 2
+        circular.Symmetry = 4
+        body.addObject(circular)
+
+        multi.Transformations = [circular]
+        self.doc.recompute()
+
+        self.assertEqual(multi.getStatusString(), "Valid")
+        self.assertAlmostEqual(multi.Shape.Volume, 5 * box.Shape.Volume)

--- a/src/Mod/PartDesign/TestPartDesignApp.py
+++ b/src/Mod/PartDesign/TestPartDesignApp.py
@@ -45,6 +45,7 @@ from PartDesignTests.TestHelix import TestHelix
 # transformations and boolean
 from PartDesignTests.TestMirrored import TestMirrored
 from PartDesignTests.TestLinearPattern import TestLinearPattern
+from PartDesignTests.TestCircularPattern import TestCircularPattern
 from PartDesignTests.TestPolarPattern import TestPolarPattern
 from PartDesignTests.TestMultiTransform import TestMultiTransform
 from PartDesignTests.TestBoolean import TestBoolean


### PR DESCRIPTION
Add the PartDesign::CircularPattern core feature using the merged circular pattern extension, including transformation of a datum-line axis into the feature’s local frame. Include regression tests for properties, concentric copies and MultiTransform.

Part of #30840. Based directly on main and independent of other open LinkArrays PRs. This is the core feature; GUI commands and its view provider remain in the later series. 