### PR TITLE
LinkArrays: add shared pattern instance suppression controls

### DIFF
--- a/src/Mod/Part/Gui/CMakeLists.txt
+++ b/src/Mod/Part/Gui/CMakeLists.txt
@@ -147,6 +147,8 @@ SET(PartGui_SRCS
     PatternParametersWidget.ui
     PatternReferenceWidget.cpp
     PatternReferenceWidget.h
+    PatternInstanceControls.cpp
+    PatternInstanceControls.h
     Resources/Part.qrc
     PreCompiled.h
     PreviewUpdateScheduler.cpp

--- a/src/Mod/Part/Gui/PatternInstanceControls.cpp
+++ b/src/Mod/Part/Gui/PatternInstanceControls.cpp
@@ -27,85 +27,18 @@
 #include <Inventor/nodes/SoCamera.h>
 #include <Inventor/sensors/SoNodeSensor.h>
 
-#include <QColor>
 #include <QEvent>
-#include <QIcon>
-#include <QPainter>
-#include <QPen>
-#include <QPixmap>
 #include <QPoint>
 #include <QSize>
 #include <QTimer>
 #include <QToolButton>
 #include <QWidget>
 
+#include <Gui/BitmapFactory.h>
 #include <Gui/View3DInventorViewer.h>
 #include <Gui/Utilities.h>
 
 using namespace PartGui;
-
-namespace
-{
-
-QIcon makeCrossIcon()
-{
-    QPixmap pixmap(18, 18);
-    pixmap.fill(Qt::transparent);
-
-    QPainter painter(&pixmap);
-    painter.setRenderHint(QPainter::Antialiasing);
-    painter.setPen(QPen(QColor(208, 36, 36), 3, Qt::SolidLine, Qt::RoundCap));
-    painter.drawLine(5, 5, 13, 13);
-    painter.drawLine(13, 5, 5, 13);
-
-    return QIcon(pixmap);
-}
-
-QIcon makePlusIcon()
-{
-    QPixmap pixmap(18, 18);
-    pixmap.fill(Qt::transparent);
-
-    QPainter painter(&pixmap);
-    painter.setRenderHint(QPainter::Antialiasing);
-    painter.setPen(QPen(QColor(29, 132, 72), 3, Qt::SolidLine, Qt::RoundCap));
-    painter.drawLine(9, 4, 9, 14);
-    painter.drawLine(4, 9, 14, 9);
-
-    return QIcon(pixmap);
-}
-
-const QIcon& suppressIcon()
-{
-    static const QIcon icon = makeCrossIcon();
-    return icon;
-}
-
-const QIcon& restoreIcon()
-{
-    static const QIcon icon = makePlusIcon();
-    return icon;
-}
-
-QString buttonStyleSheet()
-{
-    return QStringLiteral(
-        "QToolButton {"
-        "  background-color: rgba(255, 255, 255, 215);"
-        "  border: 1px solid rgba(40, 40, 40, 120);"
-        "  border-radius: 11px;"
-        "  padding: 2px;"
-        "}"
-        "QToolButton:hover {"
-        "  background-color: rgba(255, 255, 255, 245);"
-        "}"
-        "QToolButton:pressed {"
-        "  background-color: rgba(232, 232, 232, 245);"
-        "}"
-    );
-}
-
-}  // namespace
 
 PatternInstanceControls::PatternInstanceControls(Gui::View3DInventorViewer* viewer, QObject* parent)
     : QObject(parent)
@@ -168,7 +101,7 @@ void PatternInstanceControls::setInstances(const std::vector<Instance>& instance
         button->setFixedSize(24, 24);
         button->setFocusPolicy(Qt::NoFocus);
         button->setIconSize(QSize(18, 18));
-        button->setStyleSheet(buttonStyleSheet());
+        button->setObjectName(QStringLiteral("overlayButton"));
 
         ButtonInfo info;
         info.instance = instance;
@@ -289,12 +222,12 @@ void PatternInstanceControls::updateButton(ButtonInfo& info) const
     }
 
     if (info.instance.suppressed) {
-        info.button->setIcon(restoreIcon());
+        info.button->setIcon(Gui::BitmapFactory().iconFromTheme("overlay-add"));
         info.button->setToolTip(tr("Restores this instance"));
         return;
     }
 
-    info.button->setIcon(suppressIcon());
+    info.button->setIcon(Gui::BitmapFactory().iconFromTheme("overlay-minus"));
     info.button->setToolTip(tr("Suppresses this instance"));
 }
 

--- a/src/Mod/Part/Gui/PatternInstanceControls.cpp
+++ b/src/Mod/Part/Gui/PatternInstanceControls.cpp
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/****************************************************************************
+ *   Copyright (c) 2026 Boyer Pierre-Louis <pierrelouis.boyer@gmail.com>    *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include "PatternInstanceControls.h"
+
+#include <Inventor/SbLinear.h>
+#include <Inventor/nodes/SoCamera.h>
+#include <Inventor/sensors/SoNodeSensor.h>
+
+#include <QColor>
+#include <QEvent>
+#include <QIcon>
+#include <QPainter>
+#include <QPen>
+#include <QPixmap>
+#include <QPoint>
+#include <QSize>
+#include <QTimer>
+#include <QToolButton>
+#include <QWidget>
+
+#include <Gui/View3DInventorViewer.h>
+#include <Gui/Utilities.h>
+
+using namespace PartGui;
+
+namespace
+{
+
+QIcon makeCrossIcon()
+{
+    QPixmap pixmap(18, 18);
+    pixmap.fill(Qt::transparent);
+
+    QPainter painter(&pixmap);
+    painter.setRenderHint(QPainter::Antialiasing);
+    painter.setPen(QPen(QColor(208, 36, 36), 3, Qt::SolidLine, Qt::RoundCap));
+    painter.drawLine(5, 5, 13, 13);
+    painter.drawLine(13, 5, 5, 13);
+
+    return QIcon(pixmap);
+}
+
+QIcon makePlusIcon()
+{
+    QPixmap pixmap(18, 18);
+    pixmap.fill(Qt::transparent);
+
+    QPainter painter(&pixmap);
+    painter.setRenderHint(QPainter::Antialiasing);
+    painter.setPen(QPen(QColor(29, 132, 72), 3, Qt::SolidLine, Qt::RoundCap));
+    painter.drawLine(9, 4, 9, 14);
+    painter.drawLine(4, 9, 14, 9);
+
+    return QIcon(pixmap);
+}
+
+const QIcon& suppressIcon()
+{
+    static const QIcon icon = makeCrossIcon();
+    return icon;
+}
+
+const QIcon& restoreIcon()
+{
+    static const QIcon icon = makePlusIcon();
+    return icon;
+}
+
+QString buttonStyleSheet()
+{
+    return QStringLiteral(
+        "QToolButton {"
+        "  background-color: rgba(255, 255, 255, 215);"
+        "  border: 1px solid rgba(40, 40, 40, 120);"
+        "  border-radius: 11px;"
+        "  padding: 2px;"
+        "}"
+        "QToolButton:hover {"
+        "  background-color: rgba(255, 255, 255, 245);"
+        "}"
+        "QToolButton:pressed {"
+        "  background-color: rgba(232, 232, 232, 245);"
+        "}"
+    );
+}
+
+}  // namespace
+
+PatternInstanceControls::PatternInstanceControls(Gui::View3DInventorViewer* viewer, QObject* parent)
+    : QObject(parent)
+{
+    setViewer(viewer);
+}
+
+PatternInstanceControls::~PatternInstanceControls()
+{
+    detachCameraSensor();
+    clear();
+    if (hostWidget) {
+        hostWidget->removeEventFilter(this);
+    }
+}
+
+void PatternInstanceControls::setViewer(Gui::View3DInventorViewer* newViewer)
+{
+    if (viewer.data() == newViewer) {
+        attachCameraSensor();
+        refreshHostWidget();
+        updatePositions();
+        return;
+    }
+
+    if (viewer) {
+        disconnect(viewer.data(), nullptr, this, nullptr);
+    }
+    detachCameraSensor();
+    if (hostWidget) {
+        hostWidget->removeEventFilter(this);
+        hostWidget = nullptr;
+    }
+
+    viewer = newViewer;
+    if (viewer) {
+        connect(viewer.data(), &Gui::View3DInventorViewer::cameraChanged, this, [this]() {
+            attachCameraSensor();
+            updatePositions();
+        });
+    }
+    attachCameraSensor();
+    refreshHostWidget();
+    updatePositions();
+}
+
+void PatternInstanceControls::setInstances(const std::vector<Instance>& instances)
+{
+    clear();
+    refreshHostWidget();
+    if (!viewer || !hostWidget) {
+        return;
+    }
+
+    buttons.reserve(instances.size());
+    for (const auto& instance : instances) {
+        auto* button = new QToolButton(hostWidget);
+        button->setAutoRaise(true);
+        button->setCursor(Qt::ArrowCursor);
+        button->setFixedSize(24, 24);
+        button->setFocusPolicy(Qt::NoFocus);
+        button->setIconSize(QSize(18, 18));
+        button->setStyleSheet(buttonStyleSheet());
+
+        ButtonInfo info;
+        info.instance = instance;
+        info.button = button;
+        updateButton(info);
+
+        connect(button, &QToolButton::clicked, this, [this, button]() {
+            for (const auto& info : buttons) {
+                if (info.button == button) {
+                    Q_EMIT toggleRequested(info.instance.index, !info.instance.suppressed);
+                    return;
+                }
+            }
+        });
+
+        buttons.push_back(info);
+        button->show();
+    }
+
+    updatePositions();
+    QTimer::singleShot(0, this, &PatternInstanceControls::updatePositions);
+}
+
+void PatternInstanceControls::clear()
+{
+    for (auto& info : buttons) {
+        if (info.button) {
+            info.button->hide();
+            info.button->deleteLater();
+        }
+    }
+    buttons.clear();
+}
+
+void PatternInstanceControls::updatePositions()
+{
+    refreshHostWidget();
+    if (!viewer || !hostWidget) {
+        return;
+    }
+
+    const QSize hostSize = hostWidget->size();
+    for (auto& info : buttons) {
+        if (!info.button) {
+            continue;
+        }
+
+        if (hostSize.isEmpty()) {
+            info.button->hide();
+            continue;
+        }
+
+        const QSize buttonSize = info.button->size();
+        QPoint pxCoord = viewer->toQPoint(
+            viewer->getPointOnViewport(Base::convertTo<SbVec3f>(info.instance.center))
+        );
+        if (hostWidget.data() != viewer.data()) {
+            pxCoord = viewer->mapTo(hostWidget.data(), pxCoord);
+        }
+
+        pxCoord.setX(pxCoord.x() - buttonSize.width() / 2);
+        pxCoord.setY(pxCoord.y() - buttonSize.height() / 2);
+
+        if (pxCoord.x() < 0 || pxCoord.y() < 0 || pxCoord.x() + buttonSize.width() > hostSize.width()
+            || pxCoord.y() + buttonSize.height() > hostSize.height()) {
+            info.button->hide();
+            continue;
+        }
+
+        info.button->move(pxCoord);
+        info.button->raise();
+        info.button->show();
+    }
+}
+
+bool PatternInstanceControls::eventFilter(QObject* watched, QEvent* event)
+{
+    if (watched == hostWidget.data()
+        && (event->type() == QEvent::Move || event->type() == QEvent::Resize
+            || event->type() == QEvent::Show)) {
+        QTimer::singleShot(0, this, &PatternInstanceControls::updatePositions);
+    }
+
+    return QObject::eventFilter(watched, event);
+}
+
+void PatternInstanceControls::refreshHostWidget()
+{
+    QWidget* newHostWidget = viewer ? viewer->parentWidget() : nullptr;
+    if (!newHostWidget && viewer) {
+        newHostWidget = viewer.data();
+    }
+
+    if (hostWidget == newHostWidget) {
+        return;
+    }
+
+    if (hostWidget) {
+        hostWidget->removeEventFilter(this);
+    }
+    hostWidget = newHostWidget;
+    if (hostWidget) {
+        hostWidget->installEventFilter(this);
+    }
+
+    for (auto& info : buttons) {
+        if (info.button) {
+            info.button->setParent(hostWidget.data());
+            info.button->setVisible(hostWidget.data() != nullptr);
+        }
+    }
+}
+
+void PatternInstanceControls::updateButton(ButtonInfo& info) const
+{
+    if (!info.button) {
+        return;
+    }
+
+    if (info.instance.suppressed) {
+        info.button->setIcon(restoreIcon());
+        info.button->setToolTip(tr("Restores this instance"));
+        return;
+    }
+
+    info.button->setIcon(suppressIcon());
+    info.button->setToolTip(tr("Suppresses this instance"));
+}
+
+void PatternInstanceControls::attachCameraSensor()
+{
+    if (!viewer || !viewer->getCamera()) {
+        if (cameraSensor) {
+            cameraSensor->detach();
+        }
+        return;
+    }
+
+    if (!cameraSensor) {
+        cameraSensor = new SoNodeSensor(&PatternInstanceControls::cameraSensorCallback, this);
+    }
+
+    cameraSensor->detach();
+    cameraSensor->attach(viewer->getCamera());
+}
+
+void PatternInstanceControls::detachCameraSensor()
+{
+    if (!cameraSensor) {
+        return;
+    }
+
+    cameraSensor->detach();
+    delete cameraSensor;
+    cameraSensor = nullptr;
+}
+
+void PatternInstanceControls::cameraSensorCallback(void* data, SoSensor* /*sensor*/)
+{
+    auto* controls = static_cast<PatternInstanceControls*>(data);
+    if (controls) {
+        controls->updatePositions();
+    }
+}

--- a/src/Mod/Part/Gui/PatternInstanceControls.h
+++ b/src/Mod/Part/Gui/PatternInstanceControls.h
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/****************************************************************************
+ *   Copyright (c) 2026 Boyer Pierre-Louis <pierrelouis.boyer@gmail.com>    *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#pragma once
+
+#include <vector>
+
+#include <QObject>
+#include <QPointer>
+
+#include <Base/Vector3D.h>
+#include <Mod/Part/PartGlobal.h>
+
+class QToolButton;
+class QWidget;
+class SoNodeSensor;
+class SoSensor;
+
+namespace Gui
+{
+class View3DInventorViewer;
+}
+
+namespace PartGui
+{
+
+class PartGuiExport PatternInstanceControls: public QObject
+{
+    Q_OBJECT
+
+public:
+    struct Instance
+    {
+        int index = -1;
+        Base::Vector3d center;
+        bool suppressed = false;
+    };
+
+    explicit PatternInstanceControls(Gui::View3DInventorViewer* viewer, QObject* parent = nullptr);
+    ~PatternInstanceControls() override;
+
+    void setViewer(Gui::View3DInventorViewer* viewer);
+    void setInstances(const std::vector<Instance>& instances);
+    void clear();
+
+public Q_SLOTS:
+    void updatePositions();
+
+Q_SIGNALS:
+    void toggleRequested(int index, bool suppress);
+
+protected:
+    bool eventFilter(QObject* watched, QEvent* event) override;
+
+private:
+    struct ButtonInfo
+    {
+        Instance instance;
+        QPointer<QToolButton> button;
+    };
+
+    void refreshHostWidget();
+    void updateButton(ButtonInfo& info) const;
+    void attachCameraSensor();
+    void detachCameraSensor();
+    static void cameraSensorCallback(void* data, SoSensor* sensor);
+
+    QPointer<Gui::View3DInventorViewer> viewer;
+    QPointer<QWidget> hostWidget;
+    SoNodeSensor* cameraSensor = nullptr;
+    std::vector<ButtonInfo> buttons;
+};
+
+}  // namespace PartGui


### PR DESCRIPTION
Add a reusable PatternInstanceControls widget for placing suppression buttons at pattern-instance positions in the 3D view. Track camera and viewport changes and emit toggle requests for the owning task panel to handle.

Part of #30840. Based directly on main; independent of the other open LinkArrays PRs. This adds the reusable component; task-panel integration remains in the later series. 