### PR TITLE
Start: Fix card wrap calculation

### DIFF
--- a/src/Mod/Start/Gui/FileCardView.cpp
+++ b/src/Mod/Start/Gui/FileCardView.cpp
@@ -23,6 +23,10 @@
 
 #include "FileCardView.h"
 
+#include <QScrollBar>
+#include <QStyle>
+#include <QStyleOption>
+
 #include <App/Application.h>
 #include "../App/DisplayedFilesModel.h"
 #include <algorithm>
@@ -52,6 +56,22 @@ FileCardView::FileCardView(QWidget* parent)
     setSpacing(m_cardSpacing);
 }
 
+// Mirrors the layout bounds reduction in QListViewPrivate::prepareItemsLayout
+int FileCardView::reservedScrollBarWidth() const
+{
+    const auto* scrollBar = verticalScrollBar();
+    if (style()->pixelMetric(QStyle::PM_ScrollView_ScrollBarOverlap, nullptr, scrollBar) != 0) {
+        return 0;
+    }
+    int frameAroundContents = 0;
+    if (style()->styleHint(QStyle::SH_ScrollView_FrameOnlyAroundContents) != 0) {
+        QStyleOption option;
+        option.initFrom(this);
+        frameAroundContents = 2 * style()->pixelMetric(QStyle::PM_DefaultFrameWidth, &option);
+    }
+    return style()->pixelMetric(QStyle::PM_ScrollBarExtent, nullptr, scrollBar) + frameAroundContents;
+}
+
 int FileCardView::heightForWidth(int width) const
 {
     auto model = this->model();
@@ -61,7 +81,9 @@ int FileCardView::heightForWidth(int width) const
     }
     int numCards = model->rowCount();
     auto cardSize = delegate->sizeHint(QStyleOptionViewItem(), model->index(0, 0));
-    int cardsPerRow = std::max(1, static_cast<int>(width / (cardSize.width() + m_cardSpacing)));
+    // Each row starts after one spacing; the card pitch is cardWidth + spacing
+    const int usableWidth = width - 2 * frameWidth() - reservedScrollBarWidth() - m_cardSpacing;
+    const int cardsPerRow = std::max(1, usableWidth / (cardSize.width() + m_cardSpacing));
     int numRows = static_cast<int>(
         ceil(static_cast<double>(numCards) / static_cast<double>(cardsPerRow))
     );

--- a/src/Mod/Start/Gui/FileCardView.h
+++ b/src/Mod/Start/Gui/FileCardView.h
@@ -40,6 +40,8 @@ public:
     QSize sizeHint() const override;
 
 private:
+    int reservedScrollBarWidth() const;
+
     int m_cardSpacing;
 };
 


### PR DESCRIPTION
There is a small spacing bug in Start that results in our FileCardView widget calculating that it needs one fewer row than Qt thinks it needs in order to display all the cards. This ends up with Qt adding a scroll bar to let you access the bottom row of cards, when you have the window sized such that the bottom row is almost, but not completely, filled.

Note that for that `reservedScrollbarWidth()` helper function I went [straight to the source](https://code.qt.io/cgit/qt/qtbase.git/tree/src/widgets/itemviews/qlistview.cpp#n1670) (quite literally) and looked exactly how Qt is calculating the width of that view. I didn't know of any other way to ensure that I was handling all the weird edge cases in the various window managers. It's probably overkill, but this way I didn't really have to understand what all it was doing :).

To test, I suggest setting Start to show some folder with a lot of files in it. Scroll to the bottom row of that display area and resize the window width until there's just one card slot open: in main, a second scrollbar will appear allowing you access to that bottom row. With this PR, there's no need for that extra scrollbar, because we've calculated the same card layout that Qt has.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.