### PR TITLE
CI: split stale issue and pull request workflows

### DIFF
--- a/.github/workflows/auto-close_stale_issues.yml
+++ b/.github/workflows/auto-close_stale_issues.yml
@@ -14,7 +14,6 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: read
   issues: write  # for actions/stale to close stale issues
-  pull-requests: write # for actions/stale to close stale pull requests
 
 jobs:
   stale:
@@ -35,7 +34,7 @@ jobs:
           days-before-issue-close: 14
           days-before-pr-stale: -1
           days-before-pr-close: -1
-          operations-per-run: 200  # max num of ops per run
+          operations-per-run: 250  # max num of ops per run
           stale-issue-label: 'Status: Stale'
           close-issue-label: 'Status: Auto-closing'
           only-issue-types: 'Bug'
@@ -62,7 +61,7 @@ jobs:
           days-before-issue-close: 14
           days-before-pr-stale: -1
           days-before-pr-close: -1
-          operations-per-run: 100  # max num of ops per run
+          operations-per-run: 250  # max num of ops per run
           stale-issue-label: 'Status: Stale'
           close-issue-label: 'Status: Auto-closing'
           only-issue-types: 'Bug'
@@ -90,7 +89,7 @@ jobs:
           days-before-issue-close: 60
           days-before-pr-stale: -1
           days-before-pr-close: -1
-          operations-per-run: 100  # max num of ops per run
+          operations-per-run: 250  # max num of ops per run
           stale-issue-label: 'Status: Stale'
           close-issue-label: 'Status: Auto-closing'
           only-issue-types: 'Bug'
@@ -111,27 +110,3 @@ jobs:
               - **Forum**: https://forum.freecad.org
               - **Blog**: https://blog.freecad.org
               - **Wiki**: https://wiki.freecad.org
-
-      - name: '🧹 Tag & close inactive PRs'
-        id: inactive_pr
-        uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          days-before-issue-stale: -1
-          days-before-issue-close: -1
-          days-before-pr-stale: 120
-          days-before-pr-close: 60
-          operations-per-run: 150  # max num of ops per run
-          stale-pr-label: 'Status: Stale'
-          close-pr-label: 'Status: Auto-closing'
-          exempt-pr-labels: 'Needs backport,Priority: High,Priority: Critical,no-auto-close'
-          remove-stale-when-updated: true
-          ascending: true
-          stale-pr-message: |
-            Thanks for helping improve FreeCAD!
-            This pull request hasn’t seen activity in a while. We automatically check each PR after 120 days without activity to keep the repository tidy.
-
-            If the PR is still relevant, let us know by adding a comment.
-            Otherwise, we’ll close this PR automatically in 60 days.
-
-            If you would like to keep working on this pull request, we advice to rebase it on current main branch, ask feedback from users or maintainers and engage with the community to get it forward.

--- a/.github/workflows/auto-close_stale_pull-requests.yml
+++ b/.github/workflows/auto-close_stale_pull-requests.yml
@@ -1,0 +1,50 @@
+# This workflow warns and then closes pull requests that have had no activity
+# for a specified amount of time. You can adjust the behavior by modifying this file.
+# For more information, see:
+#   https://github.com/marketplace/actions/close-stale-issues
+#   https://github.com/actions/stale/blob/master/action.yml
+#   https://github.com/actions/stale
+---
+name: 'Stale Pull Requests'
+on:  # yamllint disable-line rule:truthy
+  schedule:
+    - cron: '0 15 * * *'  # Run at 00:15 UTC every day
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write  # for actions/stale to close stale pull requests
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'FreeCAD' || github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: '🧹 Tag & close inactive PRs'
+        id: inactive_pr
+        uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 90
+          days-before-pr-close: 20
+          operations-per-run: 1000  # max num of ops per run
+          stale-pr-label: 'Status: Stale'
+          close-pr-label: 'Status: Auto-closing'
+          exempt-pr-labels: 'Needs backport,Priority: High,Priority: Critical,no-auto-close'
+          remove-stale-when-updated: true
+          ascending: true
+          stale-pr-message: |
+            Thanks for helping improve FreeCAD!
+            This pull request hasn’t seen activity in a while. We automatically check each PR after 90 days without activity to keep the repository tidy.
+
+            If the PR is still relevant, let us know by adding a comment.
+            Otherwise, we’ll close this PR automatically in 20 days.
+
+            If you would like to keep working on this pull request, we advice to rebase it on current main branch, ask feedback from users or maintainers and engage with the community to get it forward.


### PR DESCRIPTION
- Split the combined stale workflow into separate daily workflows (00:00 and 00:15 UTC) for issues and pull requests
- Increase each issue stale limit to 250
- Increase the PR stale action's dedicated operation limit to go over all PRs
- Mark inactive PRs stale after 90 days and close them after 20 additional days. Currently we have 600+ PRs, almost 50% of them in draft and only 60 marked as stale but there are pretty old ones without activity or an inactive author.
