### PR TITLE
LinkArrays: add the circular pattern parameter widget

### DIFF
--- a/src/Mod/Part/Gui/CMakeLists.txt
+++ b/src/Mod/Part/Gui/CMakeLists.txt
@@ -56,6 +56,7 @@ set(PartGui_UIC_SRCS
     DlgSettingsObjectColor.ui
     DlgProjectionOnSurface.ui
     PatternParametersWidget.ui
+    PatternCircularParametersWidget.ui
     SectionCutting.ui
     ShapeFromMesh.ui
     TaskFaceAppearances.ui
@@ -142,6 +143,9 @@ SET(PartGui_SRCS
     DlgProjectionOnSurface.cpp
     DlgProjectionOnSurface.h
     DlgProjectionOnSurface.ui
+    PatternCircularParametersWidget.cpp
+    PatternCircularParametersWidget.h
+    PatternCircularParametersWidget.ui
     PatternParametersWidget.cpp
     PatternParametersWidget.h
     PatternParametersWidget.ui

--- a/src/Mod/Part/Gui/PatternCircularParametersWidget.cpp
+++ b/src/Mod/Part/Gui/PatternCircularParametersWidget.cpp
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "PatternCircularParametersWidget.h"
+
+#include <QSignalBlocker>
+
+#include <Base/Tools.h>
+#include <Gui/QuantitySpinBox.h>
+#include <Gui/SpinBox.h>
+
+#include "ui_PatternCircularParametersWidget.h"
+
+using namespace PartGui;
+
+PatternCircularParametersWidget::PatternCircularParametersWidget(QWidget* parent)
+    : PatternReferenceWidget(parent)
+    , ui(new Ui_PatternCircularParametersWidget)
+{
+    ui->setupUi(this);
+    setupReferenceCombo(ui->axisCombo);
+
+    connect(
+        ui->radialDistance,
+        qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
+        this,
+        &PatternCircularParametersWidget::onRadialDistanceChanged
+    );
+    connect(
+        ui->tangentialDistance,
+        qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
+        this,
+        &PatternCircularParametersWidget::onTangentialDistanceChanged
+    );
+    connect(
+        ui->numberCircles,
+        &Gui::UIntSpinBox::unsignedChanged,
+        this,
+        &PatternCircularParametersWidget::onNumberCirclesChanged
+    );
+    connect(
+        ui->symmetry,
+        &Gui::UIntSpinBox::unsignedChanged,
+        this,
+        &PatternCircularParametersWidget::onSymmetryChanged
+    );
+}
+
+PatternCircularParametersWidget::~PatternCircularParametersWidget() = default;
+
+void PatternCircularParametersWidget::bindProperties(
+    App::PropertyLinkSub* axis,
+    App::PropertyLength* radialDistance,
+    App::PropertyLength* tangentialDistance,
+    App::PropertyIntegerConstraint* numberCircles,
+    App::PropertyIntegerConstraint* symmetry
+)
+{
+    bindReference(axis);
+    radialDistanceProperty = radialDistance;
+    tangentialDistanceProperty = tangentialDistance;
+    numberCirclesProperty = numberCircles;
+    symmetryProperty = symmetry;
+
+    {
+        const QSignalBlocker radialBlocker(ui->radialDistance);
+        const QSignalBlocker tangentialBlocker(ui->tangentialDistance);
+        const QSignalBlocker circleCountBlocker(ui->numberCircles);
+        const QSignalBlocker symmetryBlocker(ui->symmetry);
+        ui->radialDistance->setUnit(Base::Unit::Length);
+        ui->tangentialDistance->setUnit(Base::Unit::Length);
+        ui->radialDistance->bind(*radialDistanceProperty);
+        ui->tangentialDistance->bind(*tangentialDistanceProperty);
+        ui->numberCircles->setRange(
+            numberCirclesProperty->getMinimum(),
+            numberCirclesProperty->getMaximum()
+        );
+        ui->symmetry->setRange(symmetryProperty->getMinimum(), symmetryProperty->getMaximum());
+        ui->numberCircles->bind(*numberCirclesProperty);
+        ui->symmetry->bind(*symmetryProperty);
+    }
+
+    updateUI();
+}
+
+void PatternCircularParametersWidget::updateUI()
+{
+    if (blockUpdate || !radialDistanceProperty) {
+        return;
+    }
+
+    Base::StateLocker locker(blockUpdate, true);
+    updateReferenceUI();
+    ui->radialDistance->setValue(radialDistanceProperty->getValue());
+    ui->tangentialDistance->setValue(tangentialDistanceProperty->getValue());
+    ui->numberCircles->setValue(numberCirclesProperty->getValue());
+    ui->symmetry->setValue(symmetryProperty->getValue());
+}
+
+void PatternCircularParametersWidget::applyQuantitySpinboxes() const
+{
+    ui->radialDistance->apply();
+    ui->tangentialDistance->apply();
+    ui->numberCircles->apply();
+    ui->symmetry->apply();
+}
+
+void PatternCircularParametersWidget::onRadialDistanceChanged(double value)
+{
+    if (blockUpdate || !radialDistanceProperty) {
+        return;
+    }
+    radialDistanceProperty->setValue(value);
+    Q_EMIT parametersChanged();
+}
+
+void PatternCircularParametersWidget::onTangentialDistanceChanged(double value)
+{
+    if (blockUpdate || !tangentialDistanceProperty) {
+        return;
+    }
+    tangentialDistanceProperty->setValue(value);
+    Q_EMIT parametersChanged();
+}
+
+void PatternCircularParametersWidget::onNumberCirclesChanged(unsigned value)
+{
+    if (blockUpdate || !numberCirclesProperty) {
+        return;
+    }
+    numberCirclesProperty->setValue(value);
+    Q_EMIT parametersChanged();
+}
+
+void PatternCircularParametersWidget::onSymmetryChanged(unsigned value)
+{
+    if (blockUpdate || !symmetryProperty) {
+        return;
+    }
+    symmetryProperty->setValue(value);
+    Q_EMIT parametersChanged();
+}

--- a/src/Mod/Part/Gui/PatternCircularParametersWidget.h
+++ b/src/Mod/Part/Gui/PatternCircularParametersWidget.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <memory>
+
+#include <App/PropertyStandard.h>
+#include <App/PropertyUnits.h>
+#include <Mod/Part/PartGlobal.h>
+
+#include "PatternReferenceWidget.h"
+
+namespace PartGui
+{
+
+class Ui_PatternCircularParametersWidget;
+
+class PartGuiExport PatternCircularParametersWidget: public PatternReferenceWidget
+{
+    Q_OBJECT
+
+public:
+    explicit PatternCircularParametersWidget(QWidget* parent = nullptr);
+    ~PatternCircularParametersWidget() override;
+
+    void bindProperties(
+        App::PropertyLinkSub* axis,
+        App::PropertyLength* radialDistance,
+        App::PropertyLength* tangentialDistance,
+        App::PropertyIntegerConstraint* numberCircles,
+        App::PropertyIntegerConstraint* symmetry
+    );
+    void updateUI();
+    void applyQuantitySpinboxes() const;
+
+private:
+    void onRadialDistanceChanged(double value);
+    void onTangentialDistanceChanged(double value);
+    void onNumberCirclesChanged(unsigned value);
+    void onSymmetryChanged(unsigned value);
+
+    std::unique_ptr<Ui_PatternCircularParametersWidget> ui;
+    App::PropertyLength* radialDistanceProperty = nullptr;
+    App::PropertyLength* tangentialDistanceProperty = nullptr;
+    App::PropertyIntegerConstraint* numberCirclesProperty = nullptr;
+    App::PropertyIntegerConstraint* symmetryProperty = nullptr;
+    bool blockUpdate = false;
+};
+
+}  // namespace PartGui

--- a/src/Mod/Part/Gui/PatternCircularParametersWidget.ui
+++ b/src/Mod/Part/Gui/PatternCircularParametersWidget.ui
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PartGui::PatternCircularParametersWidget</class>
+ <widget class="QWidget" name="PartGui::PatternCircularParametersWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>270</width>
+    <height>180</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Circular Pattern</string>
+     </property>
+     <layout class="QFormLayout" name="formLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="axisLabel">
+        <property name="text">
+         <string>Axis</string>
+        </property>
+        <property name="buddy">
+         <cstring>axisCombo</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="axisCombo"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="radialDistanceLabel">
+        <property name="text">
+         <string>Radial distance</string>
+        </property>
+        <property name="buddy">
+         <cstring>radialDistance</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::QuantitySpinBox" name="radialDistance" native="true">
+        <property name="keyboardTracking" stdset="0">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="tangentialDistanceLabel">
+        <property name="text">
+         <string>Tangential distance</string>
+        </property>
+        <property name="buddy">
+         <cstring>tangentialDistance</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::QuantitySpinBox" name="tangentialDistance" native="true">
+        <property name="keyboardTracking" stdset="0">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="numberCirclesLabel">
+        <property name="text">
+         <string>Concentric circles</string>
+        </property>
+        <property name="buddy">
+         <cstring>numberCircles</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::UIntSpinBox" name="numberCircles"/>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="symmetryLabel">
+        <property name="text">
+         <string>Symmetry</string>
+        </property>
+        <property name="buddy">
+         <cstring>symmetry</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="Gui::UIntSpinBox" name="symmetry"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::UIntSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>Gui/SpinBox.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Add a shared circular-pattern parameter widget for axis selection, radial and tangential spacing, circle count and symmetry. It uses the reference widget merged in #32580.

Part of #30840. Based directly on main and independent of the other open LinkArrays PRs. This is a reusable editor component; task-panel wiring and user-facing commands are separate later commits. It does not add a new command by itself. 319 added lines.

Validation: generated fresh Qt UI and meta-object code from this branch, then passed MSVC C++20 syntax checks for the widget and meta-object source. Interactive behavior and a full rebuild were not tested.

Prepared with assistance from OpenAI Codex.