### PR TITLE
BIM: Make new BIM document grid size suitable for architectural models

### DIFF
--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -45,6 +45,7 @@
 #include "NewFileButton.h"
 #include <App/Document.h>
 #include <App/DocumentObject.h>
+#include <App/DocumentSettings.h>
 #include <App/Application.h>
 #include <Base/Interpreter.h>
 #include <Base/Tools.h>
@@ -357,6 +358,14 @@ void StartView::newDraftFile()
 void StartView::newArchFile()
 {
     Gui::Application::Instance->commandManager().runCommandByName("Std_New");
+    auto* doc = App::GetApplication().getActiveDocument();
+    App::DocumentSettings gridSettings(doc, "Draft");
+
+    // Create a 10 m grid (100 mm spacing x 100 squares), matching the camera zoom set below
+    gridSettings.setString("GridSpacing", "100 mm");
+    gridSettings.setInt("GridMainlines", 10);
+    gridSettings.setInt("GridSize", 100);
+
     try {
         Gui::Application::Instance->activateWorkbench("BIMWorkbench");
     }

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -241,7 +241,7 @@ void StartView::configureNewFileButtons(QLayout* layout) const
     auto draft = gsl::owner<NewFileButton*>(new NewFileButton(
         {tr("2D Draft"), tr("Creates a 2D Draft document"), QLatin1String(":/icons/DraftWorkbench.svg")}
     ));
-    auto arch = gsl::owner<NewFileButton*>(new NewFileButton(
+    auto bim = gsl::owner<NewFileButton*>(new NewFileButton(
         {tr("BIM/Architecture"),
          tr("Creates an architectural project"),
          QLatin1String(":/icons/BIMWorkbench.svg")}
@@ -251,7 +251,7 @@ void StartView::configureNewFileButtons(QLayout* layout) const
     layout->addWidget(partDesign);
     layout->addWidget(assembly);
     layout->addWidget(draft);
-    layout->addWidget(arch);
+    layout->addWidget(bim);
     layout->addWidget(newEmptyFile);
     layout->addWidget(openFile);
 
@@ -260,7 +260,7 @@ void StartView::configureNewFileButtons(QLayout* layout) const
     connect(partDesign, &QPushButton::clicked, this, &StartView::newPartDesignFile);
     connect(assembly, &QPushButton::clicked, this, &StartView::newAssemblyFile);
     connect(draft, &QPushButton::clicked, this, &StartView::newDraftFile);
-    connect(arch, &QPushButton::clicked, this, &StartView::newArchFile);
+    connect(bim, &QPushButton::clicked, this, &StartView::newBimFile);
 }
 
 void StartView::configureFileCardWidget(QListView* fileCardWidget)
@@ -355,7 +355,7 @@ void StartView::newDraftFile()
     postStart(PostStartBehavior::doNotSwitchWorkbench);
 }
 
-void StartView::newArchFile()
+void StartView::newBimFile()
 {
     Gui::Application::Instance->commandManager().runCommandByName("Std_New");
     auto* doc = App::GetApplication().getActiveDocument();

--- a/src/Mod/Start/Gui/StartView.h
+++ b/src/Mod/Start/Gui/StartView.h
@@ -71,7 +71,7 @@ public:
     void openExistingFile();
     void newAssemblyFile();
     void newDraftFile();
-    void newArchFile();
+    void newBimFile();
     void recentFileAdded(const QString& filename);
 
     bool onHasMsg(const char* pMsg) const override;


### PR DESCRIPTION
Set a value for the grid size of new BIM documents that is more appropriate for AEC magnitudes and models. Before, the grid size was 10 cm x 10 cm, too small for any BIM model. Most importantly, with the default zoom level, the net result was a grid that appeared as a tiny speck on the screen, providing a confusing and less than optimal first user experience.

This PR makes the overall grid size to be 10 m x 10 m, matching the default BIM document zoom camera level defined in https://github.com/FreeCAD/FreeCAD/pull/20271.

Now that https://github.com/FreeCAD/FreeCAD/pull/30692 provides an API to define document-level settings and that https://github.com/FreeCAD/FreeCAD/pull/30696 subsequently defined the names for the grid-related settings, this PR builds up on that work to provide the default value for new BIM documents.

This PR contains two relatively trivial commits that can be reviewed independently:

- 01cfbaa2abad58db3a5f93fdd7a4b9d6bba1c7b8: the actual changes that set the BIM grid size 
- e6abd168db63ef7ca9b7336f642dbc3cac41f427: a minor code quality refactor to replace Arch => BIM references. It could be split into a separate PR, but due to these being minor changes, I feel the maintainer and author overhead are less if put in a single PR.

## Issues

While there wasn't a specific issue filed, this change is a follow up to address https://github.com/FreeCAD/FreeCAD/pull/20271#issuecomment-2738321115.

Issue https://github.com/FreeCAD/FreeCAD/issues/20457 is related, but already fixed by another PR.

## Before and After Images

|Before|After|
|---|---|
|<img width="1848" height="1052" alt="Captura de pantalla de 2026-09-11 09-55-54" src="https://github.com/user-attachments/assets/1be56dea-eddd-42bd-8f57-68d4072fcd75" />|<img width="1849" height="1054" alt="Captura de pantalla de 2026-09-11 12-19-02" src="https://github.com/user-attachments/assets/16f6f57a-02af-424a-be32-8ca86e471cdb" />|
