### PR TITLE
LinkArrays: add path link arrays

### DIFF
--- a/src/Mod/Part/App/AppPart.cpp
+++ b/src/Mod/Part/App/AppPart.cpp
@@ -100,6 +100,7 @@
 #include "LinkArray.h"
 #include "LinkArrayCircular.h"
 #include "LinkArrayLinear.h"
+#include "LinkArrayPath.h"
 #include "PolarPatternExtension.h"
 #include "PathPatternExtension.h"
 #include "Geometry.h"
@@ -463,6 +464,7 @@ PyMOD_INIT_FUNC(Part)
     Part::LinkArray             ::init();
     Part::LinkArrayCircular     ::init();
     Part::LinkArrayLinear       ::init();
+    Part::LinkArrayPath         ::init();
 
     Part::Feature               ::init();
     Part::FeatureExt            ::init();

--- a/src/Mod/Part/App/CMakeLists.txt
+++ b/src/Mod/Part/App/CMakeLists.txt
@@ -223,6 +223,8 @@ SET(Features_SRCS
     LinkArrayCircular.h
     LinkArrayLinear.cpp
     LinkArrayLinear.h
+    LinkArrayPath.cpp
+    LinkArrayPath.h
     PolarPatternExtension.cpp
     PolarPatternExtension.h
     PathPatternExtension.cpp

--- a/src/Mod/Part/App/LinkArrayPath.cpp
+++ b/src/Mod/Part/App/LinkArrayPath.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "LinkArrayPath.h"
+
+using namespace Part;
+
+PROPERTY_SOURCE_WITH_EXTENSIONS(Part::LinkArrayPath, Part::LinkArray)
+
+LinkArrayPath::LinkArrayPath()
+{
+    Part::PathPatternExtension::initExtension(this);
+    setPathLinkScope();
+}
+
+void LinkArrayPath::onDocumentRestored()
+{
+    inherited::onDocumentRestored();
+    setPathLinkScope();
+}
+
+std::vector<Base::Placement> LinkArrayPath::getElementPlacements()
+{
+    return placementsFromTransforms(calculateTransformations(false));
+}
+
+void LinkArrayPath::setPathLinkScope()
+{
+    Path.setScope(App::LinkScope::Global);
+}

--- a/src/Mod/Part/App/LinkArrayPath.h
+++ b/src/Mod/Part/App/LinkArrayPath.h
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include "LinkArray.h"
+#include "PathPatternExtension.h"
+
+namespace Part
+{
+
+class PartExport LinkArrayPath: public Part::LinkArray, public Part::PathPatternExtension
+{
+    PROPERTY_HEADER_WITH_EXTENSIONS(Part::LinkArrayPath);
+    using inherited = Part::LinkArray;
+
+public:
+    LinkArrayPath();
+    void onDocumentRestored() override;
+
+protected:
+    std::vector<Base::Placement> getElementPlacements() override;
+
+private:
+    void setPathLinkScope();
+};
+
+}  // namespace Part

--- a/src/Mod/Part/CMakeLists.txt
+++ b/src/Mod/Part/CMakeLists.txt
@@ -85,6 +85,7 @@ set(Part_tests
     parttests/TestTangentMode3-0.21.FCStd
     parttests/TestLinkArrayCircular.py
     parttests/TestLinkArrayLinear.py
+    parttests/TestLinkArrayPath.py
     parttests/TestPartMirror.py
     parttests/TestFaceMakerUnifiedPlanar.py
     parttests/TestFaceMakerUnifiedNonPlanar.py

--- a/src/Mod/Part/TestPartApp.py
+++ b/src/Mod/Part/TestPartApp.py
@@ -38,6 +38,7 @@ from parttests.TopoShapeListTest import TopoShapeListTest
 from parttests.TopoShapeTest import TopoShapeTest
 from parttests.TestLinkArrayCircular import TestLinkArrayCircular
 from parttests.TestLinkArrayLinear import TestLinkArrayLinear
+from parttests.TestLinkArrayPath import TestLinkArrayPath
 from parttests.TestPartMirror import TestPartMirroringRegression
 from parttests.TestFaceMakerUnifiedPlanar import *
 from parttests.TestFaceMakerUnifiedNonPlanar import *

--- a/src/Mod/Part/parttests/TestLinkArrayPath.py
+++ b/src/Mod/Part/parttests/TestLinkArrayPath.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+import FreeCAD as App
+import Part
+
+
+class TestLinkArrayPath(unittest.TestCase):
+    def setUp(self):
+        self.doc = App.newDocument("TestLinkArrayPath")
+        source = self.doc.addObject("Part::Box", "Source")
+        source.Length = 2
+        source.Width = 2
+        source.Height = 2
+        self.path = self.doc.addObject("Part::Feature", "Path")
+        self.path.Shape = Part.makePolygon(
+            [App.Vector(0, 0, 0), App.Vector(10, 0, 0), App.Vector(10, 10, 0)]
+        )
+        self.array = self.doc.addObject("Part::LinkArrayPath", "Array")
+        self.array.LinkedObject = source
+        self.array.ShowElement = False
+        self.array.Path = (self.path, ["Edge1", "Edge2"])
+
+    def tearDown(self):
+        App.closeDocument(self.doc.Name)
+
+    def testFixedCountFollowsConnectedEdges(self):
+        self.assertEqual(self.array.getTypeIdOfProperty("StartOffset"), "App::PropertyLength")
+        self.assertEqual(self.array.getTypeIdOfProperty("EndOffset"), "App::PropertyLength")
+        self.array.Count = 5
+        self.doc.recompute()
+
+        self.assertEqual(self.array.getStatusString(), "Valid")
+        self.assertEqual(self.array.ElementCount, 5)
+        expected = [
+            App.Vector(0, 0, 0),
+            App.Vector(5, 0, 0),
+            App.Vector(10, 0, 0),
+            App.Vector(10, 5, 0),
+            App.Vector(10, 10, 0),
+        ]
+        for placement, point in zip(self.array.PlacementList, expected):
+            self.assertLess((placement.Base - point).Length, 1e-7)
+
+    def testFixedSpacingAndOffsets(self):
+        self.array.SpacingMode = "Fixed spacing"
+        self.array.Spacing = 4
+        self.array.StartOffset = 2
+        self.array.EndOffset = 3
+        self.doc.recompute()
+
+        self.assertEqual(self.array.getStatusString(), "Valid")
+        self.assertEqual(self.array.ElementCount, 4)
+        expected = [
+            App.Vector(2, 0, 0),
+            App.Vector(6, 0, 0),
+            App.Vector(10, 0, 0),
+            App.Vector(10, 4, 0),
+        ]
+        for placement, point in zip(self.array.PlacementList, expected):
+            self.assertLess((placement.Base - point).Length, 1e-7)
+
+    def testReversePath(self):
+        self.array.Count = 3
+        self.array.ReversePath = True
+        self.doc.recompute()
+
+        self.assertEqual(self.array.getStatusString(), "Valid")
+        expected = [
+            App.Vector(10, 10, 0),
+            App.Vector(10, 0, 0),
+            App.Vector(0, 0, 0),
+        ]
+        for placement, point in zip(self.array.PlacementList, expected):
+            self.assertLess((placement.Base - point).Length, 1e-7)
+
+    def testAlignFollowsPathTangent(self):
+        self.array.Count = 3
+        self.array.Align = True
+        self.doc.recompute()
+
+        self.assertEqual(self.array.getStatusString(), "Valid")
+        direction = self.array.PlacementList[-1].Rotation.multVec(App.Vector(1, 0, 0))
+        self.assertLess((direction - App.Vector(0, 1, 0)).Length, 1e-7)
+
+    def testReverseAndAlignFollowPathTogether(self):
+        self.array.Count = 3
+        self.array.ReversePath = True
+        self.array.Align = True
+        self.doc.recompute()
+
+        self.assertEqual(self.array.getStatusString(), "Valid")
+        expected = [
+            App.Vector(10, 10, 0),
+            App.Vector(10, 0, 0),
+            App.Vector(0, 0, 0),
+        ]
+        for placement, point in zip(self.array.PlacementList, expected):
+            self.assertLess((placement.Base - point).Length, 1e-7)
+
+    def testUnsetPathIsSilent(self):
+        self.array.Path = None
+        self.doc.recompute()
+
+        self.assertEqual(self.array.getStatusString(), "Valid")


### PR DESCRIPTION
Add Part::LinkArrayPath using the merged path pattern extension. Generate linked instances along connected edges, with fixed count or spacing, offsets, reversed traversal and tangent alignment.

Part of #30840. Based directly on main after #32570; independently mergeable. This adds the core object and tests; task-panel integration comes later. 168 added lines.

Validation: MSVC C++20 syntax checks passed for LinkArrayPath.cpp and AppPart.cpp. All six regression tests passed in a temporary native harness compiling this branch’s path array and extension against the existing local runtime. This is focused validation, not a full rebuild. Tests are in parttests.TestLinkArrayPath.

Prepared with assistance from OpenAI Codex.