### PR TITLE
Measurement: Mass Properties should only accept visible items

### DIFF
--- a/src/Mod/Measure/Gui/TaskMassProperties.cpp
+++ b/src/Mod/Measure/Gui/TaskMassProperties.cpp
@@ -858,6 +858,10 @@ void TaskMassProperties::tryUpdate()
             return false;
         }
 
+        if (obj->Visibility.getValue() == false) {
+            return false;
+        }
+
         App::DocumentObject* object = nullptr;
         Part::ShapeOptions options = Part::ShapeOption::ResolveLink;
 


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

Currently the Mass Properties tool measures everything that the user hass selected, even if some of the child items also measured are invisible. This gives too large values for some complex parts, and can be confusing.

For fusions it currently measures both the fused shape, and the children elements and this is fixed here

a simple check was added to check if the object is visible before measuring it. 


- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.


## Issues
fixes #32574 

## Before and After Images
Before:
<img width="871" height="351" alt="image" src="https://github.com/user-attachments/assets/aeedbcd0-ebec-40f6-a6eb-5945480affb8" />

After:
<img width="900" height="312" alt="image" src="https://github.com/user-attachments/assets/10930eec-4723-498c-a750-b7744fbad09e" />


