### PR TITLE
LinkArrays: add the point pattern parameter widget

### DIFF
--- a/src/Mod/Part/Gui/CMakeLists.txt
+++ b/src/Mod/Part/Gui/CMakeLists.txt
@@ -57,6 +57,7 @@ set(PartGui_UIC_SRCS
     DlgProjectionOnSurface.ui
     PatternParametersWidget.ui
     PatternCircularParametersWidget.ui
+    PatternPointParametersWidget.ui
     SectionCutting.ui
     ShapeFromMesh.ui
     TaskFaceAppearances.ui
@@ -146,6 +147,9 @@ SET(PartGui_SRCS
     PatternCircularParametersWidget.cpp
     PatternCircularParametersWidget.h
     PatternCircularParametersWidget.ui
+    PatternPointParametersWidget.cpp
+    PatternPointParametersWidget.h
+    PatternPointParametersWidget.ui
     PatternParametersWidget.cpp
     PatternParametersWidget.h
     PatternParametersWidget.ui

--- a/src/Mod/Part/Gui/PatternPointParametersWidget.cpp
+++ b/src/Mod/Part/Gui/PatternPointParametersWidget.cpp
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "PatternPointParametersWidget.h"
+
+#include <QPushButton>
+
+#include <App/DocumentObject.h>
+
+#include "ui_PatternPointParametersWidget.h"
+
+using namespace PartGui;
+
+PatternPointParametersWidget::PatternPointParametersWidget(QWidget* parent)
+    : PatternReferenceWidget(parent)
+    , ui(new Ui_PatternPointParametersWidget)
+{
+    ui->setupUi(this);
+    connect(ui->pointObjectButton, &QPushButton::clicked, this, [this]() {
+        Q_EMIT requestReferenceSelection();
+    });
+}
+
+PatternPointParametersWidget::~PatternPointParametersWidget() = default;
+
+void PatternPointParametersWidget::bindProperty(App::PropertyLinkSub* pointObject)
+{
+    pointObjectProperty = pointObject;
+    updateUI();
+}
+
+void PatternPointParametersWidget::updateUI()
+{
+    updatePointObjectButton();
+}
+
+void PatternPointParametersWidget::getPointObject(
+    App::DocumentObject*& object,
+    std::vector<std::string>& subnames
+) const
+{
+    object = pointObjectProperty ? pointObjectProperty->getValue() : nullptr;
+    subnames = pointObjectProperty ? pointObjectProperty->getSubValues() : std::vector<std::string>();
+}
+
+void PatternPointParametersWidget::updatePointObjectButton()
+{
+    if (!pointObjectProperty || !pointObjectProperty->getValue()) {
+        ui->pointObjectButton->setText(tr("Select Point Object"));
+        return;
+    }
+
+    QString text = QString::fromUtf8(pointObjectProperty->getValue()->Label.getValue());
+    if (text.isEmpty()) {
+        text = QString::fromLatin1(pointObjectProperty->getValue()->getNameInDocument());
+    }
+    ui->pointObjectButton->setText(text);
+}

--- a/src/Mod/Part/Gui/PatternPointParametersWidget.h
+++ b/src/Mod/Part/Gui/PatternPointParametersWidget.h
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <memory>
+
+#include <App/PropertyLinks.h>
+#include <Mod/Part/PartGlobal.h>
+
+#include "PatternReferenceWidget.h"
+
+namespace PartGui
+{
+
+class Ui_PatternPointParametersWidget;
+
+class PartGuiExport PatternPointParametersWidget: public PatternReferenceWidget
+{
+    Q_OBJECT
+
+public:
+    explicit PatternPointParametersWidget(QWidget* parent = nullptr);
+    ~PatternPointParametersWidget() override;
+
+    void bindProperty(App::PropertyLinkSub* pointObject);
+    void updateUI();
+    void getPointObject(App::DocumentObject*& object, std::vector<std::string>& subnames) const;
+
+private:
+    void updatePointObjectButton();
+
+    std::unique_ptr<Ui_PatternPointParametersWidget> ui;
+    App::PropertyLinkSub* pointObjectProperty = nullptr;
+};
+
+}  // namespace PartGui

--- a/src/Mod/Part/Gui/PatternPointParametersWidget.ui
+++ b/src/Mod/Part/Gui/PatternPointParametersWidget.ui
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PartGui::PatternPointParametersWidget</class>
+ <widget class="QWidget" name="PartGui::PatternPointParametersWidget">
+  <layout class="QFormLayout" name="formLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="pointObjectLabel">
+     <property name="text"><string>Point object</string></property>
+     <property name="buddy"><cstring>pointObjectButton</cstring></property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QPushButton" name="pointObjectButton">
+     <property name="text"><string>Select Point Object</string></property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Add the reusable point-pattern parameter widget for selecting and binding a reference object. It builds on the shared reference widget merged in #32580 and uses existing property types.

Part of #30840. Based directly on main, with no dependency on the unmerged point-pattern implementation or sibling widget PRs. This adds an editor component; task-panel wiring and commands remain in later commits. It does not add a new command by itself. 118 added lines.

Validation: fresh Qt UI and meta-object generation, followed by successful MSVC C++20 syntax checks for the widget and generated meta-object source. Interactive behavior and a full rebuild were not tested.

Prepared with assistance from OpenAI Codex.