### PR TITLE
Start: Use the same algorithm for recents as menu

### DIFF
--- a/src/Mod/Start/App/DisplayedFilesModel.cpp
+++ b/src/Mod/Start/App/DisplayedFilesModel.cpp
@@ -149,14 +149,22 @@ static std::size_t indexOfFile(const std::vector<FileStats>& fileInfoCache, cons
     return std::distance(fileInfoCache.begin(), it);
 }
 
+/// Should we show this file? Don't show files that no longer exist, or that FreeCAD can't open.
+static bool shouldShow(const QFileInfo& qfi)
+{
+    if (!qfi.exists()) {
+        return false;
+    }
+    if (!freecadCanOpen(qfi.suffix())) {
+        return false;
+    }
+    return true;
+}
+
 void DisplayedFilesModel::addFile(const QString& filePath)
 {
     const QFileInfo qfi(filePath);
-    if (!qfi.isReadable()) {
-        return;
-    }
-
-    if (!freecadCanOpen(qfi.suffix())) {
+    if (!shouldShow(qfi)) {
         return;
     }
 
@@ -195,10 +203,7 @@ void DisplayedFilesModel::addFile(const QString& filePath)
 void DisplayedFilesModel::modifiedFile(const QString& filePath)
 {
     const QFileInfo qfi(filePath);
-    if (!qfi.isReadable()) {
-        return;
-    }
-    if (!freecadCanOpen(qfi.suffix())) {
+    if (!shouldShow(qfi)) {
         return;
     }
 

--- a/src/Mod/Start/App/RecentFilesModel.cpp
+++ b/src/Mod/Start/App/RecentFilesModel.cpp
@@ -39,10 +39,12 @@ void RecentFilesModel::loadRecentFiles()
 {
     beginResetModel();
     clear();
-    auto numRows {_parameterGroup->GetInt("RecentFiles", 0)};
-    for (int i = 0; i < numRows; ++i) {
-        auto entry = fmt::format("MRU{}", i);
-        auto path = _parameterGroup->GetASCII(entry.c_str(), "");
+    const auto maxRows {_parameterGroup->GetInt("RecentFiles", 0)};  // really like "MaxRecentFiles"
+    for (const auto& path : _parameterGroup->GetASCIIs("MRU")) {
+        if (rowCount() >= maxRows) {
+            // Really shouldn't ever happen -- something got corrupted
+            break;
+        }
         addFile(QString::fromStdString(path));
     }
     endResetModel();


### PR DESCRIPTION
The algorithms used to display the recent files in the menu and in Start were subtly different. This *might* have been the cause of #31539. At any rate, there's no harm in unifying them. To test, just verify that the Recent Files list in the Start Page is what you expect it to be.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

