### PR TITLE
LinkArrays: extract the shared pattern reference widget

### DIFF
--- a/src/Mod/Part/Gui/CMakeLists.txt
+++ b/src/Mod/Part/Gui/CMakeLists.txt
@@ -145,6 +145,8 @@ SET(PartGui_SRCS
     PatternParametersWidget.cpp
     PatternParametersWidget.h
     PatternParametersWidget.ui
+    PatternReferenceWidget.cpp
+    PatternReferenceWidget.h
     Resources/Part.qrc
     PreCompiled.h
     PreviewUpdateScheduler.cpp

--- a/src/Mod/Part/Gui/PatternParametersWidget.cpp
+++ b/src/Mod/Part/Gui/PatternParametersWidget.cpp
@@ -36,6 +36,7 @@
 #include <App/DocumentObject.h>
 #include <App/PropertyUnits.h>
 #include <Base/Parameter.h>
+#include <Base/Rotation.h>
 #include <Base/Tools.h>
 #include <Gui/ComboLinks.h>
 #include <Gui/QuantitySpinBox.h>
@@ -50,7 +51,7 @@ PatternParametersWidget::PatternParametersWidget(
     Gui::View3DInventorViewer* v,
     QWidget* parent
 )
-    : QWidget(parent)
+    : PatternReferenceWidget(parent)
     , ui(new Ui_PatternParametersWidget)
     , viewer(v)
     , type(type)
@@ -82,8 +83,7 @@ void PatternParametersWidget::setupUiElements()
         ui->labelOffset->setText(tr("Angular Spacing"));
     }
 
-    // Set combo box helper
-    dirLinks.setCombo(ui->comboDirection);
+    setupReferenceCombo(ui->comboDirection);
 
     ParameterGrp::handle hPart = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Part"
@@ -95,12 +95,6 @@ void PatternParametersWidget::setupUiElements()
 
 void PatternParametersWidget::connectSignals()
 {
-    connect(
-        ui->comboDirection,
-        qOverload<int>(&QComboBox::activated),
-        this,
-        &PatternParametersWidget::onDirectionChanged
-    );
     connect(ui->PushButtonReverse, &QToolButton::pressed, this, &PatternParametersWidget::onReversePressed);
     connect(
         ui->comboMode,
@@ -159,7 +153,7 @@ void PatternParametersWidget::bindProperties(
 )
 {
     // Store pointers to the properties
-    m_directionProp = directionProp;
+    bindReference(directionProp);
     m_reversedProp = reversedProp;
     m_modeProp = modeProp;
     m_extentProp = lengthProp;
@@ -195,17 +189,6 @@ void PatternParametersWidget::bindProperties(
     updateUI();
 }
 
-void PatternParametersWidget::addDirection(
-    App::DocumentObject* linkObj,
-    const std::string& linkSubname,
-    const QString& itemText,
-    int userData
-)
-{
-    // Insert custom directions before "Select reference..."
-    dirLinks.addLink(linkObj, linkSubname, itemText, userData);
-}
-
 void PatternParametersWidget::updateUI()
 {
     if (blockUpdate || !m_feature) {  // Need properties to be bound
@@ -213,18 +196,7 @@ void PatternParametersWidget::updateUI()
     }
     Base::StateLocker locker(blockUpdate, true);
 
-    // Update direction combo
-    if (dirLinks.setCurrentLink(*m_directionProp) == -1) {
-        // failed to set current, because the link isn't in the list yet
-        if (m_directionProp->getValue()) {
-            QString refStr = QStringLiteral("%1:%2").arg(
-                QString::fromLatin1(m_directionProp->getValue()->getNameInDocument()),
-                QString::fromLatin1(m_directionProp->getSubValues().front().c_str())
-            );
-            dirLinks.addLink(*m_directionProp, refStr);
-            dirLinks.setCurrentLink(*m_directionProp);
-        }
-    }
+    updateReferenceUI();
 
     // Update other controls directly from properties
     ui->comboMode->setCurrentIndex(m_modeProp->getValue());
@@ -288,16 +260,6 @@ void PatternParametersWidget::adaptVisibilityToMode()
     ui->spacingControlsWidget->setVisible(mode == PartGui::PatternMode::Spacing);
 }
 
-const App::PropertyLinkSub& PatternParametersWidget::getCurrentDirectionLink() const
-{
-    return dirLinks.getCurrentLink();
-}
-
-bool PatternParametersWidget::isSelectReferenceMode() const
-{
-    return !dirLinks.getCurrentLink().getValue();
-}
-
 void PatternParametersWidget::setTitle(const QString& title)
 {
     ui->groupBox->setTitle(title);
@@ -315,22 +277,6 @@ void PatternParametersWidget::setChecked(bool on)
 }
 
 // --- Slots ---
-
-void PatternParametersWidget::onDirectionChanged(int /*index*/)
-{
-    if (blockUpdate || !m_directionProp) {
-        return;
-    }
-
-    if (isSelectReferenceMode()) {
-        // Emit signal for the task panel to handle reference selection
-        requestReferenceSelection();
-    }
-    else {
-        m_directionProp->Paste(dirLinks.getCurrentLink());  // Update the property
-        parametersChanged();                                // Notify change
-    }
-}
 
 void PatternParametersWidget::onReversePressed()
 {
@@ -548,13 +494,6 @@ void PatternParametersWidget::updateSpacingPatternProperty()
 
 // --- Getters ---
 
-void PatternParametersWidget::getAxis(App::DocumentObject*& obj, std::vector<std::string>& sub) const
-{
-    const App::PropertyLinkSub& lnk = dirLinks.getCurrentLink();
-    obj = lnk.getValue();
-    sub = lnk.getSubValues();
-}
-
 bool PatternParametersWidget::getReverse() const
 {
     return m_reversedProp->getValue();
@@ -610,6 +549,15 @@ void PatternParametersWidget::updateSpacingLabels(
     const Base::Vector3d& direction
 )
 {
+    updateSpacingLabels(startPoint, direction, Base::Vector3d());
+}
+
+void PatternParametersWidget::updateSpacingLabels(
+    const Base::Vector3d& startPoint,
+    const Base::Vector3d& direction,
+    const Base::Vector3d& planeNormal
+)
+{
     clearAllSpacingLabels();
 
     if (!m_feature || !viewer || type != PatternType::Linear) {
@@ -625,6 +573,10 @@ void PatternParametersWidget::updateSpacingLabels(
     try {
         size_t requiredLabels = (mode == PatternMode::Extent) ? 1 : m_occurrencesProp->getValue() - 1;
         Base::Rotation rotation(Base::Vector3d(1.0, 0.0, 0.0), direction);
+        if (planeNormal.Length() > 1e-7 && direction.Cross(planeNormal).Length() > 1e-7) {
+            rotation
+                = Base::Rotation::makeRotationByAxes(direction, Base::Vector3d(), planeNormal, "XZY");
+        }
 
         if (spacingLabels.size() > requiredLabels) {
             spacingLabels.resize(requiredLabels);

--- a/src/Mod/Part/Gui/PatternParametersWidget.h
+++ b/src/Mod/Part/Gui/PatternParametersWidget.h
@@ -24,15 +24,15 @@
 
 #pragma once
 
-#include <QWidget>
 #include <memory>
 #include <vector>
 #include <App/PropertyStandard.h>  // For Property types
 #include <App/PropertyLinks.h>     // For PropertyLinkSub
-#include <Gui/ComboLinks.h>
 #include <Gui/EditableDatumLabel.h>
 
 #include <Mod/Part/PartGlobal.h>
+
+#include "PatternReferenceWidget.h"
 
 class Ui_PatternParametersWidget;
 
@@ -75,7 +75,7 @@ enum class PatternMode
  * Length/Spacing (including dynamic spacing), and Occurrences. It binds directly
  * to the corresponding properties of a Feature.
  */
-class PartGuiExport PatternParametersWidget: public QWidget
+class PartGuiExport PatternParametersWidget: public PatternReferenceWidget
 {
     Q_OBJECT
 
@@ -124,13 +124,6 @@ public:
      * @param link The PropertyLinkSub representing the custom direction.
      * @param text The user-visible text for the combo box item.
      */
-    void addDirection(
-        App::DocumentObject* linkObj,
-        const std::string& linkSubname,
-        const QString& itemText,
-        int userData = -1
-    );
-
     /**
      * @brief Updates the UI elements to reflect the current values of the bound properties.
      */
@@ -140,14 +133,6 @@ public:
      * @brief Returns the currently selected direction link from the combo box.
      * Returns an empty link if "Select reference..." is chosen.
      */
-    const App::PropertyLinkSub& getCurrentDirectionLink() const;
-
-    /**
-     * @brief Checks if the "Select reference..." item is currently selected.
-     */
-    bool isSelectReferenceMode() const;
-
-    void getAxis(App::DocumentObject*& obj, std::vector<std::string>& sub) const;
     bool getReverse() const;
     int getMode() const;
     double getExtent() const;
@@ -169,27 +154,15 @@ public:
         double startAngle
     );
     void updateSpacingLabels(const Base::Vector3d& startPoint, const Base::Vector3d& direction);
+    void updateSpacingLabels(
+        const Base::Vector3d& startPoint,
+        const Base::Vector3d& direction,
+        const Base::Vector3d& planeNormal
+    );
     void clearAllSpacingLabels();
-
-    Gui::ComboLinks dirLinks;
-
-Q_SIGNALS:
-    /**
-     * @brief Emitted when the user selects the "Select reference..." option
-     *        in the direction combo box, indicating the need to enter selection mode.
-     */
-    void requestReferenceSelection();
-
-    /**
-     * @brief Emitted when any parameter value controlled by this widget changes
-     *        that requires a recompute of the feature.
-     */
-    void parametersChanged();
-
 
 private Q_SLOTS:
     // Slots connected to UI elements
-    void onDirectionChanged(int index);
     void onReversePressed();
     void onModeChanged(int index);
     // Note: Spinbox value changes are often handled by direct binding,
@@ -227,7 +200,6 @@ private:
     std::unique_ptr<Ui_PatternParametersWidget> ui;
 
     // Pointers to bound properties (raw pointers, lifetime managed externally)
-    App::PropertyLinkSub* m_directionProp = nullptr;
     App::PropertyBool* m_reversedProp = nullptr;
     App::PropertyEnumeration* m_modeProp = nullptr;
     App::PropertyQuantity* m_extentProp = nullptr;

--- a/src/Mod/Part/Gui/PatternReferenceWidget.cpp
+++ b/src/Mod/Part/Gui/PatternReferenceWidget.cpp
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "PatternReferenceWidget.h"
+
+#include <QComboBox>
+
+#include <App/DocumentObject.h>
+#include <Base/Tools.h>
+
+using namespace PartGui;
+
+PatternReferenceWidget::PatternReferenceWidget(QWidget* parent)
+    : QWidget(parent)
+{}
+
+void PatternReferenceWidget::setupReferenceCombo(QComboBox* combo)
+{
+    dirLinks.setCombo(combo);
+    connect(combo, qOverload<int>(&QComboBox::activated), this, &PatternReferenceWidget::onDirectionChanged);
+}
+
+void PatternReferenceWidget::bindReference(App::PropertyLinkSub* reference)
+{
+    referenceProperty = reference;
+    updateReferenceUI();
+}
+
+void PatternReferenceWidget::addDirection(
+    App::DocumentObject* object,
+    const std::string& subname,
+    const QString& text,
+    int userData
+)
+{
+    dirLinks.addLink(object, subname, text, userData);
+}
+
+void PatternReferenceWidget::updateReferenceUI()
+{
+    if (blockReferenceUpdate || !referenceProperty) {
+        return;
+    }
+
+    Base::StateLocker locker(blockReferenceUpdate, true);
+    if (dirLinks.setCurrentLink(*referenceProperty) != -1 || !referenceProperty->getValue()) {
+        return;
+    }
+
+    const auto& subnames = referenceProperty->getSubValues();
+    const QString reference = QStringLiteral("%1:%2").arg(
+        QString::fromLatin1(referenceProperty->getValue()->getNameInDocument()),
+        subnames.empty() ? QString() : QString::fromStdString(subnames.front())
+    );
+    dirLinks.addLink(*referenceProperty, reference);
+    dirLinks.setCurrentLink(*referenceProperty);
+}
+
+const App::PropertyLinkSub& PatternReferenceWidget::getCurrentDirectionLink() const
+{
+    return dirLinks.getCurrentLink();
+}
+
+bool PatternReferenceWidget::isSelectReferenceMode() const
+{
+    const int userData = dirLinks.getCurrentUserData();
+    if (userData == SelectReferenceUserData) {
+        return true;
+    }
+    if (userData == DefaultDirectionUserData || userData == ObjectDirectionUserData) {
+        return false;
+    }
+
+    return !dirLinks.getCurrentLink().getValue();
+}
+
+void PatternReferenceWidget::getAxis(App::DocumentObject*& object, std::vector<std::string>& subnames) const
+{
+    const App::PropertyLinkSub& link = dirLinks.getCurrentLink();
+    object = link.getValue();
+    subnames = link.getSubValues();
+}
+
+void PatternReferenceWidget::onDirectionChanged(int)
+{
+    if (blockReferenceUpdate || !referenceProperty) {
+        return;
+    }
+
+    if (isSelectReferenceMode()) {
+        Q_EMIT requestReferenceSelection();
+        return;
+    }
+
+    referenceProperty->Paste(dirLinks.getCurrentLink());
+    Q_EMIT parametersChanged();
+}

--- a/src/Mod/Part/Gui/PatternReferenceWidget.h
+++ b/src/Mod/Part/Gui/PatternReferenceWidget.h
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <QWidget>
+
+#include <App/PropertyLinks.h>
+#include <Gui/ComboLinks.h>
+#include <Mod/Part/PartGlobal.h>
+
+class QComboBox;
+
+namespace PartGui
+{
+
+class PartGuiExport PatternReferenceWidget: public QWidget
+{
+    Q_OBJECT
+
+public:
+    static constexpr int DefaultDirectionUserData = -2;
+    static constexpr int SelectReferenceUserData = -3;
+    static constexpr int ObjectDirectionUserData = -4;
+
+    explicit PatternReferenceWidget(QWidget* parent = nullptr);
+
+    void setupReferenceCombo(QComboBox* combo);
+    void bindReference(App::PropertyLinkSub* reference);
+    void addDirection(
+        App::DocumentObject* object,
+        const std::string& subname,
+        const QString& text,
+        int userData = -1
+    );
+    void updateReferenceUI();
+
+    const App::PropertyLinkSub& getCurrentDirectionLink() const;
+    bool isSelectReferenceMode() const;
+    void getAxis(App::DocumentObject*& object, std::vector<std::string>& subnames) const;
+
+    Gui::ComboLinks dirLinks;
+
+Q_SIGNALS:
+    void requestReferenceSelection();
+    void parametersChanged();
+
+private:
+    void onDirectionChanged(int index);
+
+    App::PropertyLinkSub* referenceProperty = nullptr;
+    bool blockReferenceUpdate = false;
+};
+
+}  // namespace PartGui


### PR DESCRIPTION
Extract the reference selector from PatternParametersWidget into PatternReferenceWidget so additional pattern editors can reuse reference binding and selection signals. Keep the existing pattern editor API through inheritance and add an overload for orienting spacing labels in a specified plane.

Part of #30840. Based directly on main; independent of the new pattern features. 