### PR TITLE
LinkArrays: add the path pattern parameter widget

### DIFF
--- a/src/Mod/Part/Gui/CMakeLists.txt
+++ b/src/Mod/Part/Gui/CMakeLists.txt
@@ -58,6 +58,7 @@ set(PartGui_UIC_SRCS
     PatternParametersWidget.ui
     PatternCircularParametersWidget.ui
     PatternPointParametersWidget.ui
+    PatternPathParametersWidget.ui
     SectionCutting.ui
     ShapeFromMesh.ui
     TaskFaceAppearances.ui
@@ -150,6 +151,9 @@ SET(PartGui_SRCS
     PatternPointParametersWidget.cpp
     PatternPointParametersWidget.h
     PatternPointParametersWidget.ui
+    PatternPathParametersWidget.cpp
+    PatternPathParametersWidget.h
+    PatternPathParametersWidget.ui
     PatternParametersWidget.cpp
     PatternParametersWidget.h
     PatternParametersWidget.ui

--- a/src/Mod/Part/Gui/PatternPathParametersWidget.cpp
+++ b/src/Mod/Part/Gui/PatternPathParametersWidget.cpp
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "PatternPathParametersWidget.h"
+
+#include <QComboBox>
+#include <QPushButton>
+#include <QSignalBlocker>
+
+#include <App/DocumentObject.h>
+#include <Base/Tools.h>
+#include <Gui/QuantitySpinBox.h>
+#include <Gui/SpinBox.h>
+
+#include "ui_PatternPathParametersWidget.h"
+
+using namespace PartGui;
+
+PatternPathParametersWidget::PatternPathParametersWidget(QWidget* parent)
+    : PatternReferenceWidget(parent)
+    , ui(new Ui_PatternPathParametersWidget)
+{
+    ui->setupUi(this);
+    connect(ui->pathButton, &QPushButton::clicked, this, [this]() {
+        Q_EMIT requestReferenceSelection();
+    });
+
+    connect(ui->count, &Gui::UIntSpinBox::unsignedChanged, this, [this](unsigned value) {
+        if (!blockUpdate && countProperty) {
+            countProperty->setValue(value);
+            Q_EMIT parametersChanged();
+        }
+    });
+    connect(ui->spacingMode, qOverload<int>(&QComboBox::activated), this, [this](int value) {
+        if (!blockUpdate && spacingModeProperty) {
+            spacingModeProperty->setValue(value);
+            updateVisibility();
+            Q_EMIT parametersChanged();
+        }
+    });
+    const auto quantityChanged = [this](App::PropertyLength* property, double value) {
+        if (!blockUpdate && property) {
+            property->setValue(value);
+            Q_EMIT parametersChanged();
+        }
+    };
+    connect(
+        ui->spacing,
+        qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
+        this,
+        [this, quantityChanged](double value) { quantityChanged(spacingProperty, value); }
+    );
+    connect(
+        ui->startOffset,
+        qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
+        this,
+        [this, quantityChanged](double value) { quantityChanged(startOffsetProperty, value); }
+    );
+    connect(
+        ui->endOffset,
+        qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
+        this,
+        [this, quantityChanged](double value) { quantityChanged(endOffsetProperty, value); }
+    );
+    connect(ui->reversePath, &QCheckBox::toggled, this, [this](bool value) {
+        if (!blockUpdate && reversePathProperty) {
+            reversePathProperty->setValue(value);
+            Q_EMIT parametersChanged();
+        }
+    });
+    connect(ui->align, &QCheckBox::toggled, this, [this](bool value) {
+        if (!blockUpdate && alignProperty) {
+            alignProperty->setValue(value);
+            Q_EMIT parametersChanged();
+        }
+    });
+}
+
+PatternPathParametersWidget::~PatternPathParametersWidget() = default;
+
+void PatternPathParametersWidget::bindProperties(
+    App::PropertyLinkSub* path,
+    App::PropertyIntegerConstraint* count,
+    App::PropertyEnumeration* spacingMode,
+    App::PropertyLength* spacing,
+    App::PropertyLength* startOffset,
+    App::PropertyLength* endOffset,
+    App::PropertyBool* reversePath,
+    App::PropertyBool* align
+)
+{
+    pathProperty = path;
+    countProperty = count;
+    spacingModeProperty = spacingMode;
+    spacingProperty = spacing;
+    startOffsetProperty = startOffset;
+    endOffsetProperty = endOffset;
+    reversePathProperty = reversePath;
+    alignProperty = align;
+
+    {
+        const QSignalBlocker countBlocker(ui->count);
+        const QSignalBlocker spacingBlocker(ui->spacing);
+        const QSignalBlocker startOffsetBlocker(ui->startOffset);
+        const QSignalBlocker endOffsetBlocker(ui->endOffset);
+        ui->count->setRange(countProperty->getMinimum(), countProperty->getMaximum());
+        ui->count->bind(*countProperty);
+        ui->spacing->bind(*spacingProperty);
+        ui->startOffset->bind(*startOffsetProperty);
+        ui->endOffset->bind(*endOffsetProperty);
+    }
+    ui->spacingMode->addItems({tr("Fixed count"), tr("Fixed spacing"), tr("Fixed count and spacing")});
+    updateUI();
+}
+
+void PatternPathParametersWidget::updateUI()
+{
+    if (blockUpdate || !countProperty) {
+        return;
+    }
+    Base::StateLocker locker(blockUpdate, true);
+    updatePathButton();
+    ui->count->setValue(countProperty->getValue());
+    ui->spacingMode->setCurrentIndex(spacingModeProperty->getValue());
+    ui->spacing->setValue(spacingProperty->getValue());
+    ui->startOffset->setValue(startOffsetProperty->getValue());
+    ui->endOffset->setValue(endOffsetProperty->getValue());
+    ui->reversePath->setChecked(reversePathProperty->getValue());
+    ui->align->setChecked(alignProperty->getValue());
+    updateVisibility();
+}
+
+void PatternPathParametersWidget::getPath(
+    App::DocumentObject*& object,
+    std::vector<std::string>& subnames
+) const
+{
+    object = pathProperty ? pathProperty->getValue() : nullptr;
+    subnames = pathProperty ? pathProperty->getSubValues() : std::vector<std::string>();
+}
+
+void PatternPathParametersWidget::updatePathButton()
+{
+    if (!pathProperty || !pathProperty->getValue()) {
+        ui->pathButton->setText(tr("Select Path"));
+        return;
+    }
+
+    QString text = QString::fromUtf8(pathProperty->getValue()->Label.getValue());
+    if (text.isEmpty()) {
+        text = QString::fromLatin1(pathProperty->getValue()->getNameInDocument());
+    }
+    const auto subnames = pathProperty->getSubValues();
+    if (!subnames.empty()) {
+        text += QStringLiteral(" : %1").arg(QString::fromStdString(subnames.front()));
+        if (subnames.size() > 1) {
+            text += QStringLiteral(" ") + tr("(+%1)").arg(subnames.size() - 1);
+        }
+    }
+    ui->pathButton->setText(text);
+}
+
+void PatternPathParametersWidget::applyQuantitySpinboxes() const
+{
+    ui->count->apply();
+    ui->spacing->apply();
+    ui->startOffset->apply();
+    ui->endOffset->apply();
+}
+
+void PatternPathParametersWidget::updateVisibility()
+{
+    const int mode = ui->spacingMode->currentIndex();
+    ui->countLabel->setVisible(mode != 1);
+    ui->count->setVisible(mode != 1);
+    ui->spacingLabel->setVisible(mode != 0);
+    ui->spacing->setVisible(mode != 0);
+}

--- a/src/Mod/Part/Gui/PatternPathParametersWidget.cpp
+++ b/src/Mod/Part/Gui/PatternPathParametersWidget.cpp
@@ -10,6 +10,7 @@
 #include <Base/Tools.h>
 #include <Gui/QuantitySpinBox.h>
 #include <Gui/SpinBox.h>
+#include <Mod/Part/App/PathPatternExtension.h>
 
 #include "ui_PatternPathParametersWidget.h"
 
@@ -169,9 +170,9 @@ void PatternPathParametersWidget::applyQuantitySpinboxes() const
 
 void PatternPathParametersWidget::updateVisibility()
 {
-    const int mode = ui->spacingMode->currentIndex();
-    ui->countLabel->setVisible(mode != 1);
-    ui->count->setVisible(mode != 1);
-    ui->spacingLabel->setVisible(mode != 0);
-    ui->spacing->setVisible(mode != 0);
+    const auto mode = static_cast<Part::PathPatternSpacingMode>(ui->spacingMode->currentIndex());
+    ui->countLabel->setVisible(mode != Part::PathPatternSpacingMode::FixedSpacing);
+    ui->count->setVisible(mode != Part::PathPatternSpacingMode::FixedSpacing);
+    ui->spacingLabel->setVisible(mode != Part::PathPatternSpacingMode::FixedCount);
+    ui->spacing->setVisible(mode != Part::PathPatternSpacingMode::FixedCount);
 }

--- a/src/Mod/Part/Gui/PatternPathParametersWidget.h
+++ b/src/Mod/Part/Gui/PatternPathParametersWidget.h
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <memory>
+
+#include <App/PropertyGeo.h>
+#include <App/PropertyStandard.h>
+#include <App/PropertyUnits.h>
+#include <Mod/Part/PartGlobal.h>
+
+#include "PatternReferenceWidget.h"
+
+namespace PartGui
+{
+
+class Ui_PatternPathParametersWidget;
+
+class PartGuiExport PatternPathParametersWidget: public PatternReferenceWidget
+{
+    Q_OBJECT
+
+public:
+    explicit PatternPathParametersWidget(QWidget* parent = nullptr);
+    ~PatternPathParametersWidget() override;
+
+    void bindProperties(
+        App::PropertyLinkSub* path,
+        App::PropertyIntegerConstraint* count,
+        App::PropertyEnumeration* spacingMode,
+        App::PropertyLength* spacing,
+        App::PropertyLength* startOffset,
+        App::PropertyLength* endOffset,
+        App::PropertyBool* reversePath,
+        App::PropertyBool* align
+    );
+    void updateUI();
+    void applyQuantitySpinboxes() const;
+    void getPath(App::DocumentObject*& object, std::vector<std::string>& subnames) const;
+
+private:
+    void updateVisibility();
+    void updatePathButton();
+
+    std::unique_ptr<Ui_PatternPathParametersWidget> ui;
+    App::PropertyLinkSub* pathProperty = nullptr;
+    App::PropertyIntegerConstraint* countProperty = nullptr;
+    App::PropertyEnumeration* spacingModeProperty = nullptr;
+    App::PropertyLength* spacingProperty = nullptr;
+    App::PropertyLength* startOffsetProperty = nullptr;
+    App::PropertyLength* endOffsetProperty = nullptr;
+    App::PropertyBool* reversePathProperty = nullptr;
+    App::PropertyBool* alignProperty = nullptr;
+    bool blockUpdate = false;
+};
+
+}  // namespace PartGui

--- a/src/Mod/Part/Gui/PatternPathParametersWidget.ui
+++ b/src/Mod/Part/Gui/PatternPathParametersWidget.ui
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PartGui::PatternPathParametersWidget</class>
+ <widget class="QWidget" name="PartGui::PatternPathParametersWidget">
+  <layout class="QFormLayout" name="formLayout">
+   <item row="0" column="0"><widget class="QLabel" name="pathLabel"><property name="text"><string>Path</string></property></widget></item>
+   <item row="0" column="1"><widget class="QPushButton" name="pathButton"><property name="text"><string>Select Path</string></property></widget></item>
+   <item row="1" column="0"><widget class="QLabel" name="spacingModeLabel"><property name="text"><string>Spacing mode</string></property></widget></item>
+   <item row="1" column="1"><widget class="QComboBox" name="spacingMode"/></item>
+   <item row="2" column="0"><widget class="QLabel" name="countLabel"><property name="text"><string>Occurrences</string></property></widget></item>
+   <item row="2" column="1"><widget class="Gui::UIntSpinBox" name="count"/></item>
+   <item row="3" column="0"><widget class="QLabel" name="spacingLabel"><property name="text"><string>Spacing</string></property></widget></item>
+   <item row="3" column="1"><widget class="Gui::QuantitySpinBox" name="spacing" native="true"><property name="keyboardTracking" stdset="0"><bool>false</bool></property></widget></item>
+   <item row="4" column="0"><widget class="QLabel" name="startOffsetLabel"><property name="text"><string>Start offset</string></property></widget></item>
+   <item row="4" column="1"><widget class="Gui::QuantitySpinBox" name="startOffset" native="true"><property name="keyboardTracking" stdset="0"><bool>false</bool></property></widget></item>
+   <item row="5" column="0"><widget class="QLabel" name="endOffsetLabel"><property name="text"><string>End offset</string></property></widget></item>
+   <item row="5" column="1"><widget class="Gui::QuantitySpinBox" name="endOffset" native="true"><property name="keyboardTracking" stdset="0"><bool>false</bool></property></widget></item>
+   <item row="6" column="0" colspan="2"><widget class="QCheckBox" name="reversePath"><property name="text"><string>Reverse path</string></property></widget></item>
+   <item row="7" column="0" colspan="2"><widget class="QCheckBox" name="align"><property name="text"><string>Align to path</string></property></widget></item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget><class>Gui::QuantitySpinBox</class><extends>QWidget</extends><header>Gui/QuantitySpinBox.h</header></customwidget>
+  <customwidget><class>Gui::UIntSpinBox</class><extends>QSpinBox</extends><header>Gui/SpinBox.h</header></customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Add a shared path-pattern parameter widget for reference selection, count or spacing mode, start/end offsets, reversed traversal and alignment. It reuses the reference widget merged in #32580.

Part of #30840. Based directly on main and independent of the other open LinkArrays PRs. This is a reusable editor component; task-panel wiring and user-facing commands remain in later commits. It does not add a new command by itself. 266 added lines.

Validation: fresh Qt UI and meta-object generation, followed by successful MSVC C++20 syntax checks for the widget and generated meta-object source. Interactive behavior and a full rebuild were not tested.

Prepared with assistance from OpenAI Codex.