### PR TITLE
Fix hasher index leak

### DIFF
--- a/src/App/ComplexGeoData.h
+++ b/src/App/ComplexGeoData.h
@@ -62,6 +62,7 @@ enum class SearchOption: int
 {
     CheckGeometry = 1, ///< Whether to compare shape geometry
     SingleResult = 2, ///< Stop at first found result
+    AdaptiveTolerance = 4, ///< Widen the tolerance stepwise and accept only a unique match
 };
 
 typedef Base::Flags<SearchOption> SearchOptions;

--- a/src/App/IndexedName.cpp
+++ b/src/App/IndexedName.cpp
@@ -96,6 +96,7 @@ void IndexedName::set(const char* name,
     // NOLINTNEXTLINE cppcoreguidelines-pro-bounds-pointer-arithmetic
     if (std::any_of(name, name + suffixPosition, isInvalidChar)) {
         this->type = "";
+        this->index = 0;
         return;
     }
 

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -418,6 +418,21 @@ void PropertyLinkBase::restoreLabelReference(const DocumentObject* obj,
     subname = newSub + sub;
 }
 
+/// As a last-ditch effort at recovering otherwise-broken geometry, find the nearest geometric
+/// match. Note that there's still a tolerance window in this search so it will reject geometry that
+/// is too far away to possibly be the right match, but that's still a bit heuristic. At some point
+/// it's better to fail than to convince ourselves everything is "fine".
+static std::vector<std::string> rescueDriftedElement(const GeoFeature& geo, const char* element)
+{
+    auto names = geo.searchElementCache(element, Data::SearchOption::AdaptiveTolerance);
+    if (names.empty()) {
+        return {};
+    }
+    FC_WARN("recovered drifted element reference " << element << " -> " << names.front() << " in "
+                                                    << geo.getFullName());
+    return names;
+}
+
 bool PropertyLinkBase::_updateElementReference(DocumentObject* feature,
                                                App::DocumentObject* obj,
                                                std::string& sub,
@@ -481,6 +496,9 @@ bool PropertyLinkBase::_updateElementReference(DocumentObject* feature,
             if (names.empty()) {
                 // try floating point tolerance
                 names = geo->searchElementCache(oldElement, Data::SearchOptions());
+            }
+            if (names.empty() && missing) {
+                names = rescueDriftedElement(*geo, oldElement);
             }
             if (names.size()) {
                 missing = false;

--- a/src/Mod/Part/App/FeatureChamfer.cpp
+++ b/src/Mod/Part/App/FeatureChamfer.cpp
@@ -88,7 +88,7 @@ App::DocumentObjectExecReturn* Chamfer::execute()
             //            try {
             //                edge = baseTopoShape.getSubShape(ref.c_str());
             //            }catch(...){}
-            auto id = Data::MappedName(ref.c_str()).toIndexedName().getIndex();
+            auto id = Data::IndexedName(Data::oldElementName(ref.c_str()).c_str()).getIndex();
             const TopoDS_Edge& edge = TopoDS::Edge(mapOfEdges.FindKey(id));
             if (edge.IsNull()) {
                 return new App::DocumentObjectExecReturn("Invalid edge link");

--- a/src/Mod/Part/App/FeatureFillet.cpp
+++ b/src/Mod/Part/App/FeatureFillet.cpp
@@ -33,6 +33,7 @@
 #include <TopTools_IndexedMapOfShape.hxx>
 
 
+#include <App/ElementNamingUtils.h>
 #include <Base/Exception.h>
 
 #include "FeatureFillet.h"
@@ -96,7 +97,7 @@ App::DocumentObjectExecReturn* Fillet::execute()
             //            try {
             //                edge = baseTopoShape.getSubShape(ref.c_str());
             //            }catch(...){}
-            auto id = Data::MappedName(ref.c_str()).toIndexedName().getIndex();
+            auto id = Data::IndexedName(Data::oldElementName(ref.c_str()).c_str()).getIndex();
             const TopoDS_Edge& edge = TopoDS::Edge(mapOfEdges.FindKey(id));
 
             if (edge.IsNull()) {

--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -1564,6 +1564,51 @@ void Feature::onChanged(const App::Property* prop)
     GeoFeature::onChanged(prop);
 }
 
+/// Find the nearest match for an element that has "drifted" from its expected location. Still has
+/// a tolerance cap internally to prevent it from going totally off the rails: the element really
+/// might just be gone.
+static std::vector<std::string> searchDriftedElement(
+    const TopoShape& shape,
+    const TopoShape& element,
+    const double startTolerance
+)
+{
+    constexpr double relativeToleranceCap = 1e-3;
+    Bnd_Box bounds;
+    BRepBndLib::Add(element.getShape(), bounds);
+    const double absoluteToleranceCap = relativeToleranceCap * std::sqrt(bounds.SquareExtent());
+    if (absoluteToleranceCap < startTolerance) {
+        // For example, for a lone vertex we are going to just give up because there's no reasonable
+        // tolerance we can use.
+        return {};
+    }
+    double tolerance = startTolerance;
+    while (tolerance <= absoluteToleranceCap) {
+        std::vector<std::string> names;
+        shape.findSubShapesWithSharedVertex(element, &names, Data::SearchOptions(), tolerance);
+        if (names.size() == 1) {
+            return names;
+        }
+        if (names.size() > 1) {
+            // We overshot... as a tiebreaker, add in the actual geometry check
+            names.clear();
+            shape.findSubShapesWithSharedVertex(
+                element,
+                &names,
+                Data::SearchOption::CheckGeometry,
+                tolerance
+            );
+            if (names.size() == 1) {
+                return names;
+            }
+            return {};  // Womp womp. TODO: maybe try bisecting the tolerance??
+        }
+        constexpr double toleranceStep = 2.0;  // Double each time
+        tolerance *= toleranceStep;
+    }
+    return {};
+}
+
 const std::vector<std::string>& Feature::searchElementCache(
     const std::string& element,
     Data::SearchOptions options,
@@ -1589,8 +1634,13 @@ const std::vector<std::string>& Feature::searchElementCache(
                 break;
             }
         }
-        propShape->getShape()
-            .findSubShapesWithSharedVertex(it->second.shape, &it->second.names, options, tol, atol);
+        if (options.testFlag(Data::SearchOption::AdaptiveTolerance)) {
+            it->second.names = searchDriftedElement(propShape->getShape(), it->second.shape, tol);
+        }
+        else {
+            propShape->getShape()
+                .findSubShapesWithSharedVertex(it->second.shape, &it->second.names, options, tol, atol);
+        }
         if (!it->second.names.empty()) {
             it->second.searched = true;
         }


### PR DESCRIPTION
This started as a fix for just #29001, but in order to *really* fix it I had to expand a bit, and ended up fixing #29304 and #28851 as well.

The primary fix for #29001 -- or really, the fix for the bug that broke that file in the first place -- is the first commit. We were failing to reset index when the type was rejected. Of course, it also turned out that two other places in the code only worked because they accidentally relied on that bug, so those have to get fixed up as well.

The second commit implements a last-ditch geometry search attempt if the main fallback search fails. This is "last ditch" in the sense that we only execute it in the case of a terminally broken geometry: basically we slowly start relaxing the search tolerance until we find a match, or hit a hard cap on how large we'll let tolerance get. This is the change that allows us to actually *recover* the broken file in #29001, and ends up fixing #29304 and #28851 along the way.

Fixes #29001
Fixes #29304 
Fixes #28851 

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

ETA: I note that this passes the full 8k file integration test suite with no regressions (though also no additional fixes).
