### PR TITLE
Surface: Freehand B-spline

### DIFF
--- a/src/Mod/Surface/App/AppFreehandBSpline.cpp
+++ b/src/Mod/Surface/App/AppFreehandBSpline.cpp
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#include "FeatureFreehandBSpline.h"
+
+void initSurfaceFreehandBSplineTypes()
+{
+    Surface::FreehandBSpline::init();
+}

--- a/src/Mod/Surface/App/AppSurface.cpp
+++ b/src/Mod/Surface/App/AppSurface.cpp
@@ -40,6 +40,8 @@
 
 #include "Measure.h"
 
+void initSurfaceFreehandBSplineTypes();
+
 
 namespace Surface
 {
@@ -74,6 +76,7 @@ PyMOD_INIT_FUNC(Surface)
     }
 
     PyObject* mod = Surface::initModule();
+    initSurfaceFreehandBSplineTypes();
     Base::Console().log("Loading Surface module… done\n");
     Base::Interpreter().addType(&Surface::BlendPointPy::Type, mod, "BlendPoint");
     Base::Interpreter().addType(&Surface::BlendCurvePy::Type, mod, "BlendCurve");

--- a/src/Mod/Surface/App/CMakeLists.txt
+++ b/src/Mod/Surface/App/CMakeLists.txt
@@ -51,6 +51,8 @@ SET(Surface_SRCS
 
 add_library(Surface SHARED ${Surface_SRCS})
 
+include(FreehandBSpline.cmake)
+
 if(FREECAD_USE_PCH)
     target_precompile_headers(Surface PRIVATE
             $<$<COMPILE_LANGUAGE:CXX>:"${CMAKE_CURRENT_LIST_DIR}/PreCompiled.h">

--- a/src/Mod/Surface/App/FeatureFreehandBSpline.cpp
+++ b/src/Mod/Surface/App/FeatureFreehandBSpline.cpp
@@ -306,8 +306,8 @@ void FreehandBSpline::setPointTangent(int index, const std::string& subname)
             throw Base::ValueError("Choose an edge or face belonging to the locked reference.");
         }
         const auto& locks = SupportPointIndices.getValues();
-        object = Support.getValues(
-        )[std::distance(locks.begin(), std::find(locks.begin(), locks.end(), index))];
+        object
+            = Support.getValues()[std::distance(locks.begin(), std::find(locks.begin(), locks.end(), index))];
     }
     for (size_t i = 0; i < indices.size(); ++i) {
         if (indices[i] == index) {

--- a/src/Mod/Surface/App/FeatureFreehandBSpline.cpp
+++ b/src/Mod/Surface/App/FeatureFreehandBSpline.cpp
@@ -1,0 +1,699 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <cmath>
+#include <algorithm>
+#include <BRepBuilderAPI_MakeVertex.hxx>
+#include <BRepExtrema_DistShapeShape.hxx>
+#include <BRepAdaptor_Curve.hxx>
+#include <BRepAdaptor_Surface.hxx>
+#include <BRep_Tool.hxx>
+#include <GeomAPI_ProjectPointOnCurve.hxx>
+#include <GeomAPI_ProjectPointOnSurf.hxx>
+#include <TopoDS.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopExp.hxx>
+#include <TopTools_IndexedMapOfShape.hxx>
+#include <App/GeoFeature.h>
+#include <App/Document.h>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <GeomAPI_Interpolate.hxx>
+#include <GeomConvert.hxx>
+#include <GeomConvert_CompCurveToBSplineCurve.hxx>
+#include <Geom_BezierCurve.hxx>
+#include <Geom_TrimmedCurve.hxx>
+#include <Precision.hxx>
+#include <TColgp_HArray1OfPnt.hxx>
+#include <TColgp_Array1OfVec.hxx>
+#include <TColStd_HArray1OfReal.hxx>
+#include <TColStd_HArray1OfBoolean.hxx>
+#include <Base/Exception.h>
+
+#include "FeatureFreehandBSpline.h"
+
+using namespace Surface;
+PROPERTY_SOURCE(Surface::FreehandBSpline, Part::Spline)
+
+FreehandBSpline::FreehandBSpline()
+{
+    ADD_PROPERTY_TYPE(
+        Points,
+        (Base::Vector3d()),
+        "Curve",
+        App::Prop_None,
+        "Interpolation points in local coordinates"
+    );
+    ADD_PROPERTY_TYPE(
+        Support,
+        (nullptr),
+        "Attachment",
+        App::Prop_None,
+        "Vertex, edge or face supporting each locked point"
+    );
+    ADD_PROPERTY_TYPE(
+        SupportPointIndices,
+        (0),
+        "Attachment",
+        App::Prop_ReadOnly,
+        "Point indices corresponding to Support"
+    );
+    ADD_PROPERTY_TYPE(
+        SupportParameters,
+        (Base::Vector3d()),
+        "Attachment",
+        App::Prop_ReadOnly,
+        "Edge fractions or face UV coordinates of locked points"
+    );
+    ADD_PROPERTY_TYPE(
+        TangentSupport,
+        (nullptr),
+        "Attachment",
+        App::Prop_None,
+        "Edge or face tangent reference for each constrained point"
+    );
+    ADD_PROPERTY_TYPE(
+        TangentPointIndices,
+        (0),
+        "Attachment",
+        App::Prop_ReadOnly,
+        "Point indices corresponding to TangentSupport"
+    );
+    TangentSupport.setScope(App::LinkScope::Global);
+    TangentPointIndices.setValues(std::vector<long>());
+    Support.setScope(App::LinkScope::Global);
+    SupportPointIndices.setValues(std::vector<long>());
+    SupportParameters.setValues(std::vector<Base::Vector3d>());
+    ADD_PROPERTY_TYPE(Periodic, (false), "Curve", App::Prop_None, "Close the curve smoothly");
+    ADD_PROPERTY_TYPE(
+        Parameterization,
+        (0.5),
+        "Curve",
+        App::Prop_None,
+        "0: uniform; 0.5: centripetal; 1: chord length"
+    );
+    static const App::PropertyFloatConstraint::Constraints range {0.0, 1.0, 0.1};
+    Parameterization.setConstraints(&range);
+    ADD_PROPERTY_TYPE(
+        LinearSegments,
+        (false),
+        "Curve",
+        App::Prop_None,
+        "Interpolate marked spans as straight lines"
+    );
+}
+
+short FreehandBSpline::mustExecute() const
+{
+    return TangentSupport.isTouched() || TangentPointIndices.isTouched() || Support.isTouched()
+            || SupportPointIndices.isTouched() || SupportParameters.isTouched() || Points.isTouched()
+            || Periodic.isTouched() || Parameterization.isTouched() || LinearSegments.isTouched()
+        ? 1
+        : Part::Spline::mustExecute();
+}
+
+Handle(Geom_BSplineCurve) FreehandBSpline::interpolate() const
+{
+    return interpolate(Points.getValues());
+}
+
+Handle(Geom_BSplineCurve) FreehandBSpline::interpolate(const std::vector<Base::Vector3d>& points) const
+{
+    const int count = static_cast<int>(points.size());
+    const bool closed = Periodic.getValue();
+    if (count < (closed ? 3 : 2)) {
+        throw Base::ValueError(
+            closed ? "A closed curve needs at least three points." : "A curve needs at least two points."
+        );
+    }
+    const int spans = closed ? count : count - 1;
+    Handle(TColgp_HArray1OfPnt) data = new TColgp_HArray1OfPnt(1, count);
+    Handle(TColStd_HArray1OfReal) parameters = new TColStd_HArray1OfReal(1, spans + 1);
+    parameters->SetValue(1, 0.0);
+    for (int i = 0; i < count; ++i) {
+        const auto& p = points[i];
+        if (!std::isfinite(p.x) || !std::isfinite(p.y) || !std::isfinite(p.z)) {
+            throw Base::ValueError("Point coordinates must be finite.");
+        }
+        data->SetValue(i + 1, gp_Pnt(p.x, p.y, p.z));
+    }
+    for (int i = 0; i < spans; ++i) {
+        const double length = (points[(i + 1) % count] - points[i]).Length();
+        if (length <= Precision::Confusion()) {
+            throw Base::ValueError("Consecutive interpolation points must be different.");
+        }
+        parameters->SetValue(
+            i + 2,
+            parameters->Value(i + 1) + std::pow(length, Parameterization.getValue())
+        );
+    }
+    GeomAPI_Interpolate builder(data, parameters, closed, Precision::Confusion());
+    const auto& linear = LinearSegments.getValues();
+    TColgp_Array1OfVec tangents(1, count);
+    Handle(TColStd_HArray1OfBoolean) flags = new TColStd_HArray1OfBoolean(1, count, false);
+    bool anyLinear = false;
+    for (int i = 0; i < spans; ++i) {
+        if (i < static_cast<int>(linear.size()) && linear[i]) {
+            anyLinear = true;
+            const int next = (i + 1) % count;
+            gp_Vec tangent(data->Value(i + 1), data->Value(next + 1));
+            tangents.SetValue(i + 1, tangent);
+            tangents.SetValue(next + 1, tangent);
+            flags->SetValue(i + 1, true);
+            flags->SetValue(next + 1, true);
+        }
+    }
+    const auto& tangentIndices = TangentPointIndices.getValues();
+    if (tangentIndices.size() != TangentSupport.getValues().size()) {
+        throw Base::ValueError("Inconsistent tangent references.");
+    }
+    for (size_t j = 0; j < tangentIndices.size(); ++j) {
+        const int i = static_cast<int>(tangentIndices[j]);
+        if (i < 0 || i >= count) {
+            throw Base::ValueError("Invalid tangent point index.");
+        }
+        const auto& locks = SupportPointIndices.getValues();
+        if (std::find(locks.begin(), locks.end(), i) == locks.end()) {
+            throw Base::ValueError("A tangent point must be locked to a reference.");
+        }
+        const auto direction = tangentDirection(
+            i,
+            points,
+            TangentSupport.getValues()[j],
+            TangentSupport.getSubValues()[j]
+        );
+        gp_Vec tangent(direction.x, direction.y, direction.z);
+        if (flags->Value(i + 1) && !tangents.Value(i + 1).IsParallel(tangent, 1e-6)) {
+            throw Base::ValueError("The tangent conflicts with an adjacent linear segment.");
+        }
+        tangents.SetValue(i + 1, tangent);
+        flags->SetValue(i + 1, true);
+    }
+    if (count == 2 && tangentIndices.empty()) {
+        return GeomConvert::CurveToBSplineCurve(new Geom_BezierCurve(data->Array1()));
+    }
+    if (anyLinear || !tangentIndices.empty()) {
+        builder.Load(tangents, flags, true);
+    }
+    builder.Perform();
+    if (!builder.IsDone()) {
+        throw Base::ValueError("B-spline interpolation failed.");
+    }
+    if (!anyLinear) {
+        return builder.Curve();
+    }
+    GeomConvert_CompCurveToBSplineCurve joined;
+    for (int i = 0; i < spans; ++i) {
+        Handle(Geom_BoundedCurve) segment;
+        if (i < static_cast<int>(linear.size()) && linear[i]) {
+            TColgp_Array1OfPnt poles(1, 2);
+            poles.SetValue(1, data->Value(i + 1));
+            poles.SetValue(2, data->Value((i + 1) % count + 1));
+            segment = new Geom_BezierCurve(poles);
+        }
+        else {
+            segment = new Geom_TrimmedCurve(
+                builder.Curve(),
+                parameters->Value(i + 1),
+                parameters->Value(i + 2)
+            );
+        }
+        if (!joined.Add(segment, Precision::Confusion(), true)) {
+            throw Base::ValueError("Could not join interpolation spans.");
+        }
+    }
+    return joined.BSplineCurve();
+}
+
+namespace
+{
+TopoDS_Shape supportShape(App::DocumentObject* object, const std::string& name)
+{
+    if (!object) {
+        throw Base::ValueError("A locked point has a missing reference.");
+    }
+    auto shape = Part::Feature::getShape(
+        object,
+        Part::ShapeOption::ResolveLink | Part::ShapeOption::Transform
+            | Part::ShapeOption::NeedSubElement,
+        name.c_str()
+    );
+    if (!shape.IsNull() && (shape.ShapeType() == TopAbs_WIRE || shape.ShapeType() == TopAbs_COMPOUND)
+        && !TopExp_Explorer(shape, TopAbs_FACE).More()) {
+        TopExp_Explorer edges(shape, TopAbs_EDGE);
+        if (edges.More()) {
+            const auto edge = edges.Current();
+            edges.Next();
+            if (!edges.More()) {
+                shape = edge;
+            }
+        }
+    }
+    if (shape.IsNull()
+        || (shape.ShapeType() != TopAbs_VERTEX && shape.ShapeType() != TopAbs_EDGE
+            && shape.ShapeType() != TopAbs_FACE)) {
+        throw Base::ValueError("Select a vertex, edge or face for the point reference.");
+    }
+    return shape;
+}
+}  // namespace
+
+std::vector<std::string> FreehandBSpline::tangentChoices(int index) const
+{
+    std::vector<std::string> choices;
+    const auto& indices = SupportPointIndices.getValues();
+    auto found = std::find(indices.begin(), indices.end(), index);
+    if (found == indices.end()) {
+        return choices;
+    }
+    const auto slot = std::distance(indices.begin(), found);
+    auto object = Support.getValues()[slot];
+    // Resolve both the reference and its neighbours from the same topology, before transforms.
+    const auto topology = Part::Feature::getTopoShape(object, Part::ShapeOption::ResolveLink);
+    const auto& name = Support.getSubValues()[slot];
+    auto whole = topology.getShape();
+    auto locked = name.empty() ? whole : topology.getSubShape(name.c_str());
+    if (locked.ShapeType() == TopAbs_WIRE || locked.ShapeType() == TopAbs_COMPOUND) {
+        TopExp_Explorer edge(locked, TopAbs_EDGE);
+        if (edge.More()) {
+            locked = edge.Current();
+        }
+    }
+    TopTools_IndexedMapOfShape elements;
+    const auto type = locked.ShapeType() == TopAbs_FACE ? TopAbs_FACE : TopAbs_EDGE;
+    TopExp::MapShapes(whole, type, elements);
+    for (int i = 1; i <= elements.Extent(); ++i) {
+        bool match = elements(i).IsSame(locked);
+        if (locked.ShapeType() == TopAbs_VERTEX) {
+            for (TopExp_Explorer v(elements(i), TopAbs_VERTEX); v.More(); v.Next()) {
+                match = match || v.Current().IsSame(locked);
+            }
+        }
+        if (match) {
+            choices.push_back(std::string(type == TopAbs_FACE ? "Face" : "Edge") + std::to_string(i));
+        }
+    }
+    return choices;
+}
+
+void FreehandBSpline::setPointTangent(int index, const std::string& subname)
+{
+    auto objects = TangentSupport.getValues();
+    auto names = TangentSupport.getSubValues();
+    auto indices = TangentPointIndices.getValues();
+    App::DocumentObject* object = nullptr;
+    if (!subname.empty()) {
+        const auto choices = tangentChoices(index);
+        if (std::find(choices.begin(), choices.end(), subname) == choices.end()) {
+            throw Base::ValueError("Choose an edge or face belonging to the locked reference.");
+        }
+        const auto& locks = SupportPointIndices.getValues();
+        object = Support.getValues(
+        )[std::distance(locks.begin(), std::find(locks.begin(), locks.end(), index))];
+    }
+    for (size_t i = 0; i < indices.size(); ++i) {
+        if (indices[i] == index) {
+            objects.erase(objects.begin() + i);
+            names.erase(names.begin() + i);
+            indices.erase(indices.begin() + i);
+            break;
+        }
+    }
+    if (object) {
+        objects.push_back(object);
+        names.push_back(subname);
+        indices.push_back(index);
+    }
+    TangentSupport.setValues(objects, names);
+    TangentPointIndices.setValues(indices);
+}
+
+Base::Vector3d FreehandBSpline::tangentDirection(
+    int index,
+    const std::vector<Base::Vector3d>& points,
+    App::DocumentObject* object,
+    const std::string& name
+) const
+{
+    const int count = static_cast<int>(points.size());
+    const int previous = index > 0 ? index - 1 : Periodic.getValue() ? count - 1 : 0;
+    const int next = index + 1 < count ? index + 1 : Periodic.getValue() ? 0 : count - 1;
+    auto direction = points[next] - points[previous];
+    const auto placement = App::GeoFeature::getGlobalPlacement(this);
+    Base::Vector3d world, forward;
+    placement.multVec(points[index], world);
+    placement.getRotation().multVec(direction, forward);
+    const auto shape = supportShape(object, name);
+    gp_Pnt point(world.x, world.y, world.z);
+    gp_Vec tangent;
+    if (shape.ShapeType() == TopAbs_EDGE) {
+        double first, last;
+        auto curve = BRep_Tool::Curve(TopoDS::Edge(shape), first, last);
+        GeomAPI_ProjectPointOnCurve projection(point, curve, first, last);
+        if (!projection.NbPoints()) {
+            throw Base::ValueError("Cannot evaluate tangent on the reference edge.");
+        }
+        curve->D1(projection.LowerDistanceParameter(), point, tangent);
+    }
+    else if (shape.ShapeType() == TopAbs_FACE) {
+        auto surface = BRep_Tool::Surface(TopoDS::Face(shape));
+        GeomAPI_ProjectPointOnSurf projection(point, surface);
+        if (!projection.IsDone() || !projection.NbPoints()) {
+            throw Base::ValueError("Cannot evaluate tangent on the reference face.");
+        }
+        double u, v;
+        projection.LowerDistanceParameters(u, v);
+        gp_Vec du, dv;
+        surface->D1(u, v, point, du, dv);
+        auto normal = du.Crossed(dv);
+        if (normal.SquareMagnitude() <= Precision::SquareConfusion()) {
+            throw Base::ValueError("The reference face has no defined tangent plane here.");
+        }
+        normal.Normalize();
+        tangent = gp_Vec(forward.x, forward.y, forward.z);
+        tangent -= normal * tangent.Dot(normal);
+        if (tangent.SquareMagnitude() <= Precision::SquareConfusion()) {
+            tangent = du;
+        }
+    }
+    else {
+        throw Base::ValueError("A tangent reference must be an edge or face.");
+    }
+    if (tangent.SquareMagnitude() <= Precision::SquareConfusion()) {
+        throw Base::ValueError("The reference has no defined tangent here.");
+    }
+    tangent.Normalize();
+    if (tangent.Dot(gp_Vec(forward.x, forward.y, forward.z)) < 0) {
+        tangent.Reverse();
+    }
+    placement.getRotation().inverse().multVec(
+        Base::Vector3d(tangent.X(), tangent.Y(), tangent.Z()),
+        direction
+    );
+    return direction;
+}
+
+void FreehandBSpline::onBeforeChange(const App::Property* property)
+{
+    Part::Spline::onBeforeChange(property);
+    if (property != &Support && property != &TangentSupport) {
+        return;
+    }
+    auto& removed = property == &Support ? removedSupportSlots : removedTangentSlots;
+    removed.clear();
+    if (!getDocument() || getDocument()->isPerformingTransaction()) {
+        return;
+    }
+    const auto& objects = property == &Support ? Support.getValues() : TangentSupport.getValues();
+    for (size_t i = 0; i < objects.size(); ++i) {
+        if (objects[i] && objects[i]->isRemoving()) {
+            removed.push_back(i);
+        }
+    }
+}
+
+void FreehandBSpline::onChanged(const App::Property* property)
+{
+    if (property == &Support || property == &TangentSupport) {
+        auto& removed = property == &Support ? removedSupportSlots : removedTangentSlots;
+        auto slots = std::move(removed);
+        removed.clear();
+        if (!slots.empty()) {
+            auto indices = property == &Support ? SupportPointIndices.getValues()
+                                                : TangentPointIndices.getValues();
+            auto parameters = SupportParameters.getValues();
+            for (auto it = slots.rbegin(); it != slots.rend(); ++it) {
+                if (*it < indices.size()) {
+                    indices.erase(indices.begin() + *it);
+                }
+                if (property == &Support && *it < parameters.size()) {
+                    parameters.erase(parameters.begin() + *it);
+                }
+            }
+            if (property == &Support) {
+                SupportPointIndices.setValues(indices);
+                SupportParameters.setValues(parameters);
+            }
+            else {
+                TangentPointIndices.setValues(indices);
+            }
+        }
+    }
+    Part::Spline::onChanged(property);
+}
+
+void FreehandBSpline::sanitizeReferences()
+{
+    // A saved file from an older version may already have lost the slot mapping.
+    // Unlock ambiguous entries rather than attaching a surviving reference to the wrong point.
+    const auto clean =
+        [this](App::PropertyLinkSubList& links, App::PropertyIntegerList& pointIndices, bool tangent) {
+            const auto& oldObjects = links.getValues();
+            const auto& oldNames = links.getSubValues();
+            const auto& oldIndices = pointIndices.getValues();
+            const auto& oldParameters = SupportParameters.getValues();
+            std::vector<App::DocumentObject*> objects;
+            std::vector<std::string> names;
+            std::vector<long> indices;
+            std::vector<Base::Vector3d> parameters;
+            const bool consistent = oldObjects.size() == oldIndices.size()
+                && oldNames.size() == oldIndices.size()
+                && (tangent || oldParameters.size() == oldIndices.size());
+            if (consistent) {
+                for (size_t i = 0; i < oldIndices.size(); ++i) {
+                    const auto index = oldIndices[i];
+                    if (index < 0 || index >= Points.getSize() || !oldObjects[i]
+                        || oldObjects[i]->isRemoving()) {
+                        continue;
+                    }
+                    if (tangent) {
+                        const auto& locks = SupportPointIndices.getValues();
+                        if (std::find(locks.begin(), locks.end(), index) == locks.end()) {
+                            continue;
+                        }
+                    }
+                    try {
+                        const auto shape = supportShape(oldObjects[i], oldNames[i]);
+                        if (tangent && shape.ShapeType() != TopAbs_EDGE
+                            && shape.ShapeType() != TopAbs_FACE) {
+                            continue;
+                        }
+                    }
+                    catch (const Base::Exception&) {
+                        continue;
+                    }
+                    catch (const Standard_Failure&) {
+                        continue;
+                    }
+                    objects.push_back(oldObjects[i]);
+                    names.push_back(oldNames[i]);
+                    indices.push_back(index);
+                    if (!tangent) {
+                        parameters.push_back(oldParameters[i]);
+                    }
+                }
+            }
+            if (!consistent || objects.size() != oldObjects.size()) {
+                links.setValues(objects, names);
+                pointIndices.setValues(indices);
+                if (!tangent) {
+                    SupportParameters.setValues(parameters);
+                }
+            }
+        };
+    clean(Support, SupportPointIndices, false);
+    clean(TangentSupport, TangentPointIndices, true);
+}
+
+void FreehandBSpline::setPointSupport(int index, App::DocumentObject* object, const std::string& subname)
+{
+    sanitizeReferences();
+    if (index < 0 || index >= Points.getSize()) {
+        throw Base::ValueError("Invalid point index.");
+    }
+    if (object) {
+        const auto dependents = getInListRecursive();
+        if (object == this || object->getDocument() != getDocument()
+            || std::find(dependents.begin(), dependents.end(), object) != dependents.end()) {
+            throw Base::ValueError(
+                "The reference would create a circular or cross-document dependency."
+            );
+        }
+        supportShape(object, subname);
+    }
+    const auto oldObjects = Support.getValues();
+    const auto oldNames = Support.getSubValues();
+    const auto oldIndices = SupportPointIndices.getValues();
+    const auto oldParameters = SupportParameters.getValues();
+    auto objects = oldObjects;
+    auto names = oldNames;
+    auto indices = oldIndices;
+    auto parameters = oldParameters;
+    if (objects.size() != indices.size() || names.size() != indices.size()
+        || parameters.size() != indices.size()) {
+        throw Base::ValueError("Inconsistent point references.");
+    }
+    for (size_t i = 0; i < indices.size(); ++i) {
+        if (indices[i] == index) {
+            objects.erase(objects.begin() + i);
+            names.erase(names.begin() + i);
+            indices.erase(indices.begin() + i);
+            parameters.erase(parameters.begin() + i);
+            break;
+        }
+    }
+    if (object) {
+        objects.push_back(object);
+        names.push_back(subname);
+        indices.push_back(index);
+        parameters.emplace_back();
+    }
+    Support.setValues(objects, names);
+    SupportPointIndices.setValues(indices);
+    SupportParameters.setValues(parameters);
+    try {
+        updateSupportedPoints(true);
+    }
+    catch (...) {
+        Support.setValues(oldObjects, oldNames);
+        SupportPointIndices.setValues(oldIndices);
+        SupportParameters.setValues(oldParameters);
+        throw;
+    }
+    setPointTangent(index, {});
+}
+
+void FreehandBSpline::remapSupports(const std::vector<int>& retained)
+{
+    sanitizeReferences();
+    std::vector<App::DocumentObject*> objects;
+    std::vector<std::string> names;
+    std::vector<long> indices;
+    std::vector<Base::Vector3d> parameters;
+    const auto oldIndices = SupportPointIndices.getValues();
+    for (size_t i = 0; i < oldIndices.size(); ++i) {
+        auto found = std::find(retained.begin(), retained.end(), oldIndices[i]);
+        if (found != retained.end()) {
+            objects.push_back(Support.getValues()[i]);
+            names.push_back(Support.getSubValues()[i]);
+            indices.push_back(std::distance(retained.begin(), found));
+            parameters.push_back(SupportParameters.getValues()[i]);
+        }
+    }
+    Support.setValues(objects, names);
+    SupportPointIndices.setValues(indices);
+    SupportParameters.setValues(parameters);
+    objects.clear();
+    names.clear();
+    indices.clear();
+    const auto& tangentIndices = TangentPointIndices.getValues();
+    for (size_t i = 0; i < tangentIndices.size(); ++i) {
+        const auto found = std::find(retained.begin(), retained.end(), tangentIndices[i]);
+        if (found != retained.end()) {
+            objects.push_back(TangentSupport.getValues()[i]);
+            names.push_back(TangentSupport.getSubValues()[i]);
+            indices.push_back(std::distance(retained.begin(), found));
+        }
+    }
+    TangentSupport.setValues(objects, names);
+    TangentPointIndices.setValues(indices);
+}
+
+void FreehandBSpline::updateSupportedPoints(bool project)
+{
+    sanitizeReferences();
+    const auto objects = Support.getValues();
+    const auto names = Support.getSubValues();
+    const auto indices = SupportPointIndices.getValues();
+    auto parameters = SupportParameters.getValues();
+    auto points = Points.getValues();
+    if (objects.size() != indices.size() || names.size() != indices.size()
+        || parameters.size() != indices.size()) {
+        throw Base::ValueError("Inconsistent point references.");
+    }
+    const auto placement = App::GeoFeature::getGlobalPlacement(this);
+    const auto inverse = placement.inverse();
+    for (size_t i = 0; i < indices.size(); ++i) {
+        const auto index = indices[i];
+        if (index < 0 || index >= static_cast<long>(points.size())) {
+            throw Base::ValueError("A point reference has an invalid index.");
+        }
+        const auto shape = supportShape(objects[i], names[i]);
+        gp_Pnt point;
+        if (shape.ShapeType() == TopAbs_VERTEX) {
+            point = BRep_Tool::Pnt(TopoDS::Vertex(shape));
+        }
+        else {
+            if (project) {
+                Base::Vector3d world;
+                placement.multVec(points[index], world);
+                BRepExtrema_DistShapeShape distance(
+                    BRepBuilderAPI_MakeVertex(gp_Pnt(world.x, world.y, world.z)).Vertex(),
+                    shape
+                );
+                if (!distance.IsDone() || distance.NbSolution() == 0) {
+                    throw Base::ValueError("Cannot project point onto its reference.");
+                }
+                point = distance.PointOnShape2(1);
+            }
+            if (shape.ShapeType() == TopAbs_EDGE) {
+                BRepAdaptor_Curve curve(TopoDS::Edge(shape));
+                if (!std::isfinite(curve.FirstParameter()) || !std::isfinite(curve.LastParameter())
+                    || curve.LastParameter() - curve.FirstParameter() <= Precision::PConfusion()) {
+                    throw Base::ValueError(
+                        "The reference edge must have a finite, nonzero parameter range."
+                    );
+                }
+                if (project) {
+                    double first, last;
+                    auto geometry = BRep_Tool::Curve(TopoDS::Edge(shape), first, last);
+                    GeomAPI_ProjectPointOnCurve projection(point, geometry, first, last);
+                    parameters[i].x = (projection.LowerDistanceParameter() - first) / (last - first);
+                }
+                point = curve.Value(
+                    curve.FirstParameter()
+                    + parameters[i].x * (curve.LastParameter() - curve.FirstParameter())
+                );
+            }
+            else {
+                auto face = TopoDS::Face(shape);
+                if (project) {
+                    GeomAPI_ProjectPointOnSurf projection(point, BRep_Tool::Surface(face));
+                    if (!projection.IsDone() || projection.NbPoints() == 0) {
+                        throw Base::ValueError("Cannot project point onto its reference face.");
+                    }
+                    projection.LowerDistanceParameters(parameters[i].x, parameters[i].y);
+                }
+                point = BRepAdaptor_Surface(face).Value(parameters[i].x, parameters[i].y);
+                // Keep the point inside the trimmed face if its boundary changes on recompute.
+                BRepExtrema_DistShapeShape distance(BRepBuilderAPI_MakeVertex(point).Vertex(), face);
+                if (!distance.IsDone() || distance.NbSolution() == 0) {
+                    throw Base::ValueError("Cannot locate point on its reference face.");
+                }
+                point = distance.PointOnShape2(1);
+            }
+        }
+        inverse.multVec(Base::Vector3d(point.X(), point.Y(), point.Z()), points[index]);
+    }
+    if (!indices.empty()) {
+        Points.setValues(points);
+        if (project) {
+            SupportParameters.setValues(parameters);
+        }
+    }
+}
+
+App::DocumentObjectExecReturn* FreehandBSpline::execute()
+{
+    try {
+        updateSupportedPoints(false);
+        Part::TopoShape result(BRepBuilderAPI_MakeEdge(interpolate()).Edge());
+        result.setTransform(Placement.getValue().toMatrix());
+        Shape.setValue(result);
+        return StdReturn;
+    }
+    catch (const Standard_Failure& error) {
+        return new App::DocumentObjectExecReturn(error.GetMessageString());
+    }
+    catch (const Base::Exception& error) {
+        return new App::DocumentObjectExecReturn(error.what());
+    }
+}

--- a/src/Mod/Surface/App/FeatureFreehandBSpline.h
+++ b/src/Mod/Surface/App/FeatureFreehandBSpline.h
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#pragma once
+
+#include <Mod/Part/App/FeaturePartSpline.h>
+#include <Mod/Surface/SurfaceGlobal.h>
+#include <Geom_BSplineCurve.hxx>
+
+namespace Surface
+{
+class SurfaceExport FreehandBSpline: public Part::Spline
+{
+    PROPERTY_HEADER_WITH_OVERRIDE(Surface::FreehandBSpline);
+
+public:
+    FreehandBSpline();
+    App::PropertyVectorList Points;
+    App::PropertyBool Periodic;
+    App::PropertyFloatConstraint Parameterization;
+    App::PropertyBoolList LinearSegments;
+    App::PropertyLinkSubList Support;
+    App::PropertyIntegerList SupportPointIndices;
+    App::PropertyVectorList SupportParameters;
+    void setPointSupport(int index, App::DocumentObject* object, const std::string& subname);
+    App::PropertyLinkSubList TangentSupport;
+    App::PropertyIntegerList TangentPointIndices;
+    std::vector<std::string> tangentChoices(int index) const;
+    void setPointTangent(int index, const std::string& subname);
+    void remapSupports(const std::vector<int>& retained);
+    void updateSupportedPoints(bool project);
+    void sanitizeReferences();
+
+
+    Base::Vector3d tangentDirection(
+        int index,
+        const std::vector<Base::Vector3d>& points,
+        App::DocumentObject* object,
+        const std::string& name
+    ) const;
+    short mustExecute() const override;
+    App::DocumentObjectExecReturn* execute() override;
+    Handle(Geom_BSplineCurve) interpolate() const;
+    Handle(Geom_BSplineCurve) interpolate(const std::vector<Base::Vector3d>& points) const;
+    const char* getViewProviderName() const override
+    {
+        return "SurfaceGui::ViewProviderFreehandBSpline";
+    }
+
+protected:
+    void onBeforeChange(const App::Property*) override;
+    void onChanged(const App::Property*) override;
+
+private:
+    std::vector<size_t> removedSupportSlots;
+    std::vector<size_t> removedTangentSlots;
+};
+}  // namespace Surface

--- a/src/Mod/Surface/App/FreehandBSpline.cmake
+++ b/src/Mod/Surface/App/FreehandBSpline.cmake
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Kept separate from Intersection Curve for independent review and backporting.
+target_sources(Surface PRIVATE
+    AppFreehandBSpline.cpp
+    FeatureFreehandBSpline.cpp FeatureFreehandBSpline.h
+)

--- a/src/Mod/Surface/CMakeLists.txt
+++ b/src/Mod/Surface/CMakeLists.txt
@@ -21,6 +21,12 @@ if(BUILD_GUI)
     list (APPEND Surface_Scripts InitGui.py)
 endif(BUILD_GUI)
 
+list(APPEND Surface_Scripts TestSurfaceFreehandBSpline.py)
+list(APPEND Surface_TestScripts
+    SurfaceTests/TestFreehandBSpline.py
+    SurfaceTests/TestFreehandBSplineGui.py
+)
+
 add_custom_target(SurfaceScripts ALL
     SOURCES ${Surface_Scripts} ${Surface_TestScripts}
 )

--- a/src/Mod/Surface/FreehandBSpline.md
+++ b/src/Mod/Surface/FreehandBSpline.md
@@ -1,0 +1,58 @@
+# Freehand B-spline
+
+Choose **Freehand B-Spline** to enter drawing mode. Each click places an
+interpolation point; the moving cursor previews the next point and resulting
+B-spline without adding it to the document. New points lie in a plane parallel
+to the view through the preceding point (the object origin for the first point).
+Drawing clicks that snap to a vertex or edge also lock the new point to that
+reference. Disable snapping to place points without automatic locks. Moving the
+cursor previews the snap without creating a lock.
+Choose **End B-spline**, right-click, or press Esc to enter editing mode.
+Then select and drag points or control-polygon segments, and accept the task
+when finished. Double-click the object in the tree to reopen editing mode.
+
+- Ctrl-click adds/removes points or segments from the selection. Ctrl+A selects
+  all points. Dragging a segment moves both endpoints.
+- X, Y, Z toggle a document-axis constraint during a drag; Shift is not required.
+- Shift reduces movement to one tenth and temporarily suppresses snapping.
+- Double-click the curve to insert a point on it; Delete removes selected points
+  and both endpoints of selected segments.
+- Esc cancels an active drag. Task Cancel restores the entire edit transaction.
+- Click an X, Y or Z coordinate label in the view to edit it in a unit-aware
+  spinbox. Enter or leaving the field applies the value; Escape cancels. Existing
+  reference locks still apply.
+- The table edits local point coordinates. Align selection projects the selected
+  points onto the line through the first and last selected points in curve order.
+- Dragging snaps to nearby vertices and edges within ten pixels, preferring
+  vertices. This is temporary positioning, separate from a persistent lock.
+- To lock a point, select the spline point and a reference vertex, edge or face,
+  then choose **Lock to**. Vertex locks fix the point; edge and
+  face locks allow sliding on the reference. The spline updates when its source
+  geometry changes. Edge locks retain their fractional parameter; face locks
+  retain UV coordinates, clamped to the trimmed face boundary.
+- The **Locked to** column shows `ObjectName.Vertex1`, `ObjectName.Edge1` or
+  `ObjectName.Face1`. Edit the reference or clear the cell to unlock. References
+  are saved with the document; self-references and dependency cycles are rejected.
+  Deleted objects or missing subelements unlock the affected points at their last
+  positions and clear their tangencies. Unrelated valid locks remain attached.
+- **Tangent to** offers **None** and edges meeting at a locked vertex, the locked
+  edge, or the locked face. Edge tangency follows the edge direction; face tangency
+  projects the neighbouring spline direction into the face tangent plane. If that
+  direction is normal to the face, its surface U direction is used. Unlocking or
+  replacing a point reference clears its tangency. Tangencies survive save/reopen
+  and are remapped when points are inserted or deleted. Conflicting adjacent linear
+  segments are rejected.
+- **Interpolation spacing** controls the curve between its points: Uniform uses
+  equal parameter intervals, Centripetal uses square roots of point distances,
+  and Chord length uses the distances themselves. Centripetal is the default.
+  All three methods interpolate the same points; the combo box explains them
+  in its tooltip.
+- Linear interpolation makes the selected spans exactly straight. Smooth
+  interpolation restores their interpolated shape. Adjacent straight spans may
+  form sharp corners. Closed curves need at least three distinct points.
+
+Editing hides the normal object display and uses one unpickable curve preview,
+with Sketcher colors and line styles, a bold tree entry, small coordinate labels,
+and separate point/control-polygon handles.
+
+Run `TestSurfaceFreehandBSpline` for geometry and GUI regressions.

--- a/src/Mod/Surface/Gui/AppFreehandBSplineGui.cpp
+++ b/src/Mod/Surface/Gui/AppFreehandBSplineGui.cpp
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#include "ViewProviderFreehandBSpline.h"
+
+void CreateSurfaceFreehandBSplineCommands();
+
+void initSurfaceFreehandBSplineGui()
+{
+    SurfaceGui::ViewProviderFreehandBSpline::init();
+    CreateSurfaceFreehandBSplineCommands();
+}

--- a/src/Mod/Surface/Gui/AppSurfaceGui.cpp
+++ b/src/Mod/Surface/Gui/AppSurfaceGui.cpp
@@ -40,6 +40,7 @@
 
 // use a different name to CreateCommand()
 void CreateSurfaceCommands();
+void initSurfaceFreehandBSplineGui();
 
 
 namespace SurfaceGui
@@ -73,6 +74,8 @@ PyMOD_INIT_FUNC(SurfaceGui)
 
     Base::Interpreter().runString("import Surface");
     Base::Interpreter().runString("import PartGui");
+
+    initSurfaceFreehandBSplineGui();
 
     // clang-format off
     // instantiating the commands

--- a/src/Mod/Surface/Gui/CMakeLists.txt
+++ b/src/Mod/Surface/Gui/CMakeLists.txt
@@ -61,6 +61,8 @@ add_library(SurfaceGui SHARED
     ${SurfaceGuiIcon_SVG}
 )
 
+include(FreehandBSpline.cmake)
+
 if(FREECAD_USE_PCH)
     target_precompile_headers(SurfaceGui PRIVATE
             $<$<COMPILE_LANGUAGE:CXX>:"${CMAKE_CURRENT_LIST_DIR}/PreCompiled.h">

--- a/src/Mod/Surface/Gui/CommandFreehandBSpline.cpp
+++ b/src/Mod/Surface/Gui/CommandFreehandBSpline.cpp
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <App/Document.h>
+#include <Gui/Application.h>
+#include <Gui/Command.h>
+#include <Gui/Control.h>
+
+DEF_STD_CMD_A(CmdSurfaceFreehandBSpline)
+CmdSurfaceFreehandBSpline::CmdSurfaceFreehandBSpline()
+    : Command("Surface_FreehandBSpline")
+{
+    sAppModule = "Surface";
+    sGroup = QT_TR_NOOP("Surface");
+    sMenuText = QT_TR_NOOP("Freehand B-Spline");
+    sToolTipText = QT_TR_NOOP("Creates an editable B-spline through points placed in the 3D view");
+    sStatusTip = sToolTipText;
+    sPixmap = "Surface_FreehandBSpline";
+}
+bool CmdSurfaceFreehandBSpline::isActive()
+{
+    return hasActiveDocument() && !Gui::Control().activeDialog();
+}
+void CmdSurfaceFreehandBSpline::activated(int)
+{
+    auto name = getUniqueObjectName("FreehandBSpline");
+    openCommand(QT_TRANSLATE_NOOP("Command", "Create freehand B-spline"));
+    doCommand(Doc, "App.ActiveDocument.addObject('Surface::FreehandBSpline', '%s')", name.c_str());
+    doCommand(Doc, "App.ActiveDocument.%s.Points = []", name.c_str());
+    doCommand(Gui, "Gui.ActiveDocument.setEdit('%s')", name.c_str());
+}
+
+void CreateSurfaceFreehandBSplineCommands()
+{
+    auto& manager = Gui::Application::Instance->commandManager();
+    manager.addCommand(new CmdSurfaceFreehandBSpline);
+}

--- a/src/Mod/Surface/Gui/FreehandBSpline.cmake
+++ b/src/Mod/Surface/Gui/FreehandBSpline.cmake
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+qt_add_resources(FreehandBSpline_QRC_SRCS Resources/FreehandBSpline.qrc OPTIONS ${FREECAD_RCC_OPTIONS})
+target_sources(SurfaceGui PRIVATE
+    ${FreehandBSpline_QRC_SRCS}
+    AppFreehandBSplineGui.cpp
+    CommandFreehandBSpline.cpp
+    FreehandBSplineEditor.cpp FreehandBSplineEditor.h
+    ViewProviderFreehandBSpline.cpp ViewProviderFreehandBSpline.h
+)

--- a/src/Mod/Surface/Gui/FreehandBSplineEditor.cpp
+++ b/src/Mod/Surface/Gui/FreehandBSplineEditor.cpp
@@ -229,8 +229,10 @@ FreehandBSplineEditor::FreehandBSplineEditor(ViewProviderFreehandBSpline* provid
                 subname = subs.empty() ? std::string() : subs.front();
             }
             if (!reference) {
-                throw Base::ValueError("Select a reference vertex, edge or face in the view, then "
-                                       "press Lock to.");
+                throw Base::ValueError(
+                    "Select a reference vertex, edge or face in the view, then "
+                    "press Lock to."
+                );
             }
             feature->setPointSupport(*selectedPoints.begin(), reference, subname);
             applyPoints(feature->Points.getValues());
@@ -731,8 +733,10 @@ void FreehandBSplineEditor::refresh()
             auto combo = qobject_cast<QComboBox*>(table->cellWidget(i, 1));
             if (!combo) {
                 combo = new QComboBox;
-                combo->setToolTip(tr("Follow an edge tangent or the tangent plane of a face. "
-                                     "None leaves the spline direction unconstrained."));
+                combo->setToolTip(
+                    tr("Follow an edge tangent or the tangent plane of a face. "
+                       "None leaves the spline direction unconstrained.")
+                );
                 table->setCellWidget(i, 1, combo);
                 connect(combo, qOverload<int>(&QComboBox::activated), this, [this, combo, i] {
                     const auto objects = feature->TangentSupport.getValues();
@@ -773,8 +777,9 @@ void FreehandBSplineEditor::refresh()
             const auto& tangentIndices = feature->TangentPointIndices.getValues();
             for (size_t j = 0; j < tangentIndices.size(); ++j) {
                 if (tangentIndices[j] == i) {
-                    const auto value = QString::fromStdString(feature->TangentSupport.getSubValues(
-                    )[j]);
+                    const auto value = QString::fromStdString(
+                        feature->TangentSupport.getSubValues()[j]
+                    );
                     int selected = combo->findData(value);
                     if (selected < 0) {
                         combo->addItem(value, value);
@@ -1235,8 +1240,7 @@ bool FreehandBSplineEditor::editCoordinateAt(const QPointF& position)
         spin->setUnit(Base::Unit::Length);
         spin->setRange(-1e12, 1e12);
         spin->setValue(feature->Points.getValues()[coordinatePoint][coordinateAxis]);
-        spin->setToolTip(tr("Point %1 - %2").arg(coordinatePoint + 1).arg(QChar('X' + coordinateAxis))
-        );
+        spin->setToolTip(tr("Point %1 - %2").arg(coordinatePoint + 1).arg(QChar('X' + coordinateAxis)));
         spin->resize(spin->sizeHint().expandedTo(QSize(140, 0)));
         const auto bounds = viewer->getGLWidget()->size();
         // Like EditableDatumLabel, center the editor at the label and clamp it to the view.

--- a/src/Mod/Surface/Gui/FreehandBSplineEditor.cpp
+++ b/src/Mod/Surface/Gui/FreehandBSplineEditor.cpp
@@ -1,0 +1,1585 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <algorithm>
+#include <cmath>
+#include <QApplication>
+#include <QCheckBox>
+#include <QComboBox>
+#include <QHeaderView>
+#include <QHBoxLayout>
+#include <QKeyEvent>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMouseEvent>
+#include <QPushButton>
+#include <QSignalBlocker>
+#include <QTableWidget>
+#include <QVBoxLayout>
+#include <Inventor/SbLine.h>
+#include <Inventor/SoPickedPoint.h>
+#include <memory>
+#include <Inventor/SbPlane.h>
+#include <Inventor/nodes/SoBaseColor.h>
+#include <Inventor/nodes/SoCamera.h>
+#include <Inventor/nodes/SoCoordinate3.h>
+#include <Inventor/nodes/SoDrawStyle.h>
+#include <Inventor/nodes/SoFont.h>
+#include <Inventor/nodes/SoLineSet.h>
+#include <Inventor/nodes/SoPickStyle.h>
+#include <Inventor/nodes/SoPointSet.h>
+#include <Inventor/nodes/SoMarkerSet.h>
+#include <App/Application.h>
+#include <Gui/Inventor/MarkerBitmaps.h>
+#include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoText2.h>
+#include <Inventor/nodes/SoTranslation.h>
+#include <BRep_Tool.hxx>
+#include <GeomAPI_ProjectPointOnCurve.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopExp.hxx>
+#include <TopTools_IndexedMapOfShape.hxx>
+#include <TopoDS.hxx>
+#include <App/Document.h>
+#include <Base/Exception.h>
+#include <Gui/Document.h>
+#include <Gui/InputHint.h>
+#include <Gui/QuantitySpinBox.h>
+#include <Inventor/actions/SoRayPickAction.h>
+#include <Inventor/SoRenderManager.h>
+#include <Inventor/details/SoTextDetail.h>
+#include <Gui/MainWindow.h>
+#include <Gui/Selection/Selection.h>
+#include <Gui/View3DInventorViewer.h>
+#include <Mod/Surface/App/FeatureFreehandBSpline.h>
+#include "FreehandBSplineEditor.h"
+#include "ViewProviderFreehandBSpline.h"
+
+using namespace SurfaceGui;
+
+namespace
+{
+// Share Sketcher's preference keys without requiring the Sketcher workbench to be loaded.
+struct EditStyle
+{
+    ParameterGrp::handle view = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/View"
+    );
+    ParameterGrp::handle sketch = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Sketcher/View"
+    );
+    SbColor color(const char* key, unsigned long fallback) const
+    {
+        SbColor result;
+        float transparency = 0;
+        result.setPackedValue(static_cast<uint32_t>(view->GetUnsigned(key, fallback)), transparency);
+        return result;
+    }
+    SbColor geometry = color("EditedEdgeColor", 0xffffffff);
+    SbColor construction = color("ConstructionColor", 0x0000dcff);
+    SbColor constraint = color("ConstrainedIcoColor", 0xff2600ff);
+    SbColor selection = color("SelectionColor", 0x00abffff);
+    SbColor preselection = color("HighlightColor", 0x0ac8ffff);
+    SbColor highlight(const SbColor& normal, bool selected, bool hovered) const
+    {
+        return hovered ? preselection : selected ? selection : normal;
+    }
+    double scale(double pixelRatio) const
+    {
+        return pixelRatio * std::clamp(view->GetFloat("ViewScalingFactor", 1.0), 0.5, 5.0);
+    }
+    SoMarkerSet* marker(double pixelRatio) const
+    {
+        const auto sizes = Gui::Inventor::MarkerBitmaps::getSupportedSizes("CIRCLE_FILLED");
+        auto size = static_cast<int>(std::lround(view->GetInt("MarkerSize", 7) * pixelRatio));
+        if (!sizes.empty()) {
+            const auto match = std::lower_bound(sizes.begin(), sizes.end(), size);
+            size = match != sizes.end() ? *match : sizes.back();
+        }
+        auto result = new SoMarkerSet;
+        result->markerIndex = Gui::Inventor::MarkerBitmaps::getMarkerIndex("CIRCLE_FILLED", size);
+        return result;
+    }
+};
+SbVec3f coin(const Base::Vector3d& p)
+{
+    return SbVec3f(static_cast<float>(p.x), static_cast<float>(p.y), static_cast<float>(p.z));
+}
+Base::Vector3d vector(const gp_Pnt& p)
+{
+    return Base::Vector3d(p.X(), p.Y(), p.Z());
+}
+double squareDistance(const QPointF& a, const QPointF& b)
+{
+    const auto d = a - b;
+    return d.x() * d.x() + d.y() * d.y();
+}
+double segmentDistance(const QPointF& p, const QPointF& a, const QPointF& b, double& t)
+{
+    const auto ab = b - a, ap = p - a;
+    const double length = squareDistance(a, b);
+    t = length > 1e-12 ? std::clamp((ap.x() * ab.x() + ap.y() * ab.y()) / length, 0.0, 1.0) : 0;
+    return squareDistance(p, a + ab * t);
+}
+}  // namespace
+
+FreehandBSplineEditor::FreehandBSplineEditor(ViewProviderFreehandBSpline* provider)
+    : Gui::SelectionObserver(false)
+    , vp(provider)
+    , feature(static_cast<Surface::FreehandBSpline*>(provider->getObject()))
+    , overlay(new SoSeparator)
+    , sceneRoot(provider->getRoot())
+{
+    setWindowTitle(tr("Freehand B-spline"));
+    setObjectName(QStringLiteral("FreehandBSplineEditor"));
+    overlay->setName("FreehandBSplineEditOverlay");
+    overlay->ref();
+    sceneRoot->ref();
+    sceneRoot->addChild(overlay);
+    auto layout = new QVBoxLayout(this);
+    drawing = feature->Points.getSize() < 2;
+    preview = new SoSeparator;
+    preview->ref();
+    preview->setName("FreehandBSplineDrawingPreview");
+    sceneRoot->addChild(preview);
+    endDrawingButton = new QPushButton(tr("End B-spline"));
+    endDrawingButton->setObjectName(QStringLiteral("endBSpline"));
+    endDrawingButton->setVisible(drawing);
+    connect(endDrawingButton, &QPushButton::clicked, this, [this] { endDrawing(); });
+    layout->addWidget(endDrawingButton);
+    snapping = new QCheckBox(tr("Snap to vertices and edges"));
+    snapping->setObjectName(QStringLiteral("snapping"));
+    snapping->setChecked(true);
+    layout->addWidget(snapping);
+    coordinates = new QCheckBox(tr("Show point coordinates"));
+    coordinates->setChecked(true);
+    layout->addWidget(coordinates);
+    auto closed = new QCheckBox(tr("Closed curve"));
+    closed->setObjectName(QStringLiteral("closedCurve"));
+    closed->setChecked(feature->Periodic.getValue());
+    layout->addWidget(closed);
+    auto parameterization = new QComboBox;
+    parameterization->setObjectName(QStringLiteral("parameterization"));
+    parameterization->addItem(tr("Uniform"), 0.0);
+    parameterization->addItem(tr("Centripetal"), 0.5);
+    parameterization->addItem(tr("Chord length"), 1.0);
+    parameterization->setCurrentIndex(
+        feature->Parameterization.getValue() < 0.25       ? 0
+            : feature->Parameterization.getValue() > 0.75 ? 2
+                                                          : 1
+    );
+    parameterization->setToolTip(
+        tr("Controls how the curve bends between interpolation points.\n"
+           "Uniform: gives each span equal weight, regardless of point spacing.\n"
+           "Centripetal: uses the square root of point spacing; a balanced default for unevenly "
+           "spaced points.\n"
+           "Chord length: uses the distance between points to weight each span.\n"
+           "All three methods pass through the same points.")
+    );
+    auto interpolationRow = new QHBoxLayout;
+    interpolationRow->addWidget(new QLabel(tr("Interpolation spacing")));
+    interpolationRow->addWidget(parameterization, 1);
+    layout->addLayout(interpolationRow);
+    table = new QTableWidget(0, 5);
+    table->setObjectName(QStringLiteral("interpolationPoints"));
+    table->setHorizontalHeaderLabels(
+        {tr("Locked to"), tr("Tangent to"), tr("X (mm)"), tr("Y (mm)"), tr("Z (mm)")}
+    );
+    table->setSelectionBehavior(QAbstractItemView::SelectRows);
+    table->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    table->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Interactive);
+    table->setColumnWidth(0, 112);
+    table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Interactive);
+    table->setColumnWidth(1, 100);
+    for (int column = 2; column < 5; ++column) {
+        table->horizontalHeader()->setSectionResizeMode(column, QHeaderView::Interactive);
+        table->setColumnWidth(column, 60);
+    }
+    table->setMinimumHeight(140);
+    layout->addWidget(table);
+    auto buttons = new QGridLayout;
+    auto button = [&](const QString& text, const char* name, int row, int column, auto callback) {
+        auto widget = new QPushButton(text);
+        widget->setObjectName(QString::fromLatin1(name));
+        buttons->addWidget(widget, row, column);
+        connect(widget, &QPushButton::clicked, this, callback);
+    };
+    button(tr("Align selection"), "alignSelection", 0, 0, [this] { alignPoints(); });
+    button(tr("Lock to"), "lockPoint", 0, 1, [this] {
+        if (selectedPoints.size() != 1) {
+            status->setText(tr("Select one spline point, then a vertex, edge or face to lock it to."));
+            return;
+        }
+        try {
+            if (selectedPointIsLocked()) {
+                feature->setPointSupport(*selectedPoints.begin(), nullptr, {});
+                applyPoints(feature->Points.getValues());
+                return;
+            }
+            App::DocumentObject* reference = nullptr;
+            std::string subname;
+            for (auto selected : Gui::Selection().getSelectionEx()) {
+                if (selected.getObject() == feature) {
+                    continue;
+                }
+                const auto subs = selected.getSubNames();
+                if (reference || subs.size() > 1) {
+                    throw Base::ValueError("Select exactly one reference vertex, edge or face.");
+                }
+                reference = selected.getObject();
+                subname = subs.empty() ? std::string() : subs.front();
+            }
+            if (!reference) {
+                throw Base::ValueError("Select a reference vertex, edge or face in the view, then "
+                                       "press Lock to.");
+            }
+            feature->setPointSupport(*selectedPoints.begin(), reference, subname);
+            applyPoints(feature->Points.getValues());
+        }
+        catch (const Base::Exception& error) {
+            status->setText(QString::fromUtf8(error.what()));
+        }
+        catch (const Standard_Failure& error) {
+            status->setText(QString::fromUtf8(error.GetMessageString()));
+        }
+    });
+    button(tr("Set linear interpolation"), "toggleInterpolation", 1, 0, [this] {
+        setLinear(!selectedSpansAreLinear());
+    });
+    button(tr("Select all"), "selectAll", 1, 1, [this] { selectAllPoints(); });
+    editControls = new QWidget;
+    editControls->setLayout(buttons);
+    editControls->setEnabled(!drawing);
+    table->setEnabled(!drawing);
+    layout->addWidget(editControls);
+    status = new QLabel;
+    status->setWordWrap(true);
+    layout->addWidget(status);
+    connect(coordinates, &QCheckBox::toggled, this, [this] { refresh(); });
+    connect(closed, &QCheckBox::toggled, this, [this](bool value) {
+        feature->Periodic.setValue(value);
+        selectedSegments.clear();
+        applyPoints(feature->Points.getValues());
+    });
+    connect(
+        parameterization,
+        qOverload<int>(&QComboBox::currentIndexChanged),
+        this,
+        [this, parameterization] {
+            feature->Parameterization.setValue(parameterization->currentData().toDouble());
+            applyPoints(feature->Points.getValues());
+        }
+    );
+    connect(table, &QTableWidget::itemSelectionChanged, this, [this] {
+        if (refreshing) {
+            return;
+        }
+        selectedPoints.clear();
+        selectedSegments.clear();
+        for (auto item : table->selectedItems()) {
+            selectedPoints.insert(item->row());
+        }
+        refresh();
+    });
+    connect(table, &QTableWidget::cellChanged, this, [this](int row, int column) {
+        if (refreshing) {
+            return;
+        }
+        if (column == 0) {
+            try {
+                const auto text = table->item(row, column)->text().trimmed();
+                App::DocumentObject* object = nullptr;
+                std::string subname;
+                if (!text.isEmpty()) {
+                    const auto split = text.indexOf(QLatin1Char('.'));
+                    const auto objectName = split < 0 ? text : text.left(split);
+                    object = feature->getDocument()->getObject(objectName.toUtf8().constData());
+                    subname = split < 0 ? std::string() : text.mid(split + 1).toStdString();
+                    if (!object) {
+                        throw Base::ValueError("The reference object does not exist.");
+                    }
+                }
+                feature->setPointSupport(row, object, subname);
+                applyPoints(feature->Points.getValues());
+            }
+            catch (const Base::Exception& error) {
+                refresh();
+                status->setText(QString::fromUtf8(error.what()));
+            }
+            catch (const Standard_Failure& error) {
+                refresh();
+                status->setText(QString::fromUtf8(error.GetMessageString()));
+            }
+            return;
+        }
+        if (column == 1) {
+            return;
+        }
+        bool valid = false;
+        double value = table->item(row, column)->text().toDouble(&valid);
+        if (!valid || !std::isfinite(value)) {
+            refresh();
+            return;
+        }
+        auto points = feature->Points.getValues();
+        points[row][column - 2] = value;
+        applyPoints(points);
+    });
+    Gui::Selection().clearSelection();
+    refresh();
+}
+
+FreehandBSplineEditor::~FreehandBSplineEditor()
+{
+    qApp->removeEventFilter(this);
+    setViewer(nullptr);
+    sceneRoot->removeChild(preview);
+    preview->unref();
+    sceneRoot->removeChild(overlay);
+    sceneRoot->unref();
+    overlay->unref();
+}
+
+void FreehandBSplineEditor::setViewer(Gui::View3DInventorViewer* view)
+{
+    finishCoordinateEdit(false);
+    detachSelection();
+    qApp->removeEventFilter(this);
+    const bool hadViewer = viewer;
+    if (viewer) {
+        if (drawing) {
+            Gui::ToolHandler::deactivate();
+        }
+    }
+    viewer = view;
+    if (viewer) {
+        attachSelection();
+        qApp->installEventFilter(this);
+        viewer->getGLWidget()->setMouseTracking(true);
+        cacheSnapShapes();
+        if (drawing) {
+            Gui::ToolHandler::activate();
+        }
+    }
+    dragging = false;
+    ownedButtons = Qt::NoButton;
+    if (viewer) {
+        updateHints();
+    }
+    else if (hadViewer && Gui::getMainWindow()) {
+        Gui::getMainWindow()->hideHints();
+    }
+}
+
+QWidget* FreehandBSplineEditor::getCursorWidget()
+{
+    return viewer ? viewer->getGLWidget() : nullptr;
+}
+
+QString FreehandBSplineEditor::getCrosshairCursorSVGName() const
+{
+    return QStringLiteral("Surface_Pointer_FreehandBSpline");
+}
+
+void FreehandBSplineEditor::endDrawing()
+{
+    if (!validate()) {
+        return;
+    }
+    if (viewer) {
+        Gui::ToolHandler::deactivate();
+    }
+    drawing = false;
+    preview->removeAllChildren();
+    endDrawingButton->hide();
+    editControls->setEnabled(true);
+    table->setEnabled(true);
+    if (viewer) {
+        viewer->getGLWidget()->setFocus();
+    }
+    refresh();
+}
+
+void FreehandBSplineEditor::updateDrawingPreview(const QPointF& position)
+{
+    auto points = feature->Points.getValues();
+    auto candidate = onViewPlane(position, toWorld(points.empty() ? Base::Vector3d() : points.back()));
+    if (snapping->isChecked()) {
+        snap(candidate, position);
+    }
+    points.push_back(toLocal(candidate));
+    updateCurvePreview(points, true);
+}
+
+void FreehandBSplineEditor::updateCurvePreview(const std::vector<Base::Vector3d>& points, bool showCursor)
+{
+    preview->removeAllChildren();
+    auto pick = new SoPickStyle;
+    pick->style = SoPickStyle::UNPICKABLE;
+    preview->addChild(pick);
+    auto color = new SoBaseColor;
+    const EditStyle preferences;
+    const auto ratio = viewer ? viewer->getGLWidget()->devicePixelRatioF() : devicePixelRatioF();
+    color->rgb = preferences.geometry;
+    preview->addChild(color);
+    auto style = new SoDrawStyle;
+    style->lineWidth = preferences.sketch->GetInt("EdgeWidth", 2) * preferences.scale(ratio);
+    style->linePattern = preferences.sketch->GetInt("EdgePattern", 0xffff);
+    preview->addChild(style);
+    if (showCursor && !points.empty()) {
+        auto cursor = new SoCoordinate3;
+        cursor->point.set1Value(0, coin(points.back()));
+        preview->addChild(cursor);
+        preview->addChild(preferences.marker(ratio));
+    }
+    try {
+        // Use the same interpolation as the feature, without modifying document properties.
+        auto curve = feature->interpolate(points);
+        auto vertices = new SoCoordinate3;
+        constexpr int samples = 128;
+        for (int i = 0; i <= samples; ++i) {
+            double parameter = curve->FirstParameter()
+                + (curve->LastParameter() - curve->FirstParameter()) * i / samples;
+            vertices->point.set1Value(i, coin(vector(curve->Value(parameter))));
+        }
+        preview->addChild(vertices);
+        auto line = new SoLineSet;
+        line->numVertices.set1Value(0, samples + 1);
+        preview->addChild(line);
+    }
+    catch (const Base::Exception&) {
+        // An insufficient or coincident provisional point still has a cursor marker.
+    }
+    catch (const Standard_Failure&) {
+    }
+}
+
+void FreehandBSplineEditor::updateHints()
+{
+    if (!viewer) {
+        return;
+    }
+    using enum Gui::InputHint::UserInput;
+    std::list<Gui::InputHint> hints;
+    if (drawing) {
+        hints = {
+            {.message = tr("%1 place interpolation point"), .sequences = {MouseLeft}},
+            {.message = tr("%1 / %2 end B-spline and edit points"),
+             .sequences = {MouseRight, KeyEscape}},
+        };
+    }
+    else if (dragging) {
+        hints = {
+            {.message = axis < 0
+                 ? tr("%1 move selection")
+                 : tr("%1 move along %2").arg(QStringLiteral("%1"), QString(QChar('X' + axis))),
+             .sequences = {MouseMoveLeft}},
+            {.message = tr("%1 fine movement"), .sequences = {ModifierShift}},
+            {.message = tr("%1 / %2 / %3 toggle axis constraint"), .sequences = {KeyX, KeyY, KeyZ}},
+            {.message = tr("%1 cancel drag"), .sequences = {KeyEscape}},
+        };
+    }
+    else {
+        hints = {
+            {.message = tr("%1 extend selection"), .sequences = {{ModifierCtrl, MouseLeft}}},
+            {.message = tr("%1 drag selection"), .sequences = {MouseMoveLeft}},
+            {.message = tr("%1 insert point"), .sequences = {MouseDoubleLeft}},
+            {.message = tr("%1 select all"), .sequences = {{ModifierCtrl, KeyA}}},
+        };
+        if (!movingPoints().empty()) {
+            hints.push_back({.message = tr("%1 delete points"), .sequences = {KeyDelete}});
+        }
+    }
+    Gui::getMainWindow()->showHints(hints);
+}
+
+Base::Vector3d FreehandBSplineEditor::toWorld(const Base::Vector3d& p) const
+{
+    Base::Vector3d result;
+    App::GeoFeature::getGlobalPlacement(feature).multVec(p, result);
+    return result;
+}
+Base::Vector3d FreehandBSplineEditor::toLocal(const Base::Vector3d& p) const
+{
+    Base::Vector3d result;
+    App::GeoFeature::getGlobalPlacement(feature).inverse().multVec(p, result);
+    return result;
+}
+QPointF FreehandBSplineEditor::screen(const Base::Vector3d& p) const
+{
+    const auto size = viewer->getGLWidget()->size();
+    SbVec3f projected;
+    viewer->getCamera()
+        ->getViewVolume(static_cast<float>(size.width()) / size.height())
+        .projectToScreen(coin(p), projected);
+    return {projected[0] * size.width(), (1 - projected[1]) * size.height()};
+}
+Base::Vector3d FreehandBSplineEditor::onViewPlane(
+    const QPointF& position,
+    const Base::Vector3d& origin
+) const
+{
+    const auto size = viewer->getGLWidget()->size();
+    auto volume = viewer->getCamera()->getViewVolume(static_cast<float>(size.width()) / size.height());
+    SbLine ray;
+    volume.projectPointToLine(
+        SbVec2f(
+            static_cast<float>(position.x() / size.width()),
+            static_cast<float>(1 - position.y() / size.height())
+        ),
+        ray
+    );
+    SbPlane plane(volume.getProjectionDirection(), coin(origin));
+    SbVec3f result;
+    if (!plane.intersect(ray, result)) {
+        return origin;
+    }
+    return Base::Vector3d(result[0], result[1], result[2]);
+}
+
+bool FreehandBSplineEditor::selectedPointIsLocked() const
+{
+    if (selectedPoints.size() != 1 || !selectedSegments.empty()) {
+        return false;
+    }
+    const auto& indices = feature->SupportPointIndices.getValues();
+    return std::find(indices.begin(), indices.end(), *selectedPoints.begin()) != indices.end();
+}
+
+bool FreehandBSplineEditor::selectedSpansAreLinear() const
+{
+    const int count = feature->Points.getSize();
+    const int spans = feature->Periodic.getValue() ? count : count - 1;
+    const auto& flags = feature->LinearSegments.getValues();
+    bool found = false;
+    for (int i = 0; i < spans; ++i) {
+        if (selectedSegments.count(i)) {
+            found = true;
+            if (i >= static_cast<int>(flags.size()) || !flags[i]) {
+                return false;
+            }
+        }
+    }
+    return found;
+}
+
+bool FreehandBSplineEditor::hasValidReference() const
+{
+    try {
+        App::DocumentObject* reference = nullptr;
+        std::string subname;
+        for (auto selected : Gui::Selection().getSelectionEx()) {
+            if (selected.getObject() == feature) {
+                continue;
+            }
+            const auto subs = selected.getSubNames();
+            if (reference || subs.size() > 1) {
+                return false;
+            }
+            reference = selected.getObject();
+            subname = subs.empty() ? std::string() : subs.front();
+        }
+        if (!reference || reference->getDocument() != feature->getDocument()) {
+            return false;
+        }
+        const auto dependents = feature->getInListRecursive();
+        if (std::find(dependents.begin(), dependents.end(), reference) != dependents.end()) {
+            return false;
+        }
+        auto shape = Part::Feature::getShape(
+            reference,
+            Part::ShapeOption::ResolveLink | Part::ShapeOption::Transform
+                | Part::ShapeOption::NeedSubElement,
+            subname.c_str()
+        );
+        if (shape.IsNull()) {
+            return false;
+        }
+        if (shape.ShapeType() == TopAbs_VERTEX || shape.ShapeType() == TopAbs_EDGE
+            || shape.ShapeType() == TopAbs_FACE) {
+            return true;
+        }
+        if ((shape.ShapeType() == TopAbs_WIRE || shape.ShapeType() == TopAbs_COMPOUND)
+            && !TopExp_Explorer(shape, TopAbs_FACE).More()) {
+            TopExp_Explorer edges(shape, TopAbs_EDGE);
+            if (edges.More()) {
+                edges.Next();
+                return !edges.More();
+            }
+        }
+    }
+    catch (const Base::Exception&) {
+    }
+    catch (const Standard_Failure&) {
+    }
+    return false;
+}
+
+void FreehandBSplineEditor::onSelectionChanged(const Gui::SelectionChanges&)
+{
+    if (viewer) {
+        updateToolButtons();
+    }
+}
+
+void FreehandBSplineEditor::updateToolButtons()
+{
+    const auto moving = movingPoints();
+    const auto& points = feature->Points.getValues();
+    auto lock = findChild<QPushButton*>(QStringLiteral("lockPoint"));
+    lock->setText(selectedPointIsLocked() ? tr("Unlock") : tr("Lock to"));
+    lock->setEnabled(
+        !drawing && selectedPoints.size() == 1 && selectedSegments.empty()
+        && (selectedPointIsLocked() || hasValidReference())
+    );
+    auto interpolation = findChild<QPushButton*>(QStringLiteral("toggleInterpolation"));
+    interpolation->setText(
+        selectedSpansAreLinear() ? tr("Set smooth interpolation") : tr("Set linear interpolation")
+    );
+    interpolation->setEnabled(!drawing && !selectedSegments.empty());
+    findChild<QPushButton*>(QStringLiteral("alignSelection"))
+        ->setEnabled(
+            !drawing && moving.size() >= 3
+            && (points[*moving.rbegin()] - points[*moving.begin()]).Sqr() >= 1e-14
+        );
+    findChild<QPushButton*>(QStringLiteral("selectAll"))
+        ->setEnabled(!drawing && !points.empty() && selectedPoints.size() != points.size());
+}
+
+void FreehandBSplineEditor::refresh()
+{
+    feature->sanitizeReferences();
+    const EditStyle preferences;
+    const auto ratio = viewer ? viewer->getGLWidget()->devicePixelRatioF() : devicePixelRatioF();
+    refreshing = true;
+    QSignalBlocker blocker(table);
+    const auto& points = feature->Points.getValues();
+    table->setRowCount(static_cast<int>(points.size()));
+    table->clearSelection();
+    coordinateLabels.assign(points.size(), nullptr);
+    overlay->removeAllChildren();
+    auto pick = new SoPickStyle;
+    pick->style = SoPickStyle::UNPICKABLE;
+    overlay->addChild(pick);
+    const int count = static_cast<int>(points.size());
+    const int spans = feature->Periodic.getValue() && count > 2 ? count : count - 1;
+    for (int i = 0; i < spans; ++i) {
+        auto separator = new SoSeparator;
+        auto color = new SoBaseColor;
+        color->rgb = preferences.highlight(
+            preferences.construction,
+            selectedSegments.count(i),
+            hoveredSegment == i
+        );
+        auto style = new SoDrawStyle;
+        style->lineWidth = preferences.sketch->GetInt("ConstructionWidth", 2)
+            * preferences.scale(ratio);
+        style->linePattern = preferences.sketch->GetInt("ConstructionPattern", 0xfcfc);
+        auto vertices = new SoCoordinate3;
+        vertices->point.set1Value(0, coin(points[i]));
+        vertices->point.set1Value(1, coin(points[(i + 1) % count]));
+        auto line = new SoLineSet;
+        line->numVertices.set1Value(0, 2);
+        separator->addChild(color);
+        separator->addChild(style);
+        separator->addChild(vertices);
+        separator->addChild(line);
+        overlay->addChild(separator);
+    }
+    for (int i = 0; i < count; ++i) {
+        for (int j = 0; j < 3; ++j) {
+            auto item = table->item(i, j + 2);
+            if (!item) {
+                item = new QTableWidgetItem;
+                table->setItem(i, j + 2, item);
+            }
+            item->setText(QString::number(points[i][j], 'g', 10));
+            item->setSelected(selectedPoints.count(i));
+        }
+        auto reference = table->item(i, 0);
+        if (!reference) {
+            reference = new QTableWidgetItem;
+            table->setItem(i, 0, reference);
+        }
+        QString name;
+        const auto indices = feature->SupportPointIndices.getValues();
+        for (size_t j = 0; j < indices.size(); ++j) {
+            if (indices[j] == i && feature->Support.getValues()[j]) {
+                name = QString::fromUtf8(feature->Support.getValues()[j]->getNameInDocument());
+                if (!feature->Support.getSubValues()[j].empty()) {
+                    name += QLatin1Char('.')
+                        + QString::fromStdString(feature->Support.getSubValues()[j]);
+                }
+            }
+        }
+        reference->setText(name);
+        reference->setToolTip(
+            tr("Persistent reference: ObjectName.Vertex1, ObjectName.Edge1 or "
+               "ObjectName.Face1.\nEdit to replace the reference, or clear to unlock.")
+        );
+        reference->setSelected(selectedPoints.count(i));
+        auto tangentItem = table->item(i, 1);
+        if (!tangentItem) {
+            tangentItem = new QTableWidgetItem;
+            tangentItem->setFlags(tangentItem->flags() & ~Qt::ItemIsEditable);
+            table->setItem(i, 1, tangentItem);
+        }
+        tangentItem->setSelected(selectedPoints.count(i));
+        if (name.isEmpty()) {
+            table->removeCellWidget(i, 1);
+        }
+        else {
+            auto combo = qobject_cast<QComboBox*>(table->cellWidget(i, 1));
+            if (!combo) {
+                combo = new QComboBox;
+                combo->setToolTip(tr("Follow an edge tangent or the tangent plane of a face. "
+                                     "None leaves the spline direction unconstrained."));
+                table->setCellWidget(i, 1, combo);
+                connect(combo, qOverload<int>(&QComboBox::activated), this, [this, combo, i] {
+                    const auto objects = feature->TangentSupport.getValues();
+                    const auto names = feature->TangentSupport.getSubValues();
+                    const auto indices = feature->TangentPointIndices.getValues();
+                    try {
+                        feature->setPointTangent(i, combo->currentData().toString().toStdString());
+                        feature->interpolate();
+                        applyPoints(feature->Points.getValues());
+                    }
+                    catch (const Base::Exception& error) {
+                        feature->TangentSupport.setValues(objects, names);
+                        feature->TangentPointIndices.setValues(indices);
+                        refresh();
+                        status->setText(QString::fromUtf8(error.what()));
+                    }
+                    catch (const Standard_Failure& error) {
+                        feature->TangentSupport.setValues(objects, names);
+                        feature->TangentPointIndices.setValues(indices);
+                        refresh();
+                        status->setText(QString::fromUtf8(error.GetMessageString()));
+                    }
+                });
+            }
+            const QSignalBlocker comboBlocker(combo);
+            combo->clear();
+            combo->addItem(tr("None"), QString());
+            try {
+                for (const auto& choice : feature->tangentChoices(i)) {
+                    const auto label = QString::fromStdString(choice);
+                    combo->addItem(label, label);
+                }
+            }
+            catch (const Base::Exception&) {
+            }
+            catch (const Standard_Failure&) {
+            }
+            const auto& tangentIndices = feature->TangentPointIndices.getValues();
+            for (size_t j = 0; j < tangentIndices.size(); ++j) {
+                if (tangentIndices[j] == i) {
+                    const auto value = QString::fromStdString(feature->TangentSupport.getSubValues(
+                    )[j]);
+                    int selected = combo->findData(value);
+                    if (selected < 0) {
+                        combo->addItem(value, value);
+                        selected = combo->count() - 1;
+                    }
+                    combo->setCurrentIndex(selected);
+                }
+            }
+        }
+        auto separator = new SoSeparator;
+        auto color = new SoBaseColor;
+        const bool endpoint = !feature->Periodic.getValue() && (i == 0 || i == count - 1);
+        const auto normal = !name.isEmpty() ? preferences.constraint
+            : endpoint                      ? preferences.geometry
+                                            : preferences.construction;
+        color->rgb = preferences.highlight(normal, selectedPoints.count(i), hoveredPoint == i);
+        auto vertex = new SoCoordinate3;
+        vertex->point.set1Value(0, coin(points[i]));
+        separator->addChild(color);
+        separator->addChild(vertex);
+        separator->addChild(preferences.marker(ratio));
+        if (coordinates->isChecked()) {
+            auto translation = new SoTranslation;
+            translation->translation = coin(points[i]);
+            auto font = new SoFont;
+            font->size = 10;
+            auto text = new SoText2;
+            coordinateLabels[i] = text;
+            const QStringList labels {
+                QStringLiteral("  %1").arg(i + 1),
+                tr("  X %1").arg(points[i].x, 0, 'f', 2),
+                tr("  Y %1").arg(points[i].y, 0, 'f', 2),
+                tr("  Z %1").arg(points[i].z, 0, 'f', 2),
+            };
+            for (int row = 0; row < labels.size(); ++row) {
+                text->string.set1Value(row, labels[row].toUtf8().constData());
+            }
+            separator->addChild(translation);
+            separator->addChild(font);
+            separator->addChild(text);
+        }
+        overlay->addChild(separator);
+    }
+    updateCurvePreview(points);
+    updateToolButtons();
+    refreshing = false;
+    updateHints();
+}
+
+void FreehandBSplineEditor::applyPoints(const std::vector<Base::Vector3d>& points)
+{
+    hoveredPoint = -1;
+    hoveredSegment = -1;
+    feature->Points.setValues(points);
+    try {
+        feature->updateSupportedPoints(true);
+    }
+    catch (const Base::Exception& error) {
+        refresh();
+        status->setText(QString::fromUtf8(error.what()));
+        return;
+    }
+    catch (const Standard_Failure& error) {
+        refresh();
+        status->setText(QString::fromUtf8(error.GetMessageString()));
+        return;
+    }
+    if (points.size() >= (feature->Periodic.getValue() ? 3U : 2U)) {
+        if (validate()) {
+            feature->recomputeFeature();
+        }
+    }
+    else {
+        feature->Shape.setValue(TopoDS_Shape());
+    }
+    refresh();
+}
+
+bool FreehandBSplineEditor::validate()
+{
+    try {
+        feature->interpolate();
+        status->clear();
+        return true;
+    }
+    catch (const Standard_Failure& error) {
+        status->setText(QString::fromUtf8(error.GetMessageString()));
+    }
+    catch (const Base::Exception& error) {
+        status->setText(QString::fromUtf8(error.what()));
+    }
+    return false;
+}
+
+std::set<int> FreehandBSplineEditor::movingPoints() const
+{
+    auto result = selectedPoints;
+    const int count = feature->Points.getSize();
+    for (int i : selectedSegments) {
+        result.insert(i);
+        result.insert((i + 1) % count);
+    }
+    return result;
+}
+
+int FreehandBSplineEditor::hitPoint(const QPointF& position) const
+{
+    const auto& points = feature->Points.getValues();
+    double distance = 100.0;
+    int hit = -1;
+    for (size_t i = 0; i < points.size(); ++i) {
+        const double d = squareDistance(position, screen(toWorld(points[i])));
+        if (d < distance) {
+            distance = d;
+            hit = static_cast<int>(i);
+        }
+    }
+    return hit;
+}
+int FreehandBSplineEditor::hitSegment(const QPointF& position) const
+{
+    const auto& points = feature->Points.getValues();
+    const int count = static_cast<int>(points.size());
+    int hit = -1;
+    double distance = 64.0;
+    for (int i = 0; i < (feature->Periodic.getValue() ? count : count - 1); ++i) {
+        double t;
+        const double d = segmentDistance(
+            position,
+            screen(toWorld(points[i])),
+            screen(toWorld(points[(i + 1) % count])),
+            t
+        );
+        if (d < distance) {
+            hit = i;
+            distance = d;
+        }
+    }
+    return hit;
+}
+
+void FreehandBSplineEditor::selectAllPoints()
+{
+    selectedPoints.clear();
+    selectedSegments.clear();
+    for (int i = 0; i < feature->Points.getSize(); ++i) {
+        selectedPoints.insert(i);
+    }
+    refresh();
+}
+
+void FreehandBSplineEditor::deletePoints()
+{
+    const auto removed = movingPoints();
+    if (removed.empty()) {
+        return;
+    }
+    auto points = feature->Points.getValues();
+    std::vector<Base::Vector3d> remaining;
+    boost::dynamic_bitset<> linear;
+    const auto flags = feature->LinearSegments.getValues();
+    std::vector<int> retained;
+    for (int i = 0; i < static_cast<int>(points.size()); ++i) {
+        if (!removed.count(i)) {
+            remaining.push_back(points[i]);
+            retained.push_back(i);
+        }
+    }
+    if (remaining.size() < (feature->Periodic.getValue() ? 3U : 2U)) {
+        status->setText(tr("Keep at least two points, or three for a closed curve."));
+        return;
+    }
+    const size_t spans = feature->Periodic.getValue() ? retained.size() : retained.size() - 1;
+    for (size_t i = 0; i < spans; ++i) {
+        int previous = retained[i], next = retained[(i + 1) % retained.size()];
+        linear.push_back(
+            next == (previous + 1) % static_cast<int>(points.size())
+            && previous < static_cast<int>(flags.size()) && flags[previous]
+        );
+    }
+    feature->remapSupports(retained);
+    feature->LinearSegments.setValues(linear);
+    selectedPoints.clear();
+    selectedSegments.clear();
+    applyPoints(remaining);
+}
+
+void FreehandBSplineEditor::alignPoints()
+{
+    const auto selected = movingPoints();
+    if (selected.size() < 3) {
+        status->setText(tr("Select at least three points to align."));
+        return;
+    }
+    auto points = feature->Points.getValues();
+    const auto origin = points[*selected.begin()];
+    auto direction = points[*selected.rbegin()] - origin;
+    double length = direction.Sqr();
+    if (length < 1e-14) {
+        status->setText(tr("The first and last selected points must differ."));
+        return;
+    }
+    for (int i : selected) {
+        points[i] = origin + direction * ((points[i] - origin).Dot(direction) / length);
+    }
+    applyPoints(points);
+}
+
+void FreehandBSplineEditor::setLinear(bool value)
+{
+    const int count = feature->Points.getSize();
+    const int spans = feature->Periodic.getValue() ? count : count - 1;
+    if (spans < 1) {
+        return;
+    }
+    auto flags = feature->LinearSegments.getValues();
+    flags.resize(spans, false);
+    bool changed = false;
+    for (int i = 0; i < spans; ++i) {
+        if (selectedSegments.count(i)) {
+            flags[i] = value;
+            changed = true;
+        }
+    }
+    if (!changed) {
+        status->setText(tr("Select one or more segments."));
+        return;
+    }
+    feature->LinearSegments.setValues(flags);
+    applyPoints(feature->Points.getValues());
+}
+
+void FreehandBSplineEditor::insertPoint(const QPointF& position)
+{
+    if (feature->Points.getSize() < 2) {
+        return;
+    }
+    try {
+        auto curve = feature->interpolate();
+        const double first = curve->FirstParameter(), last = curve->LastParameter();
+        double parameter = first, distance = 100.0;
+        const int samples = std::max(200, feature->Points.getSize() * 30);
+        for (int i = 0; i < samples; ++i) {
+            const double a = first + (last - first) * i / samples,
+                         b = first + (last - first) * (i + 1) / samples;
+            double t;
+            double d = segmentDistance(
+                position,
+                screen(toWorld(vector(curve->Value(a)))),
+                screen(toWorld(vector(curve->Value(b)))),
+                t
+            );
+            if (d < distance) {
+                distance = d;
+                parameter = a + (b - a) * t;
+            }
+        }
+        if (distance >= 100.0) {
+            return;
+        }
+        auto points = feature->Points.getValues();
+        Base::Vector3d added = vector(curve->Value(parameter));
+        for (const auto& p : points) {
+            if ((p - added).Length() < 1e-7) {
+                return;
+            }
+        }
+        size_t index = points.size();
+        for (size_t i = 1; i < points.size(); ++i) {
+            GeomAPI_ProjectPointOnCurve project(gp_Pnt(points[i].x, points[i].y, points[i].z), curve);
+            if (project.LowerDistanceParameter() > parameter) {
+                index = i;
+                break;
+            }
+        }
+        auto flags = feature->LinearSegments.getValues();
+        flags.resize(feature->Periodic.getValue() ? points.size() : points.size() - 1, false);
+        const bool splitLinear = index > 0 && index - 1 < flags.size() && flags[index - 1];
+        const size_t insertion = std::min(index, flags.size());
+        flags.resize(flags.size() + 1);
+        for (size_t i = flags.size() - 1; i > insertion; --i) {
+            flags[i] = flags[i - 1];
+        }
+        flags[insertion] = splitLinear;
+        feature->LinearSegments.setValues(flags);
+        std::vector<int> retained;
+        for (int i = 0; i < static_cast<int>(points.size()); ++i) {
+            retained.push_back(i);
+        }
+        retained.insert(retained.begin() + index, -1);
+        feature->remapSupports(retained);
+        points.insert(points.begin() + index, added);
+        selectedPoints = {static_cast<int>(index)};
+        selectedSegments.clear();
+        applyPoints(points);
+    }
+    catch (const Standard_Failure&) {
+    }
+    catch (const Base::Exception&) {
+    }
+}
+
+void FreehandBSplineEditor::cacheSnapShapes()
+{
+    snapVertices.clear();
+    snapCurves.clear();
+    const auto dependents = feature->getInListRecursive();
+    for (auto object : feature->getDocument()->getObjects()) {
+        if (object == feature
+            || std::find(dependents.begin(), dependents.end(), object) != dependents.end()) {
+            continue;
+        }
+        auto provider = vp->getDocument()->getViewProvider(object);
+        if (!provider || !provider->isVisible()) {
+            continue;
+        }
+        try {
+            auto shape = Part::Feature::getShape(
+                object,
+                Part::ShapeOption::ResolveLink | Part::ShapeOption::Transform
+            );
+            if (shape.IsNull()) {
+                continue;
+            }
+            // Unique indexed topology gives the same VertexN/EdgeN names as the property editor.
+            TopTools_IndexedMapOfShape vertices, edges;
+            TopExp::MapShapes(shape, TopAbs_VERTEX, vertices);
+            TopExp::MapShapes(shape, TopAbs_EDGE, edges);
+            const std::string objectName = object->getNameInDocument();
+            for (int i = 1; i <= vertices.Extent(); ++i) {
+                snapVertices.push_back(
+                    {vector(BRep_Tool::Pnt(TopoDS::Vertex(vertices(i)))),
+                     {objectName, "Vertex" + std::to_string(i)}}
+                );
+            }
+            for (int i = 1; i <= edges.Extent(); ++i) {
+                SnapCurve edge;
+                edge.reference = {objectName, "Edge" + std::to_string(i)};
+                edge.curve = BRep_Tool::Curve(TopoDS::Edge(edges(i)), edge.first, edge.last);
+                if (!edge.curve.IsNull()) {
+                    snapCurves.push_back(edge);
+                }
+            }
+        }
+        catch (const Standard_Failure&) {
+        }
+        catch (const Base::Exception&) {
+        }
+    }
+}
+
+bool FreehandBSplineEditor::snap(
+    Base::Vector3d& point,
+    const QPointF& position,
+    SnapReference* reference
+) const
+{
+    double best = 100.0;
+    bool found = false;
+    Base::Vector3d target = point;
+    // Prefer a vertex to an edge within the same pixel tolerance.
+    for (const auto& vertex : snapVertices) {
+        double d = squareDistance(screen(vertex.point), position);
+        if (d < best) {
+            best = d;
+            target = vertex.point;
+            if (reference) {
+                *reference = vertex.reference;
+            }
+            found = true;
+        }
+    }
+    if (found) {
+        point = target;
+        return true;
+    }
+    for (const auto& edge : snapCurves) {
+        // Screen-space sampling also finds edges in planes at a different depth.
+        for (int i = 0; i < 40; ++i) {
+            double a = edge.first + (edge.last - edge.first) * i / 40;
+            double b = edge.first + (edge.last - edge.first) * (i + 1) / 40;
+            double t;
+            double d = segmentDistance(
+                position,
+                screen(vector(edge.curve->Value(a))),
+                screen(vector(edge.curve->Value(b))),
+                t
+            );
+            if (d < best) {
+                best = d;
+                target = vector(edge.curve->Value(a + (b - a) * t));
+                if (reference) {
+                    *reference = edge.reference;
+                }
+                found = true;
+            }
+        }
+    }
+    if (found) {
+        point = target;
+    }
+    return found;
+}
+
+bool FreehandBSplineEditor::editCoordinateAt(const QPointF& position)
+{
+    if (drawing || !coordinates->isChecked() || hitPoint(position) >= 0) {
+        return false;
+    }
+    // Pick the existing text without changing the displayed scene's unpickable state.
+    auto root = std::unique_ptr<SoSeparator, void (*)(SoSeparator*)>(
+        new SoSeparator,
+        [](SoSeparator* node) { node->unref(); }
+    );
+    root->ref();
+    auto pickStyle = new SoPickStyle;
+    pickStyle->style = SoPickStyle::SHAPE;
+    pickStyle->setOverride(true);
+    root->addChild(pickStyle);
+    root->addChild(viewer->getSoRenderManager()->getSceneGraph());
+    SoRayPickAction pick(viewer->getSoRenderManager()->getViewportRegion());
+    const auto ratio = viewer->getGLWidget()->devicePixelRatioF();
+    pick.setPoint(SbVec2s(
+        static_cast<short>(position.x() * ratio),
+        static_cast<short>((viewer->getGLWidget()->height() - position.y()) * ratio)
+    ));
+    pick.setRadius(0);
+    pick.setPickAll(true);
+    pick.apply(root.get());
+    const auto& hits = pick.getPickedPointList();
+    for (int j = 0; j < hits.getLength(); ++j) {
+        const auto hit = hits[j];
+        const auto found
+            = std::find(coordinateLabels.begin(), coordinateLabels.end(), hit->getPath()->getTail());
+        if (found == coordinateLabels.end()) {
+            continue;
+        }
+        const auto detail = dynamic_cast<const SoTextDetail*>(hit->getDetail());
+        if (!detail || detail->getStringIndex() < 1 || detail->getStringIndex() > 3) {
+            continue;
+        }
+        const int pointIndex = static_cast<int>(std::distance(coordinateLabels.begin(), found));
+        // Keep coordinate clicks clear of the point handle and the label's leading spaces.
+        constexpr double coordinateClickOffset = 14.0;
+        const auto anchor = screen(toWorld(feature->Points.getValues()[pointIndex]));
+        if (position.x() < anchor.x() + coordinateClickOffset) {
+            continue;
+        }
+        finishCoordinateEdit(true);
+        if (coordinateSpinBox) {
+            return true;
+        }
+        coordinatePoint = pointIndex;
+        coordinateAxis = detail->getStringIndex() - 1;
+        auto spin = new Gui::QuantitySpinBox(viewer->getGLWidget());
+        coordinateSpinBox = spin;
+        spin->setObjectName(QStringLiteral("pointCoordinateEditor"));
+        spin->setUnit(Base::Unit::Length);
+        spin->setRange(-1e12, 1e12);
+        spin->setValue(feature->Points.getValues()[coordinatePoint][coordinateAxis]);
+        spin->setToolTip(tr("Point %1 - %2").arg(coordinatePoint + 1).arg(QChar('X' + coordinateAxis))
+        );
+        spin->resize(spin->sizeHint().expandedTo(QSize(140, 0)));
+        const auto bounds = viewer->getGLWidget()->size();
+        // Like EditableDatumLabel, center the editor at the label and clamp it to the view.
+        spin->move(
+            std::clamp(
+                static_cast<int>(position.x()) - spin->width() / 2,
+                0,
+                std::max(0, bounds.width() - spin->width())
+            ),
+            std::clamp(
+                static_cast<int>(position.y()) - spin->height() / 2,
+                0,
+                std::max(0, bounds.height() - spin->height())
+            )
+        );
+        connect(spin, &QAbstractSpinBox::editingFinished, this, [this] {
+            finishCoordinateEdit(true);
+        });
+        spin->show();
+        spin->raise();
+        spin->setFocus();
+        spin->selectNumber();
+        return true;
+    }
+    return false;
+}
+
+void FreehandBSplineEditor::finishCoordinateEdit(bool apply)
+{
+    if (!coordinateSpinBox) {
+        return;
+    }
+    auto spin = coordinateSpinBox.data();
+    if (apply && !spin->hasValidInput()) {
+        return;
+    }
+    const int point = coordinatePoint;
+    const int component = coordinateAxis;
+    const double value = spin->rawValue();
+    coordinateSpinBox = nullptr;
+    coordinatePoint = coordinateAxis = -1;
+    spin->hide();
+    spin->deleteLater();
+    if (apply && std::isfinite(value) && point >= 0 && point < feature->Points.getSize()) {
+        auto points = feature->Points.getValues();
+        points[point][component] = value;
+        applyPoints(points);
+    }
+}
+
+bool FreehandBSplineEditor::eventFilter(QObject* watched, QEvent* event)
+{
+    auto widget = qobject_cast<QWidget*>(watched);
+    if (coordinateSpinBox && widget
+        && (widget == coordinateSpinBox || coordinateSpinBox->isAncestorOf(widget))) {
+        if (event->type() == QEvent::ShortcutOverride || event->type() == QEvent::KeyPress) {
+            const int key = static_cast<QKeyEvent*>(event)->key();
+            if (key == Qt::Key_Escape || key == Qt::Key_Return || key == Qt::Key_Enter) {
+                event->accept();
+                if (event->type() == QEvent::KeyPress) {
+                    finishCoordinateEdit(key != Qt::Key_Escape);
+                    if (!coordinateSpinBox && viewer) {
+                        viewer->getGLWidget()->setFocus();
+                    }
+                }
+                return true;
+            }
+        }
+        return QWidget::eventFilter(watched, event);
+    }
+    const bool inPanel = widget && (widget == this || isAncestorOf(widget));
+    const bool inViewer = widget && viewer && (widget == viewer || viewer->isAncestorOf(widget));
+    const bool editingInput = (inPanel || inViewer) && !qobject_cast<QLineEdit*>(watched);
+    if ((editingInput || (drawing && inPanel))
+        && (event->type() == QEvent::ShortcutOverride || event->type() == QEvent::KeyPress)) {
+        auto key = static_cast<QKeyEvent*>(event);
+        const bool selectAll = !drawing && key->matches(QKeySequence::SelectAll);
+        const bool remove = !drawing && key->key() == Qt::Key_Delete && !movingPoints().empty();
+        const bool constraint = dragging
+            && (key->key() == Qt::Key_X || key->key() == Qt::Key_Y || key->key() == Qt::Key_Z);
+        const bool escape = key->key() == Qt::Key_Escape && (drawing || dragging);
+        if (selectAll || remove || constraint || escape) {
+            event->accept();
+            if (event->type() == QEvent::ShortcutOverride) {
+                return true;
+            }
+            if (selectAll) {
+                selectAllPoints();
+            }
+            if (remove && !dragging) {
+                deletePoints();
+            }
+            if (constraint) {
+                const int requested = key->key() - Qt::Key_X;
+                axis = axis == requested ? -1 : requested;
+            }
+            if (escape && drawing) {
+                endDrawing();
+                return true;
+            }
+            if (escape) {
+                if (dragging) {
+                    applyPoints(dragPoints);
+                }
+                dragging = false;
+                axis = -1;
+            }
+            updateHints();
+            return true;
+        }
+    }
+    if (!viewer || watched != viewer->getGLWidget()) {
+        return QWidget::eventFilter(watched, event);
+    }
+    if (event->type() == QEvent::Enter || event->type() == QEvent::FocusIn) {
+        updateHints();
+    }
+    if (event->type() == QEvent::ContextMenu && suppressContextMenu) {
+        suppressContextMenu = false;
+        return true;
+    }
+    // Keep complete button sequences together: native navigation must receive the
+    // release for every press passed through to it (including reference selection).
+    if (event->type() == QEvent::MouseButtonRelease) {
+        auto mouse = static_cast<QMouseEvent*>(event);
+        if (!ownedButtons.testFlag(mouse->button())) {
+            return false;
+        }
+        ownedButtons &= ~Qt::MouseButtons(mouse->button());
+        if (mouse->button() == Qt::LeftButton) {
+            if (dragging) {
+                feature->getDocument()->recompute();
+            }
+            dragging = false;
+            axis = -1;
+            updateHints();
+        }
+        return true;
+    }
+    // The drawing handler owns pointer input until the user explicitly ends the spline.
+    if (drawing) {
+        if (event->type() == QEvent::ContextMenu) {
+            return true;
+        }
+        if (event->type() == QEvent::MouseMove) {
+            auto mouse = static_cast<QMouseEvent*>(event);
+            if ((mouse->buttons() & ~ownedButtons) != Qt::NoButton) {
+                return false;
+            }
+            updateDrawingPreview(mouse->position());
+            return true;
+        }
+        if (event->type() == QEvent::Leave) {
+            updateCurvePreview(feature->Points.getValues());
+        }
+        if (event->type() == QEvent::MouseButtonPress) {
+            auto mouse = static_cast<QMouseEvent*>(event);
+            if (mouse->button() == Qt::RightButton) {
+                ownedButtons |= Qt::RightButton;
+                suppressContextMenu = true;
+                endDrawing();
+                return true;
+            }
+            if (mouse->button() == Qt::LeftButton && !mouse->modifiers().testFlag(Qt::AltModifier)) {
+                ownedButtons |= Qt::LeftButton;
+                auto points = feature->Points.getValues();
+                auto added = onViewPlane(
+                    mouse->position(),
+                    toWorld(points.empty() ? Base::Vector3d() : points.back())
+                );
+                SnapReference reference;
+                if (snapping->isChecked()) {
+                    cacheSnapShapes();
+                    snap(added, mouse->position(), &reference);
+                }
+                added = toLocal(added);
+                if (points.empty() || (points.back() - added).Length() > 1e-7) {
+                    const auto previous = points;
+                    points.push_back(added);
+                    try {
+                        if (!reference.objectName.empty()) {
+                            auto object = feature->getDocument()->getObject(
+                                reference.objectName.c_str()
+                            );
+                            if (!object) {
+                                throw Base::ValueError("The snapped reference no longer exists.");
+                            }
+                            feature->Points.setValues(points);
+                            feature->setPointSupport(
+                                static_cast<int>(points.size()) - 1,
+                                object,
+                                reference.subname
+                            );
+                        }
+                        applyPoints(points);
+                    }
+                    catch (const Base::Exception& error) {
+                        applyPoints(previous);
+                        status->setText(QString::fromUtf8(error.what()));
+                    }
+                    catch (const Standard_Failure& error) {
+                        applyPoints(previous);
+                        status->setText(QString::fromUtf8(error.GetMessageString()));
+                    }
+                }
+                updateCurvePreview(feature->Points.getValues());
+                return true;
+            }
+        }
+        if (event->type() == QEvent::MouseButtonDblClick) {
+            auto mouse = static_cast<QMouseEvent*>(event);
+            if (mouse->button() == Qt::LeftButton) {
+                ownedButtons |= Qt::LeftButton;
+                return true;
+            }
+            return false;
+        }
+    }
+    if (event->type() == QEvent::Leave || event->type() == QEvent::MouseMove) {
+        int point = -1;
+        int segment = -1;
+        if (event->type() == QEvent::MouseMove) {
+            auto mouse = static_cast<QMouseEvent*>(event);
+            if (!drawing && !dragging && mouse->buttons() == Qt::NoButton) {
+                point = hitPoint(mouse->position());
+                segment = point < 0 ? hitSegment(mouse->position()) : -1;
+            }
+        }
+        if (point != hoveredPoint || segment != hoveredSegment) {
+            hoveredPoint = point;
+            hoveredSegment = segment;
+            refresh();
+        }
+    }
+    if (event->type() == QEvent::MouseButtonDblClick) {
+        auto mouse = static_cast<QMouseEvent*>(event);
+        if (mouse->button() == Qt::LeftButton) {
+            ownedButtons |= Qt::LeftButton;
+            dragging = false;
+            insertPoint(mouse->position());
+            updateHints();
+            return true;
+        }
+    }
+    if (event->type() == QEvent::MouseButtonPress) {
+        auto mouse = static_cast<QMouseEvent*>(event);
+        if (mouse->button() != Qt::LeftButton || mouse->modifiers().testFlag(Qt::AltModifier)) {
+            return false;
+        }
+        if (editCoordinateAt(mouse->position())) {
+            ownedButtons |= Qt::LeftButton;
+            return true;
+        }
+        viewer->getGLWidget()->setFocus();
+        const auto position = mouse->position();
+        int point = hitPoint(position);
+        int segment = point < 0 ? hitSegment(position) : -1;
+        if (point < 0 && segment < 0) {
+            const auto ratio = viewer->getGLWidget()->devicePixelRatioF();
+            std::unique_ptr<SoPickedPoint> picked(viewer->pickPoint(SbVec2s(
+                static_cast<short>(position.x() * ratio),
+                static_cast<short>((viewer->getGLWidget()->height() - position.y()) * ratio)
+            )));
+            if (!picked && !mouse->modifiers().testFlag(Qt::ControlModifier)) {
+                selectedPoints.clear();
+                selectedSegments.clear();
+                refresh();
+            }
+            return false;  // Native selection handles external references and empty space.
+        }
+        ownedButtons |= Qt::LeftButton;
+        const bool control = mouse->modifiers().testFlag(Qt::ControlModifier);
+        const bool already = point >= 0 ? selectedPoints.count(point)
+                                        : selectedSegments.count(segment);
+        if (!control && !already) {
+            selectedPoints.clear();
+            selectedSegments.clear();
+        }
+        if (point >= 0) {
+            if (control && already) {
+                selectedPoints.erase(point);
+            }
+            else {
+                selectedPoints.insert(point);
+            }
+        }
+        if (segment >= 0) {
+            if (control && already) {
+                selectedSegments.erase(segment);
+            }
+            else {
+                selectedSegments.insert(segment);
+            }
+        }
+        auto moving = movingPoints();
+        dragging = (point >= 0 || segment >= 0) && !moving.empty() && !(control && already);
+        if (dragging) {
+            dragPoints = feature->Points.getValues();
+            dragAnchor = point >= 0 ? point : segment;
+            dragOrigin = onViewPlane(position, toWorld(dragPoints[dragAnchor]));
+            pressPosition = position;
+            axis = -1;
+            cacheSnapShapes();
+        }
+        refresh();
+        return true;
+    }
+    if (event->type() == QEvent::MouseMove && dragging) {
+        auto mouse = static_cast<QMouseEvent*>(event);
+        if (!mouse->buttons().testFlag(Qt::LeftButton)) {
+            dragging = false;
+            ownedButtons &= ~Qt::MouseButtons(Qt::LeftButton);
+            axis = -1;
+            updateHints();
+            return false;
+        }
+        auto delta = onViewPlane(mouse->position(), dragOrigin) - dragOrigin;
+        if (axis >= 0) {
+            Base::Vector3d unit;
+            unit[axis] = 1.0;
+            auto origin = screen(dragOrigin), direction = screen(dragOrigin + unit) - origin;
+            auto offset = mouse->position() - pressPosition;
+            double length = direction.x() * direction.x() + direction.y() * direction.y();
+            delta = unit
+                * (length > 1e-12 ? (offset.x() * direction.x() + offset.y() * direction.y()) / length
+                                  : 0);
+        }
+        const bool fine = mouse->modifiers().testFlag(Qt::ShiftModifier);
+        if (fine) {
+            delta *= 0.1;
+        }
+        if (snapping->isChecked() && !fine && axis < 0) {
+            auto candidate = toWorld(dragPoints[dragAnchor]) + delta;
+            if (snap(candidate, screen(candidate))) {
+                delta = candidate - toWorld(dragPoints[dragAnchor]);
+            }
+        }
+        auto points = dragPoints;
+        for (int i : movingPoints()) {
+            points[i] = toLocal(toWorld(dragPoints[i]) + delta);
+        }
+        applyPoints(points);
+        return true;
+    }
+    return QWidget::eventFilter(watched, event);
+}

--- a/src/Mod/Surface/Gui/FreehandBSplineEditor.h
+++ b/src/Mod/Surface/Gui/FreehandBSplineEditor.h
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#pragma once
+
+#include <set>
+#include <vector>
+#include <QWidget>
+#include <QPointer>
+#include <Base/Vector3D.h>
+#include <Geom_Curve.hxx>
+#include <Gui/ToolHandler.h>
+
+class QCheckBox;
+class QPushButton;
+class QTableWidget;
+class QLabel;
+class SoSeparator;
+class SoText2;
+namespace Gui
+{
+class View3DInventorViewer;
+class QuantitySpinBox;
+}  // namespace Gui
+namespace Surface
+{
+class FreehandBSpline;
+}
+namespace SurfaceGui
+{
+class ViewProviderFreehandBSpline;
+class FreehandBSplineEditor: public QWidget, private Gui::ToolHandler, private Gui::SelectionObserver
+{
+public:
+    explicit FreehandBSplineEditor(ViewProviderFreehandBSpline*);
+    ~FreehandBSplineEditor() override;
+    void setViewer(Gui::View3DInventorViewer*);
+    void selectAllPoints();
+    bool validate();
+    void deletePoints();
+
+protected:
+    bool eventFilter(QObject*, QEvent*) override;
+    QWidget* getCursorWidget() override;
+    QString getCrosshairCursorSVGName() const override;
+
+private:
+    ViewProviderFreehandBSpline* vp;
+    Surface::FreehandBSpline* feature;
+    QPointer<Gui::View3DInventorViewer> viewer;
+    SoSeparator* overlay;
+    SoSeparator* sceneRoot;
+    QTableWidget* table;
+    QLabel* status;
+    QPushButton* endDrawingButton;
+    QWidget* editControls;
+    SoSeparator* preview;
+    bool drawing {false};
+    bool suppressContextMenu {false};
+    Qt::MouseButtons ownedButtons {Qt::NoButton};
+    void endDrawing();
+    void updateDrawingPreview(const QPointF&);
+    void updateCurvePreview(const std::vector<Base::Vector3d>&, bool showCursor = false);
+    QCheckBox* snapping;
+    QCheckBox* coordinates;
+    std::set<int> selectedPoints;
+    std::set<int> selectedSegments;
+    std::vector<Base::Vector3d> dragPoints;
+    Base::Vector3d dragOrigin;
+    QPointF pressPosition;
+    int hoveredPoint {-1};
+    int hoveredSegment {-1};
+    int dragAnchor {-1};
+    int axis {-1};
+    bool dragging {false};
+    bool refreshing {false};
+    QPointer<Gui::QuantitySpinBox> coordinateSpinBox;
+    int coordinatePoint {-1};
+    int coordinateAxis {-1};
+    std::vector<SoText2*> coordinateLabels;
+    bool editCoordinateAt(const QPointF&);
+    void finishCoordinateEdit(bool apply);
+    struct SnapReference
+    {
+        std::string objectName;
+        std::string subname;
+    };
+    struct SnapVertex
+    {
+        Base::Vector3d point;
+        SnapReference reference;
+    };
+    struct SnapCurve
+    {
+        Handle(Geom_Curve) curve;
+        double first;
+        double last;
+        SnapReference reference;
+    };
+    std::vector<SnapVertex> snapVertices;
+    std::vector<SnapCurve> snapCurves;
+
+    Base::Vector3d toWorld(const Base::Vector3d&) const;
+    Base::Vector3d toLocal(const Base::Vector3d&) const;
+    Base::Vector3d onViewPlane(const QPointF&, const Base::Vector3d&) const;
+    QPointF screen(const Base::Vector3d&) const;
+    void refresh();
+    bool selectedPointIsLocked() const;
+    void updateToolButtons();
+    bool hasValidReference() const;
+    void onSelectionChanged(const Gui::SelectionChanges&) override;
+    bool selectedSpansAreLinear() const;
+    void updateHints();
+    void applyPoints(const std::vector<Base::Vector3d>&);
+    std::set<int> movingPoints() const;
+    int hitPoint(const QPointF&) const;
+    int hitSegment(const QPointF&) const;
+    void insertPoint(const QPointF&);
+    void alignPoints();
+    void setLinear(bool);
+    void cacheSnapShapes();
+    bool snap(Base::Vector3d&, const QPointF&, SnapReference* reference = nullptr) const;
+};
+}  // namespace SurfaceGui

--- a/src/Mod/Surface/Gui/Resources/FreehandBSpline.qrc
+++ b/src/Mod/Surface/Gui/Resources/FreehandBSpline.qrc
@@ -1,0 +1,6 @@
+<RCC>
+  <qresource>
+    <file>icons/Surface_FreehandBSpline.svg</file>
+    <file>icons/Surface_Pointer_FreehandBSpline.svg</file>
+  </qresource>
+</RCC>

--- a/src/Mod/Surface/Gui/Resources/icons/Surface_FreehandBSpline.svg
+++ b/src/Mod/Surface/Gui/Resources/icons/Surface_FreehandBSpline.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <path d="M7 49L20 14L43 42L57 10" fill="none" stroke="#888a85" stroke-width="2"/>
+  <path d="M7 49C8 12 13 5 20 14S37 53 43 42S54 15 57 10" fill="none" stroke="#204a87" stroke-width="5"/>
+  <g fill="#729fcf" stroke="#0b1521" stroke-width="2">
+    <circle cx="7" cy="49" r="4"/><circle cx="20" cy="14" r="4"/>
+    <circle cx="43" cy="42" r="4"/><circle cx="57" cy="10" r="4"/>
+  </g>
+</svg>

--- a/src/Mod/Surface/Gui/Resources/icons/Surface_Pointer_FreehandBSpline.svg
+++ b/src/Mod/Surface/Gui/Resources/icons/Surface_Pointer_FreehandBSpline.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <g transform="translate(23 23) scale(0.6)">
+
+  <path d="M7 49L20 14L43 42L57 10" fill="none" stroke="#888a85" stroke-width="2"/>
+  <path d="M7 49C8 12 13 5 20 14S37 53 43 42S54 15 57 10" fill="none" stroke="#204a87" stroke-width="5"/>
+  <g fill="#729fcf" stroke="#0b1521" stroke-width="2">
+    <circle cx="7" cy="49" r="4"/><circle cx="20" cy="14" r="4"/>
+    <circle cx="43" cy="42" r="4"/><circle cx="57" cy="10" r="4"/>
+  </g>
+  </g>
+  <g fill="none" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round">
+    <path d="m16,3v9m0,8v9m-13-13h9m8,0h9"/>
+  </g>
+</svg>

--- a/src/Mod/Surface/Gui/ViewProviderFreehandBSpline.cpp
+++ b/src/Mod/Surface/Gui/ViewProviderFreehandBSpline.cpp
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <Gui/BitmapFactory.h>
+#include <Gui/Control.h>
+#include <Gui/Document.h>
+#include <Gui/Selection/Selection.h>
+#include <Gui/TaskView/TaskDialog.h>
+#include <Gui/TreeItemMode.h>
+#include <App/Document.h>
+#include <Mod/Surface/App/FeatureFreehandBSpline.h>
+#include <Inventor/nodes/SoSwitch.h>
+#include <Inventor/nodes/SoSeparator.h>
+#include "FreehandBSplineEditor.h"
+#include "ViewProviderFreehandBSpline.h"
+
+using namespace SurfaceGui;
+PROPERTY_SOURCE(SurfaceGui::ViewProviderFreehandBSpline, PartGui::ViewProviderSpline)
+
+namespace
+{
+class TaskFreehandBSpline: public Gui::TaskView::TaskDialog
+{
+public:
+    TaskFreehandBSpline(ViewProviderFreehandBSpline* provider, FreehandBSplineEditor* widget)
+        : vp(provider)
+        , panel(widget)
+    {
+        addTaskBox(Gui::BitmapFactory().pixmap("Surface_FreehandBSpline"), panel);
+        setDocumentName(vp->getObject()->getDocument()->getName());
+        setAutoCloseOnTransactionChange(false);
+    }
+    bool accept() override
+    {
+        if (!panel->validate()) {
+            return false;
+        }
+        auto doc = vp->getDocument();
+        doc->resetEdit();
+        doc->getDocument()->recompute();
+        doc->commitCommand();
+        return true;
+    }
+    bool reject() override
+    {
+        auto doc = vp->getDocument();
+        doc->abortCommand();
+        doc->resetEdit();
+        doc->getDocument()->recompute();
+        return true;
+    }
+
+private:
+    ViewProviderFreehandBSpline* vp;
+    FreehandBSplineEditor* panel;
+};
+}  // namespace
+
+QIcon ViewProviderFreehandBSpline::getIcon() const
+{
+    return Gui::BitmapFactory().pixmap("Surface_FreehandBSpline");
+}
+
+bool ViewProviderFreehandBSpline::doubleClicked()
+{
+    startDefaultEditMode();
+    return true;
+}
+
+bool ViewProviderFreehandBSpline::isSelectable() const
+{
+    return !editor && ViewProviderSpline::isSelectable();
+}
+
+void ViewProviderFreehandBSpline::onChanged(const App::Property* property)
+{
+    ViewProviderSpline::onChanged(property);
+    if (editor && property == &Selectable) {
+        setSelectable(false);
+    }
+}
+
+bool ViewProviderFreehandBSpline::setEdit(int mode)
+{
+    if (mode != Default) {
+        return ViewProviderSpline::setEdit(mode);
+    }
+    if (Gui::Control().activeDialog()) {
+        return false;
+    }
+    if (!getDocument()->hasPendingCommand()) {
+        getDocument()->openCommand(QT_TRANSLATE_NOOP("Command", "Edit freehand B-spline"));
+    }
+    // Clear the old highlight before the editor starts rebuilding the shape during drags.
+    Gui::Selection().rmvPreselect();
+    Gui::Selection().rmvSelection(
+        getObject()->getDocument()->getName(),
+        getObject()->getNameInDocument()
+    );
+    static_cast<Surface::FreehandBSpline*>(getObject())->sanitizeReferences();
+    // Construct the panel before hiding the normal display.
+    editor = new FreehandBSplineEditor(this);
+    // Wrap the normal display so shape updates cannot make it visible during editing.
+    auto root = getRoot();
+    auto normal = getModeSwitch();
+    editDisplaySwitch = new SoSwitch;
+    editDisplaySwitch->setName("FreehandBSplineHiddenDisplay");
+    editDisplaySwitch->whichChild = SO_SWITCH_NONE;
+    editDisplaySwitch->addChild(normal);
+    root->replaceChild(normal, editDisplaySwitch);
+    // Change only the scene's picking state, preserving the saved Selectable preference.
+    setSelectable(false);
+    Gui::Control().showDialog(new TaskFreehandBSpline(this, editor));
+    signalChangeHighlight(true, Gui::HighlightMode::Bold);
+    return true;
+}
+
+void ViewProviderFreehandBSpline::unsetEdit(int mode)
+{
+    if (mode != Default) {
+        ViewProviderSpline::unsetEdit(mode);
+        return;
+    }
+    if (editor) {
+        editor->setViewer(nullptr);
+    }
+    editor = nullptr;
+    if (editDisplaySwitch) {
+        getRoot()->replaceChild(editDisplaySwitch, getModeSwitch());
+        editDisplaySwitch = nullptr;
+    }
+    setSelectable(Selectable.getValue());
+    signalChangeHighlight(false, Gui::HighlightMode::Bold);
+    Gui::Control().closeDialog();
+}
+
+void ViewProviderFreehandBSpline::setEditViewer(Gui::View3DInventorViewer* viewer, int mode)
+{
+    ViewProviderSpline::setEditViewer(viewer, mode);
+    if (editor) {
+        editor->setViewer(viewer);
+    }
+}
+
+void ViewProviderFreehandBSpline::unsetEditViewer(Gui::View3DInventorViewer* viewer)
+{
+    if (editor) {
+        editor->setViewer(nullptr);
+    }
+    ViewProviderSpline::unsetEditViewer(viewer);
+}
+
+bool ViewProviderFreehandBSpline::selectAll()
+{
+    if (!editor) {
+        return false;
+    }
+    editor->selectAllPoints();
+    return true;
+}
+
+bool ViewProviderFreehandBSpline::onDelete(const std::vector<std::string>& subNames)
+{
+    if (editor) {
+        editor->deletePoints();
+        return false;
+    }
+    return ViewProviderSpline::onDelete(subNames);
+}

--- a/src/Mod/Surface/Gui/ViewProviderFreehandBSpline.h
+++ b/src/Mod/Surface/Gui/ViewProviderFreehandBSpline.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#pragma once
+
+#include <QPointer>
+#include <Mod/Part/Gui/ViewProviderSpline.h>
+
+class SoSwitch;
+
+namespace SurfaceGui
+{
+class FreehandBSplineEditor;
+class ViewProviderFreehandBSpline: public PartGui::ViewProviderSpline
+{
+    PROPERTY_HEADER_WITH_OVERRIDE(SurfaceGui::ViewProviderFreehandBSpline);
+
+public:
+    QIcon getIcon() const override;
+    bool doubleClicked() override;
+    bool isSelectable() const override;
+    bool selectAll() override;
+    bool onDelete(const std::vector<std::string>&) override;
+    void setEditViewer(Gui::View3DInventorViewer*, int) override;
+    void unsetEditViewer(Gui::View3DInventorViewer*) override;
+
+protected:
+    void onChanged(const App::Property*) override;
+    bool setEdit(int) override;
+    void unsetEdit(int) override;
+
+private:
+    QPointer<FreehandBSplineEditor> editor;
+    SoSwitch* editDisplaySwitch {nullptr};
+};
+}  // namespace SurfaceGui

--- a/src/Mod/Surface/Gui/Workbench.cpp
+++ b/src/Mod/Surface/Gui/Workbench.cpp
@@ -57,6 +57,8 @@ Gui::MenuItem* Workbench::setupMenuBar() const
      *surface << "Surface_Cut";
      */
 
+    *surface << "Separator" << "Surface_FreehandBSpline";
+
     return root;
 }
 
@@ -75,6 +77,8 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     /*
      *surface << "Surface_Cut";
      */
+
+    *surface << "Separator" << "Surface_FreehandBSpline";
 
     return root;
 }

--- a/src/Mod/Surface/Init.py
+++ b/src/Mod/Surface/Init.py
@@ -3,4 +3,4 @@
 # FreeCAD init script of the Surface module
 # (c) 2001 Juergen Riegel LGPL
 
-FreeCAD.__unit_test__ += ["TestSurfaceApp"]
+FreeCAD.__unit_test__ += ["TestSurfaceApp", "TestSurfaceFreehandBSpline"]

--- a/src/Mod/Surface/SurfaceTests/TestFreehandBSpline.py
+++ b/src/Mod/Surface/SurfaceTests/TestFreehandBSpline.py
@@ -1,0 +1,220 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+import tempfile
+import unittest
+
+import FreeCAD as App
+import Part
+import Surface
+
+
+class TestFreehandBSpline(unittest.TestCase):
+    def setUp(self):
+        self.doc = App.newDocument("CurveNetworkTest")
+
+    def tearDown(self):
+        App.closeDocument(self.doc.Name)
+
+    def curve(self, points):
+        obj = self.doc.addObject("Surface::FreehandBSpline", "Curve")
+        obj.Points = [App.Vector(*p) for p in points]
+        self.doc.recompute()
+        self.assertTrue(obj.isValid(), obj.getStatusString())
+        return obj
+
+    def test_interpolation_and_placement(self):
+        curve = self.curve([(0, 0, 0), (3, 4, 1), (8, 1, 4), (10, 0, 0)])
+        self.assertEqual(len(curve.Shape.Edges), 1)
+        for p in curve.Points:
+            self.assertLess(curve.Shape.distToShape(Part.Vertex(p))[0], 1e-6)
+        placement = App.Placement(App.Vector(4, 6, 8), App.Rotation(App.Vector(1, 1, 0), 33))
+        curve.Placement = placement
+        points = curve.Points
+        points[1] = App.Vector(3, 5, 1)
+        curve.Points = points
+        self.doc.recompute()
+        for p in points:
+            self.assertLess(curve.Shape.distToShape(Part.Vertex(placement.multVec(p)))[0], 1e-6)
+
+    def test_persistent_point_supports(self):
+        curve = self.curve([(0, 0, 0), (5, 8, 0), (10, 0, 0), (15, -4, 0)])
+        support = self.doc.addObject("Part::Feature", "Support")
+        support.Shape = Part.makeLine(App.Vector(0, 2, 0), App.Vector(20, 2, 0))
+        curve.Support = [(support, ("Vertex1",)), (support, ("Edge1",))]
+        curve.SupportPointIndices = [0, 1]
+        curve.SupportParameters = [App.Vector(), App.Vector(0.25, 0, 0)]
+        self.doc.recompute()
+        self.assertEqual(curve.Points[0], App.Vector(0, 2, 0))
+        self.assertEqual(curve.Points[1], App.Vector(5, 2, 0))
+        support.Shape = Part.makeLine(App.Vector(0, 2, 0), App.Vector(40, 2, 0))
+        support.Placement.Base = App.Vector(3, 4, 5)
+        self.doc.recompute()
+        self.assertEqual(curve.Points[0], App.Vector(3, 6, 5))
+        self.assertEqual(curve.Points[1], App.Vector(13, 6, 5))
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "LockedSpline.FCStd")
+            self.doc.saveAs(path)
+            App.closeDocument(self.doc.Name)
+            self.doc = App.openDocument(path)
+            restored = self.doc
+            try:
+                restored.Support.Placement.Base = App.Vector(3, 9, 5)
+                restored.recompute()
+                self.assertEqual(restored.Curve.Points[1], App.Vector(13, 11, 5))
+                self.assertTrue(restored.Curve.isValid())
+            finally:
+                App.closeDocument(restored.Name)
+                self.doc = App.newDocument("CurveNetworkTest")
+
+    def test_point_support_inside_body(self):
+        body = self.doc.addObject("PartDesign::Body", "Body")
+        sketch = self.doc.addObject("Sketcher::SketchObject", "Sketch")
+        body.addObject(sketch)
+        corners = [
+            App.Vector(0, 0, 0),
+            App.Vector(10, 0, 0),
+            App.Vector(10, 10, 0),
+            App.Vector(0, 10, 0),
+        ]
+        for i in range(4):
+            sketch.addGeometry(Part.LineSegment(corners[i], corners[(i + 1) % 4]), False)
+        pad = body.newObject("PartDesign::Pad", "Pad")
+        pad.Profile = sketch
+        pad.Length = 5
+        self.doc.recompute()
+        vertex = next(i for i, v in enumerate(pad.Shape.Vertexes) if v.Point.z > 4)
+        curve = self.curve([(0, 0, 0), (15, 15, 10), (20, 0, 0)])
+        curve.Support = [(pad, ("Vertex%d" % (vertex + 1),))]
+        curve.SupportPointIndices = [0]
+        curve.SupportParameters = [App.Vector()]
+        self.doc.recompute()
+        self.assertEqual(curve.Points[0], pad.Shape.Vertexes[vertex].Point)
+        self.assertTrue(curve.isValid(), curve.getStatusString())
+
+    def test_reference_tangents(self):
+        curve = self.curve([(0, 0, 0), (5, 8, 3), (15, 0, 0)])
+        support = self.doc.addObject("Part::Feature", "TangentEdge")
+        support.Shape = Part.makeLine(App.Vector(), App.Vector(10, 0, 0))
+        curve.Support = [(support, ("Vertex1",))]
+        curve.SupportPointIndices = [0]
+        curve.SupportParameters = [App.Vector()]
+        curve.TangentSupport = [(support, ("Edge1",))]
+        curve.TangentPointIndices = [0]
+        self.doc.recompute()
+        self.assertTrue(curve.isValid(), curve.getStatusString())
+        edge = curve.Shape.Edges[0]
+        tangent = edge.tangentAt(edge.FirstParameter)
+        self.assertLess(tangent.cross(App.Vector(1, 0, 0)).Length, 1e-7)
+        # Two interpolation points must also honor the requested endpoint direction.
+        curve.Points = [App.Vector(), App.Vector(10, 10, 0)]
+        self.doc.recompute()
+        edge = curve.Shape.Edges[0]
+        self.assertLess(edge.tangentAt(edge.FirstParameter).cross(App.Vector(1, 0, 0)).Length, 1e-7)
+        self.assertGreater(edge.Length, (curve.Points[1] - curve.Points[0]).Length)
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "TangentSpline.FCStd")
+            self.doc.saveAs(path)
+            App.closeDocument(self.doc.Name)
+            self.doc = App.openDocument(path)
+            self.doc.recompute()
+            self.assertEqual(self.doc.Curve.TangentPointIndices, [0])
+            edge = self.doc.Curve.Shape.Edges[0]
+            self.assertLess(
+                edge.tangentAt(edge.FirstParameter).cross(App.Vector(1, 0, 0)).Length, 1e-7
+            )
+
+    def test_face_tangent_plane(self):
+        curve = self.curve([(2, 2, 0), (5, 8, 3), (15, 0, 6)])
+        face = self.doc.addObject("Part::Feature", "TangentFace")
+        face.Shape = Part.makePlane(20, 20)
+        curve.Support = [(face, ("Face1",))]
+        curve.SupportPointIndices = [0]
+        curve.SupportParameters = [App.Vector(2, 2, 0)]
+        curve.TangentSupport = [(face, ("Face1",))]
+        curve.TangentPointIndices = [0]
+        self.doc.recompute()
+        self.assertTrue(curve.isValid(), curve.getStatusString())
+        edge = curve.Shape.Edges[0]
+        self.assertAlmostEqual(edge.tangentAt(edge.FirstParameter).z, 0, places=7)
+        curve.LinearSegments = [True, False]
+        self.doc.recompute()
+        self.assertFalse(curve.isValid())
+
+    def test_deleted_reference_unlocks_only_affected_points(self):
+        curve = self.curve([(0, 0, 0), (5, 8, 0), (10, 0, 0)])
+        first = self.doc.addObject("Part::Feature", "FirstSupport")
+        first.Shape = Part.makeLine(App.Vector(), App.Vector(0, 10, 0))
+        second = self.doc.addObject("Part::Feature", "SecondSupport")
+        second.Shape = Part.makeLine(App.Vector(10, 0, 0), App.Vector(20, 0, 0))
+        curve.Support = [(first, ("Vertex1",)), (second, ("Vertex1",))]
+        curve.SupportPointIndices = [0, 2]
+        curve.SupportParameters = [App.Vector(), App.Vector()]
+        curve.TangentSupport = [(first, ("Edge1",)), (second, ("Edge1",))]
+        curve.TangentPointIndices = [0, 2]
+        self.doc.recompute()
+        original = list(curve.Points)
+        self.doc.UndoMode = 1
+        self.doc.openTransaction("Delete support")
+        self.doc.removeObject(first.Name)
+        self.doc.recompute()
+        self.doc.commitTransaction()
+        self.assertEqual(curve.SupportPointIndices, [2])
+        self.assertEqual(curve.TangentPointIndices, [2])
+        self.assertEqual(curve.Points, original)
+        self.assertTrue(curve.isValid(), curve.getStatusString())
+        self.doc.undo()
+        self.doc.recompute()
+        self.assertEqual(curve.SupportPointIndices, [0, 2])
+        self.assertEqual(curve.TangentPointIndices, [0, 2])
+        self.doc.redo()
+        self.doc.recompute()
+        self.assertEqual(curve.SupportPointIndices, [2])
+        second.Placement.Base = App.Vector(0, 0, 4)
+        self.doc.recompute()
+        self.assertEqual(curve.Points[0], original[0])
+        self.assertEqual(curve.Points[2], original[2] + App.Vector(0, 0, 4))
+
+    def test_missing_subelement_unlocks(self):
+        curve = self.curve([(0, 0, 0), (5, 8, 0), (10, 0, 0)])
+        support = self.doc.addObject("Part::Feature", "Support")
+        support.Shape = Part.makeLine(App.Vector(), App.Vector(0, 10, 0))
+        curve.Support = [(support, ("Vertex999",))]
+        curve.SupportPointIndices = [0]
+        curve.SupportParameters = [App.Vector()]
+        curve.TangentSupport = [(support, ("Edge1",))]
+        curve.TangentPointIndices = [0]
+        before = list(curve.Points)
+        self.doc.recompute()
+        self.assertTrue(curve.isValid(), curve.getStatusString())
+        self.assertEqual(curve.SupportPointIndices, [])
+        self.assertEqual(curve.TangentPointIndices, [])
+        self.assertEqual(curve.Points, before)
+
+    def test_periodic_and_linear(self):
+        curve = self.curve([(0, 0, 0), (5, 8, 0), (10, 0, 0), (5, -4, 0)])
+        curve.Periodic = True
+        self.doc.recompute()
+        self.assertTrue(curve.Shape.isClosed())
+        self.assertTrue(curve.Shape.Edges[0].Curve.isPeriodic())
+        curve.LinearSegments = [True, False, True, False]
+        self.doc.recompute()
+        self.assertTrue(curve.isValid(), curve.getStatusString())
+        self.assertTrue(curve.Shape.isClosed())
+        for i in (0, 2):
+            for step in range(11):
+                p = curve.Points[i] + (curve.Points[i + 1] - curve.Points[i]) * step / 10
+                self.assertLess(curve.Shape.distToShape(Part.Vertex(p))[0], 1e-6)
+
+    def test_linear_corner(self):
+        curve = self.curve([(0, 0, 0), (10, 0, 0), (10, 10, 0), (20, 10, 0)])
+        curve.LinearSegments = [True, True, True]
+        self.doc.recompute()
+        self.assertTrue(curve.isValid(), curve.getStatusString())
+        self.assertAlmostEqual(curve.Shape.Length, 30, places=6)
+
+    def test_duplicate_points_are_rejected(self):
+        curve = self.curve([(0, 0, 0), (10, 0, 0)])
+        curve.Points = [App.Vector(), App.Vector()]
+        self.doc.recompute()
+        self.assertFalse(curve.isValid())

--- a/src/Mod/Surface/SurfaceTests/TestFreehandBSplineGui.py
+++ b/src/Mod/Surface/SurfaceTests/TestFreehandBSplineGui.py
@@ -1,0 +1,723 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Exercise the native editor through Qt events and its actual task controls."""
+
+import unittest
+import FreeCAD as App
+
+
+@unittest.skipUnless(App.GuiUp, "Requires the FreeCAD GUI")
+class TestFreehandBSplineGui(unittest.TestCase):
+    def setUp(self):
+        import FreeCADGui as Gui
+        from PySide import QtCore, QtGui, QtWidgets
+
+        self.Gui, self.Core, self.GuiQt = Gui, QtCore, QtGui
+        self.Widgets = QtWidgets
+        self.previousWorkbench = Gui.activeWorkbench().name()
+        Gui.activateWorkbench("SurfaceWorkbench")
+        self.doc = App.newDocument("CurveEditorTest")
+        self.curve = self.doc.addObject("Surface::FreehandBSpline", "Curve")
+        self.curve.Points = [
+            App.Vector(0, 0, 0),
+            App.Vector(10, 10, 0),
+            App.Vector(20, 0, 0),
+            App.Vector(30, 5, 0),
+        ]
+        self.doc.recompute()
+        QtWidgets.QApplication.processEvents()
+        self.view = Gui.getDocument(self.doc.Name).activeView()
+        self.view.viewTop()
+        self.view.fitAll()
+        Gui.getDocument(self.doc.Name).setEdit(self.curve.Name)
+        QtWidgets.QApplication.processEvents()
+        self.panel = Gui.getMainWindow().findChild(QtWidgets.QWidget, "FreehandBSplineEditor")
+        self.assertIsNotNone(self.panel)
+        self.table = self.panel.findChild(QtWidgets.QTableWidget, "interpolationPoints")
+        self.gl = max(
+            (
+                w
+                for w in Gui.getMainWindow().findChildren(QtWidgets.QWidget)
+                if w.metaObject().className() == "QOpenGLWidget"
+            ),
+            key=lambda w: w.width() * w.height(),
+        )
+
+    def tearDown(self):
+        guiDoc = self.Gui.getDocument(self.doc.Name)
+        if guiDoc.getInEdit():
+            self.doc.abortTransaction()
+            guiDoc.resetEdit()
+        self.Core.QCoreApplication.sendPostedEvents(None, self.Core.QEvent.DeferredDelete)
+        App.closeDocument(self.doc.Name)
+        self.Gui.activateWorkbench(self.previousWorkbench)
+
+    def screen(self, point):
+        x, y = self.view.getPointOnScreen(point)
+        ratio = self.gl.devicePixelRatioF()
+        return self.Core.QPointF(x / ratio, self.gl.height() - y / ratio)
+
+    def mouse(self, kind, pos, button=None, buttons=None, modifiers=None):
+        qt = self.Core.Qt
+        event = self.GuiQt.QMouseEvent(
+            kind,
+            pos,
+            self.gl.mapToGlobal(pos.toPoint()),
+            button or qt.NoButton,
+            buttons or qt.NoButton,
+            modifiers or qt.NoModifier,
+        )
+        self.Widgets.QApplication.sendEvent(self.gl, event)
+
+    def click(self, pos, modifiers=None):
+        qt, event = self.Core.Qt, self.Core.QEvent
+        self.mouse(event.MouseButtonPress, pos, qt.LeftButton, qt.LeftButton, modifiers)
+        self.mouse(event.MouseButtonRelease, pos, qt.LeftButton, modifiers=modifiers)
+
+    def key(self, key, modifiers=None):
+        event = self.GuiQt.QKeyEvent(
+            self.Core.QEvent.KeyPress, key, modifiers or self.Core.Qt.NoModifier
+        )
+        self.Widgets.QApplication.sendEvent(self.gl, event)
+
+    def drag(self, pos, delta, modifiers=None, key=None):
+        qt, event = self.Core.Qt, self.Core.QEvent
+        self.mouse(event.MouseButtonPress, pos, qt.LeftButton, qt.LeftButton)
+        if key is not None:
+            self.key(key)
+        self.mouse(event.MouseMove, pos + delta, buttons=qt.LeftButton, modifiers=modifiers)
+        self.mouse(event.MouseButtonRelease, pos + delta, qt.LeftButton)
+
+    def button(self, name):
+        return self.panel.findChild(self.Widgets.QPushButton, name)
+
+    def finish(self, accept=False):
+        role = self.Widgets.QDialogButtonBox.Ok if accept else self.Widgets.QDialogButtonBox.Cancel
+        boxes = self.Gui.getMainWindow().findChildren(self.Widgets.QDialogButtonBox)
+        button = next(
+            box.button(role)
+            for box in boxes
+            if box.button(role) is not None and box.button(role).isVisible()
+        )
+        button.click()
+        self.Widgets.QApplication.processEvents()
+
+    def test_edit_colors_and_preselection(self):
+        from pivy import coin
+
+        prefs = App.ParamGet("User parameter:BaseApp/Preferences/View")
+        keys = {
+            "EditedEdgeColor": 0xEEEEEEFF,
+            "ConstructionColor": 0x223344FF,
+            "SelectionColor": 0x556677FF,
+            "HighlightColor": 0x8899AAFF,
+        }
+        previous = {key: prefs.GetUnsigned(key, value) for key, value in keys.items()}
+        try:
+            for key, value in keys.items():
+                prefs.SetUnsigned(key, value)
+            self.table.selectRow(1)
+            self.table.clearSelection()
+            search = coin.SoSearchAction()
+            search.setName("FreehandBSplineEditOverlay")
+            search.apply(self.view.getSceneGraph())
+            overlay = search.getPath().getTail()
+
+            def color(child):
+                return overlay.getChild(child).getChild(0).rgb[0].getPackedValue()
+
+            self.assertEqual(color(1), keys["ConstructionColor"])
+            self.assertEqual(color(4), keys["EditedEdgeColor"])
+            self.assertEqual(color(5), keys["ConstructionColor"])
+            self.mouse(self.Core.QEvent.MouseMove, self.screen(self.curve.Points[1]))
+            self.assertEqual(color(5), keys["HighlightColor"])
+            self.Widgets.QApplication.sendEvent(self.gl, self.Core.QEvent(self.Core.QEvent.Leave))
+            self.assertEqual(color(5), keys["ConstructionColor"])
+            self.table.selectRow(1)
+            self.assertEqual(color(5), keys["SelectionColor"])
+            self.mouse(
+                self.Core.QEvent.MouseMove,
+                self.screen((self.curve.Points[0] + self.curve.Points[1]) * 0.5),
+            )
+            self.assertEqual(color(1), keys["HighlightColor"])
+            self.assertEqual(len(self.curve.Points), 4)
+        finally:
+            for key, value in previous.items():
+                prefs.SetUnsigned(key, value)
+
+    def test_single_unpickable_edit_curve_and_display_restore(self):
+        from pivy import coin
+
+        def find(name):
+            search = coin.SoSearchAction()
+            search.setSearchingAll(True)
+            search.setName(name)
+            search.apply(self.view.getSceneGraph())
+            return search.getPath().getTail() if search.getPath() else None
+
+        hidden = find("FreehandBSplineHiddenDisplay")
+        self.assertIsNotNone(hidden)
+        self.assertEqual(hidden.whichChild.getValue(), coin.SO_SWITCH_NONE)
+        preview = find("FreehandBSplineDrawingPreview")
+        self.assertEqual(preview.getChild(0).style.getValue(), coin.SoPickStyle.UNPICKABLE)
+        vertices = preview.getChild(preview.getNumChildren() - 2)
+        before = str(vertices.point.getValues())
+        self.drag(self.screen(self.curve.Points[1]), self.Core.QPointF(12, -8))
+        self.assertEqual(hidden.whichChild.getValue(), coin.SO_SWITCH_NONE)
+        vertices = preview.getChild(preview.getNumChildren() - 2)
+        self.assertNotEqual(str(vertices.point.getValues()), before)
+        self.assertFalse(self.curve.Shape.isClosed())
+        # The preview is one open line strip, with no extra endpoint-to-endpoint edge.
+        self.assertEqual(preview.getChild(preview.getNumChildren() - 1).numVertices.getNum(), 1)
+        self.assertNotEqual(
+            tuple(vertices.point[0].getValue()),
+            tuple(vertices.point[vertices.point.getNum() - 1].getValue()),
+        )
+        self.assertTrue(self.curve.ViewObject.Selectable)
+        self.finish(True)
+        self.Core.QCoreApplication.sendPostedEvents(None, self.Core.QEvent.DeferredDelete)
+        self.assertIsNone(find("FreehandBSplineHiddenDisplay"))
+        self.assertIsNone(find("FreehandBSplineDrawingPreview"))
+        self.assertTrue(self.curve.ViewObject.Selectable)
+        self.assertTrue(self.curve.ViewObject.Visibility)
+
+    def test_tangent_choices_and_unlock(self):
+        import Part
+
+        support = self.doc.addObject("Part::Feature", "TangentWire")
+        support.Shape = Part.makePolygon(
+            [App.Vector(0, 0, 0), App.Vector(10, 0, 0), App.Vector(10, 10, 0)]
+        )
+        self.doc.recompute()
+        self.assertEqual(self.table.horizontalHeaderItem(1).text(), "Tangent to")
+        self.assertEqual(self.table.columnWidth(0), 112)
+        self.assertIsNone(self.table.cellWidget(0, 1))
+        self.table.item(0, 0).setText("TangentWire.Vertex2")
+        combo = self.table.cellWidget(0, 1)
+        self.assertEqual(
+            [combo.itemText(i) for i in range(combo.count())], ["None", "Edge1", "Edge2"]
+        )
+        combo.setCurrentIndex(2)
+        combo.activated.emit(2)
+        self.assertEqual(self.curve.TangentPointIndices, [0])
+        edge = self.curve.Shape.Edges[0]
+        self.assertLess(edge.tangentAt(edge.FirstParameter).cross(App.Vector(0, 1, 0)).Length, 1e-7)
+        self.table.item(0, 0).setText("")
+        self.assertEqual(self.curve.TangentPointIndices, [])
+        self.assertIsNone(self.table.cellWidget(0, 1))
+        self.table.item(0, 0).setText("TangentWire.Edge1")
+        combo = self.table.cellWidget(0, 1)
+        self.assertEqual([combo.itemText(i) for i in range(combo.count())], ["None", "Edge1"])
+        combo.setCurrentIndex(1)
+        combo.activated.emit(1)
+        self.table.selectRow(0)
+        self.key(self.Core.Qt.Key_Delete)
+        self.assertEqual(self.curve.TangentPointIndices, [])
+
+    def test_drawing_clicks_lock_snapped_references(self):
+        import Part
+
+        self.finish()
+        self.curve.ViewObject.Visibility = False
+        support = self.doc.addObject("Part::Feature", "DrawingReference")
+        support.Shape = Part.makePolygon(
+            [App.Vector(-10, -8, 0), App.Vector(10, -8, 0), App.Vector(10, -20, 0)]
+        )
+        self.doc.recompute()
+        self.Gui.runCommand("Surface_FreehandBSpline")
+        self.Widgets.QApplication.processEvents()
+        created = self.doc.getObject("FreehandBSpline")
+        self.panel = self.Gui.getMainWindow().findChild(
+            self.Widgets.QWidget, "FreehandBSplineEditor"
+        )
+        self.table = self.panel.findChild(self.Widgets.QTableWidget, "interpolationPoints")
+        vertex = self.screen(App.Vector(10, -8, 0))
+        self.mouse(self.Core.QEvent.MouseMove, vertex)
+        self.assertEqual(created.SupportPointIndices, [])
+        self.click(vertex)
+        self.click(self.screen(App.Vector(0, -8, 0)))
+        self.click(self.screen(App.Vector(25, 15, 0)))
+        self.assertEqual(created.SupportPointIndices, [0, 1])
+        self.assertEqual(
+            [name for entry in created.Support for name in entry[1]], ["Vertex2", "Edge1"]
+        )
+        snapping = next(
+            box
+            for box in self.panel.findChildren(self.Widgets.QCheckBox)
+            if box.text() == "Snap to vertices and edges"
+        )
+        snapping.setChecked(False)
+        self.click(self.screen(App.Vector(10, -20, 0)))
+        self.assertEqual(len(created.Points), 4)
+        self.assertEqual(created.SupportPointIndices, [0, 1])
+        self.button("endBSpline").click()
+        self.assertEqual(self.table.item(0, 0).text(), "DrawingReference.Vertex2")
+        self.assertEqual(self.table.item(1, 0).text(), "DrawingReference.Edge1")
+        self.assertIsNotNone(self.table.cellWidget(0, 1))
+        self.finish(True)
+        support.Placement.Base = App.Vector(0, 0, 5)
+        self.doc.recompute()
+        self.assertAlmostEqual(created.Points[0].z, 5)
+        self.assertAlmostEqual(created.Points[1].z, 5)
+        self.assertAlmostEqual(created.Points[2].z, 0)
+
+    def test_point_clicks_take_priority_over_coordinate_labels(self):
+        for dx, dy in ((0, 0), (5, 3), (8, 5), (9, 0)):
+            self.table.clearSelection()
+            self.click(self.screen(self.curve.Points[1]) + self.Core.QPointF(dx, dy))
+            self.assertEqual([row.row() for row in self.table.selectionModel().selectedRows()], [1])
+            self.assertFalse(
+                any(
+                    w.isVisible()
+                    for w in self.gl.findChildren(
+                        self.Widgets.QAbstractSpinBox, "pointCoordinateEditor"
+                    )
+                )
+            )
+        before = self.curve.Points[1]
+        self.drag(self.screen(before) + self.Core.QPointF(8, 4), self.Core.QPointF(20, -15))
+        self.assertGreater((self.curve.Points[1] - before).Length, 0.1)
+
+    def test_inline_coordinate_editing(self):
+        point = 1
+
+        def find_editor(axis):
+            origin = self.screen(self.curve.Points[point])
+            # Locate the rendered glyphs, accounting for Coin's font metrics and viewport scaling.
+            for y in range(-24, 49, 2):
+                for x in range(8, 37, 2):
+                    pos = origin + self.Core.QPointF(x, y)
+                    self.click(pos)
+                    spin = next(
+                        (
+                            w
+                            for w in self.gl.findChildren(self.Widgets.QAbstractSpinBox)
+                            if w.objectName() == "pointCoordinateEditor" and w.isVisible()
+                        ),
+                        None,
+                    )
+                    if spin:
+                        if spin.toolTip().endswith(axis):
+                            return spin
+                        event = self.GuiQt.QKeyEvent(
+                            self.Core.QEvent.KeyPress,
+                            self.Core.Qt.Key_Escape,
+                            self.Core.Qt.NoModifier,
+                        )
+                        self.Widgets.QApplication.sendEvent(spin, event)
+            self.fail("Could not click coordinate " + axis)
+
+        spin = find_editor("X")
+        self.assertTrue(self.gl.rect().contains(spin.geometry()))
+        spin.findChild(self.Widgets.QLineEdit).setText("1.2 cm")
+        self.Widgets.QApplication.sendEvent(
+            spin,
+            self.GuiQt.QKeyEvent(
+                self.Core.QEvent.KeyPress, self.Core.Qt.Key_Return, self.Core.Qt.NoModifier
+            ),
+        )
+        self.assertAlmostEqual(self.curve.Points[point].x, 12)
+        spin = find_editor("Y")
+        original = self.curve.Points[point]
+        spin.setProperty("rawValue", 99.0)
+        self.Widgets.QApplication.sendEvent(
+            spin,
+            self.GuiQt.QKeyEvent(
+                self.Core.QEvent.KeyPress, self.Core.Qt.Key_Escape, self.Core.Qt.NoModifier
+            ),
+        )
+        self.assertEqual(self.curve.Points[point], original)
+        spin = find_editor("Z")
+        spin.setProperty("rawValue", 4.0)
+        self.Widgets.QApplication.sendEvent(
+            spin,
+            self.GuiQt.QKeyEvent(
+                self.Core.QEvent.KeyPress, self.Core.Qt.Key_Return, self.Core.Qt.NoModifier
+            ),
+        )
+        self.assertAlmostEqual(self.curve.Points[point].z, 4)
+        self.finish()
+        self.Core.QCoreApplication.sendPostedEvents(None, self.Core.QEvent.DeferredDelete)
+        self.assertIsNone(self.gl.findChild(self.Widgets.QAbstractSpinBox, "pointCoordinateEditor"))
+
+    def test_edit_after_deleting_body_reference(self):
+        import Part
+
+        self.finish()
+        body = self.doc.addObject("PartDesign::Body", "SupportBody")
+        solid = body.newObject("PartDesign::Feature", "Solid")
+        solid.Shape = Part.makeBox(4, 4, 4)
+        body.Tip = solid
+        self.doc.recompute()
+        self.curve.Support = [(body, ("Vertex1",))]
+        self.curve.SupportPointIndices = [0]
+        self.curve.SupportParameters = [App.Vector()]
+        self.doc.recompute()
+        before = list(self.curve.Points)
+        self.doc.removeObject(body.Name)
+        self.doc.recompute()
+        self.assertTrue(self.curve.isValid(), self.curve.getStatusString())
+        self.assertEqual(self.curve.SupportPointIndices, [])
+        self.assertEqual(self.curve.Points, before)
+        # Reproduce already-corrupted metadata from a file created before this fix.
+        self.curve.SupportPointIndices = [0]
+        self.curve.SupportParameters = [App.Vector()]
+        self.Gui.getDocument(self.doc.Name).setEdit(self.curve.Name)
+        self.Widgets.QApplication.processEvents()
+        self.panel = self.Gui.getMainWindow().findChild(
+            self.Widgets.QWidget, "FreehandBSplineEditor"
+        )
+        self.table = self.panel.findChild(self.Widgets.QTableWidget, "interpolationPoints")
+        self.assertEqual(self.table.item(0, 0).text(), "")
+        self.assertEqual(self.curve.SupportPointIndices, [])
+        self.drag(self.screen(self.curve.Points[1]), self.Core.QPointF(15, -12))
+        self.finish(True)
+        self.assertIsNone(self.Gui.getDocument(self.doc.Name).getInEdit())
+        self.assertTrue(self.curve.ViewObject.Visibility)
+        self.assertTrue(self.curve.isValid(), self.curve.getStatusString())
+
+    def test_create_accept_undo_redo_and_cancel(self):
+        self.finish()
+        self.Gui.runCommand("Surface_FreehandBSpline")
+        self.Widgets.QApplication.processEvents()
+        created = self.doc.getObject("FreehandBSpline")
+        self.assertIsNotNone(created)
+        for p in (App.Vector(0, 1, 0), App.Vector(8, 3, 0), App.Vector(14, 1, 0)):
+            self.click(self.screen(p))
+        self.assertEqual(len(created.Points), 3)
+        self.finish(True)
+        self.assertTrue(created.Shape.isValid())
+        self.doc.undo()
+        self.assertIsNone(self.doc.getObject("FreehandBSpline"))
+        self.doc.redo()
+        self.assertTrue(self.doc.FreehandBSpline.Shape.isValid())
+        self.Gui.runCommand("Surface_FreehandBSpline")
+        self.Widgets.QApplication.processEvents()
+        self.assertIsNotNone(self.doc.getObject("FreehandBSpline001"))
+        self.finish()
+        self.assertIsNone(self.doc.getObject("FreehandBSpline001"))
+
+    def test_drawing_preview_and_transition_to_editing(self):
+        from pivy import coin
+
+        self.finish()
+        qt, event = self.Core.Qt, self.Core.QEvent
+        for ending in ("button", "escape", "right"):
+            self.Gui.runCommand("Surface_FreehandBSpline")
+            self.Widgets.QApplication.processEvents()
+            created = self.doc.getObject("FreehandBSpline")
+            self.panel = self.Gui.getMainWindow().findChild(
+                self.Widgets.QWidget, "FreehandBSplineEditor"
+            )
+            self.table = self.panel.findChild(self.Widgets.QTableWidget, "interpolationPoints")
+            self.assertFalse(self.table.isEnabled())
+            positions = [self.screen(App.Vector(x, y, 0)) for x, y in ((0, 1), (8, 7), (14, 1))]
+            for pos in positions:
+                self.click(pos)
+            original = list(created.Points)
+            shape = created.Shape.copy()
+            self.mouse(event.MouseMove, self.screen(App.Vector(19, 9, 0)))
+            self.assertEqual(created.Points, original)
+            self.assertAlmostEqual(created.Shape.Length, shape.Length)
+            search = coin.SoSearchAction()
+            search.setName("FreehandBSplineDrawingPreview")
+            search.apply(self.view.getSceneGraph())
+            self.assertIsNotNone(search.getPath())
+            preview = search.getPath().getTail()
+            self.assertGreater(preview.getNumChildren(), 0)
+            # A second pointer move changes the curve preview, not its committed points.
+            vertices = preview.getChild(preview.getNumChildren() - 2)
+            before = str(vertices.point.getValues())
+            self.mouse(event.MouseMove, self.screen(App.Vector(19, -6, 0)))
+            vertices = preview.getChild(preview.getNumChildren() - 2)
+            self.assertNotEqual(str(vertices.point.getValues()), before)
+            if ending == "button":
+                self.button("endBSpline").click()
+            elif ending == "escape":
+                self.key(qt.Key_Escape)
+            else:
+                self.mouse(event.MouseButtonPress, positions[-1], qt.RightButton, qt.RightButton)
+                self.mouse(event.MouseButtonRelease, positions[-1], qt.RightButton)
+            self.assertIsNotNone(self.Gui.getDocument(self.doc.Name).getInEdit())
+            self.assertTrue(self.table.isEnabled())
+            self.assertGreater(preview.getNumChildren(), 0)
+            self.click(self.screen(App.Vector(25, -8, 0)))
+            self.assertEqual(created.Points, original)
+            edge = created.Shape.Edges[0]
+            point = edge.valueAt(
+                edge.FirstParameter + (edge.LastParameter - edge.FirstParameter) * 0.3
+            )
+            pos = self.screen(point)
+            # Real Qt double-click sequence includes the initial press and release.
+            self.click(pos)
+            self.mouse(event.MouseButtonDblClick, pos, qt.LeftButton, qt.LeftButton)
+            self.mouse(event.MouseButtonRelease, pos, qt.LeftButton)
+            self.assertEqual(len(created.Points), 4)
+            self.key(qt.Key_Delete)
+            self.assertEqual(len(created.Points), 3)
+            self.finish()
+            self.assertIsNone(self.doc.getObject("FreehandBSpline"))
+
+    def test_point_reference_lock_and_delete_shortcut(self):
+        import Part
+
+        qt = self.Core.Qt
+        support = self.doc.addObject("Part::Feature", "SupportEdge")
+        support.Shape = Part.makeLine(App.Vector(-10, 3, 0), App.Vector(40, 3, 0))
+        self.doc.recompute()
+        self.click(self.screen(self.curve.Points[1]))
+        self.Gui.Selection.clearSelection()
+        self.Gui.Selection.addSelection(support, "Edge1")
+        self.button("lockPoint").click()
+        self.assertEqual(self.curve.SupportPointIndices, [1])
+        self.assertAlmostEqual(self.curve.Points[1].y, 3)
+        self.assertEqual(self.table.item(1, 0).text(), "SupportEdge.Edge1")
+        self.assertEqual(self.button("lockPoint").text(), "Unlock")
+        self.button("lockPoint").click()
+        self.assertEqual(self.curve.SupportPointIndices, [])
+        self.assertEqual(self.table.item(1, 0).text(), "")
+        self.assertEqual(self.button("lockPoint").text(), "Lock to")
+        self.button("lockPoint").click()
+        self.assertEqual(self.curve.SupportPointIndices, [1])
+        self.table.selectRow(2)
+        self.assertEqual(self.button("lockPoint").text(), "Lock to")
+        self.table.selectRow(1)
+        self.assertEqual(self.button("lockPoint").text(), "Unlock")
+        edge = self.curve.Shape.Edges[0]
+        point = edge.valueAt(edge.FirstParameter + (edge.LastParameter - edge.FirstParameter) * 0.1)
+        self.mouse(
+            self.Core.QEvent.MouseButtonDblClick, self.screen(point), qt.LeftButton, qt.LeftButton
+        )
+        self.assertEqual(self.curve.SupportPointIndices, [2])
+        self.key(qt.Key_Delete)
+        self.assertEqual(self.curve.SupportPointIndices, [1])
+        self.drag(self.screen(self.curve.Points[1]), self.Core.QPointF(25, 35))
+        self.assertAlmostEqual(self.curve.Points[1].y, 3)
+        fraction = self.curve.SupportParameters[0].x
+        support.Placement.Base = App.Vector(0, 4, 0)
+        self.doc.recompute()
+        self.assertAlmostEqual(self.curve.Points[1].y, 7)
+        self.assertAlmostEqual(self.curve.SupportParameters[0].x, fraction)
+        # Clear the reference through the actual editable table cell.
+        self.table.item(1, 0).setText("")
+        self.assertEqual(self.curve.SupportPointIndices, [])
+        self.table.item(1, 0).setText("SupportEdge")
+        self.assertEqual(self.table.item(1, 0).text(), "SupportEdge")
+        self.assertEqual(self.curve.SupportPointIndices, [1])
+        self.table.item(1, 0).setText("")
+        # Lock through a typed reference, then remove both segment endpoints with Delete.
+        self.table.item(0, 0).setText("SupportEdge.Vertex1")
+        self.assertEqual(self.curve.SupportPointIndices, [0])
+        self.click((self.screen(self.curve.Points[0]) + self.screen(self.curve.Points[1])) / 2)
+        before = self.curve.Points[2:]
+        override = self.GuiQt.QKeyEvent(
+            self.Core.QEvent.ShortcutOverride, qt.Key_Delete, qt.NoModifier
+        )
+        self.Widgets.QApplication.sendEvent(self.gl, override)
+        self.assertTrue(override.isAccepted())
+        self.key(qt.Key_Delete)
+        self.assertEqual(self.curve.Points, before)
+        self.assertEqual(self.curve.SupportPointIndices, [])
+        self.assertIsNotNone(self.doc.getObject(self.curve.Name))
+
+    def test_native_reference_selection_and_balanced_mouse_events(self):
+        import Part
+
+        qt, event = self.Core.Qt, self.Core.QEvent
+        support = self.doc.addObject("Part::Feature", "PickReference")
+        support.Shape = Part.makeLine(App.Vector(-10, -8, 0), App.Vector(40, -8, 0))
+        self.doc.recompute()
+        self.Widgets.QApplication.processEvents()
+        self.view.fitAll()
+        loop = self.Core.QEventLoop()
+        self.Core.QTimer.singleShot(600, loop.quit)
+        loop.exec()
+        self.view.redraw()
+        self.Widgets.QApplication.processEvents()
+        self.table.selectRow(1)
+
+        class MouseObserver(self.Core.QObject):
+            def __init__(self):
+                super().__init__()
+                self.events = []
+
+            def eventFilter(self, watched, received):
+                if received.type() in (event.MouseButtonPress, event.MouseButtonRelease):
+                    self.events.append(received.type())
+                return False
+
+        observer = MouseObserver()
+        self.gl.installEventFilter(observer)
+        try:
+            # Locate the rendered edge, including viewport scaling and camera fitting.
+            x, y = self.view.getPointOnScreen(App.Vector(5, -8, 0))
+            hits = [
+                candidate
+                for candidate in range(y - 40, y + 41)
+                if (self.view.getObjectInfo((x, candidate)) or {}).get("Object") == support.Name
+            ]
+            hitY = hits[len(hits) // 2]
+            ratio = self.gl.devicePixelRatioF()
+            pos = self.Core.QPointF(x / ratio, self.gl.height() - hitY / ratio)
+            self.mouse(event.MouseMove, pos)
+            self.click(pos)
+            self.Widgets.QApplication.processEvents()
+            self.assertEqual(observer.events, [event.MouseButtonPress, event.MouseButtonRelease])
+            selected = self.Gui.Selection.getSelectionEx()
+            self.assertEqual(len(selected), 1)
+            self.assertEqual(selected[0].ObjectName, support.Name)
+            self.assertEqual(selected[0].SubElementNames, ("Edge1",))
+            self.assertEqual(len(self.table.selectionModel().selectedRows()), 1)
+            self.button("lockPoint").click()
+            self.assertEqual(self.curve.SupportPointIndices, [1])
+            # An empty-space click deselects the spline point and reaches native selection.
+            empty = self.Core.QPointF(35, self.gl.height() - 35)
+            self.mouse(event.MouseMove, empty)
+            self.click(empty)
+            self.assertEqual(len(self.table.selectionModel().selectedRows()), 0)
+            self.assertEqual(len(observer.events), 4)
+            self.finish(True)
+            self.mouse(event.MouseMove, empty + self.Core.QPointF(40, -25))
+            self.assertFalse(
+                any(
+                    w.isVisible()
+                    for w in self.Gui.getMainWindow().findChildren(self.Widgets.QRubberBand)
+                )
+            )
+        finally:
+            self.gl.removeEventFilter(observer)
+
+    def test_tools_follow_selection_validity(self):
+        import Part
+
+        self.assertFalse(self.button("alignSelection").isEnabled())
+        self.assertFalse(self.button("lockPoint").isEnabled())
+        self.assertFalse(self.button("toggleInterpolation").isEnabled())
+        self.assertTrue(self.button("selectAll").isEnabled())
+        self.table.selectRow(1)
+        self.assertFalse(self.button("lockPoint").isEnabled())
+        reference = self.doc.addObject("Part::Feature", "Reference")
+        reference.Shape = Part.makeLine(App.Vector(0, 3, 0), App.Vector(30, 3, 0))
+        self.doc.recompute()
+        self.Gui.Selection.addSelection(reference, "Edge1")
+        self.assertTrue(self.button("lockPoint").isEnabled())
+        self.Gui.Selection.clearSelection()
+        self.assertFalse(self.button("lockPoint").isEnabled())
+        self.table.selectAll()
+        self.assertTrue(self.button("alignSelection").isEnabled())
+        self.assertFalse(self.button("selectAll").isEnabled())
+        self.assertFalse(self.button("lockPoint").isEnabled())
+        self.assertFalse(self.button("toggleInterpolation").isEnabled())
+        self.table.clearSelection()
+        self.assertFalse(self.button("alignSelection").isEnabled())
+        self.assertTrue(self.button("selectAll").isEnabled())
+
+    def test_face_lock_slide_and_cycle_rejection(self):
+        import Part
+
+        support = self.doc.addObject("Part::Feature", "SupportFace")
+        support.Shape = Part.makePlane(40, 30, App.Vector(-5, -5, 4))
+        self.doc.recompute()
+        self.table.item(1, 0).setText("SupportFace.Face1")
+        self.assertAlmostEqual(self.curve.Points[1].z, 4)
+        self.table.item(1, 2).setText("100")
+        self.assertAlmostEqual(self.curve.Points[1].x, 35)
+        self.table.item(1, 4).setText("20")
+        self.assertAlmostEqual(self.curve.Points[1].z, 4)
+        support.Placement.Base = App.Vector(0, 0, 6)
+        self.doc.recompute()
+        self.assertAlmostEqual(self.curve.Points[1].z, 10)
+        self.table.item(1, 0).setText(self.curve.Name + ".Edge1")
+        self.assertEqual(self.table.item(1, 0).text(), "SupportFace.Face1")
+        self.assertEqual(self.curve.SupportPointIndices, [1])
+
+    def test_drag_constraints_selection_and_insertion(self):
+        qt = self.Core.Qt
+        self.panel.findChild(self.Widgets.QCheckBox, "snapping").setChecked(False)
+        before = self.curve.Points
+        self.drag(self.screen(before[0]), self.Core.QPointF(30, -15), key=qt.Key_X)
+        self.assertGreater(abs(self.curve.Points[0].x - before[0].x), 0.1)
+        self.assertAlmostEqual(self.curve.Points[0].y, before[0].y, places=5)
+        before = self.curve.Points
+        self.drag(self.screen(before[0]), self.Core.QPointF(20, 0))
+        normal = (self.curve.Points[0] - before[0]).Length
+        before = self.curve.Points
+        self.drag(self.screen(before[0]), self.Core.QPointF(20, 0), qt.ShiftModifier)
+        self.assertAlmostEqual((self.curve.Points[0] - before[0]).Length / normal, 0.1, places=2)
+        before = self.curve.Points
+        self.click(self.screen(before[0]))
+        self.click(self.screen(before[1]), qt.ControlModifier)
+        self.drag(self.screen(before[0]), self.Core.QPointF(0, 20))
+        self.assertLess(
+            ((self.curve.Points[0] - before[0]) - (self.curve.Points[1] - before[1])).Length, 1e-5
+        )
+        before = self.curve.Points
+        self.drag((self.screen(before[2]) + self.screen(before[3])) / 2, self.Core.QPointF(0, 20))
+        self.assertGreater((self.curve.Points[2] - before[2]).Length, 0.1)
+        self.assertLess(
+            ((self.curve.Points[2] - before[2]) - (self.curve.Points[3] - before[3])).Length, 1e-5
+        )
+        edge = self.curve.Shape.Edges[0]
+        p = edge.valueAt(edge.FirstParameter + (edge.LastParameter - edge.FirstParameter) * 0.13)
+        self.mouse(
+            self.Core.QEvent.MouseButtonDblClick, self.screen(p), qt.LeftButton, qt.LeftButton
+        )
+        self.assertEqual(len(self.curve.Points), 5)
+        self.key(qt.Key_Delete)
+        self.assertEqual(len(self.curve.Points), 4)
+        self.key(qt.Key_A, qt.ControlModifier)
+        self.assertEqual(len(self.table.selectionModel().selectedRows()), 4)
+
+    def test_snapping_alignment_and_linear_controls(self):
+        import Part
+
+        support = self.doc.addObject("Part::Feature", "SnapVertex")
+        target = self.curve.Points[0] + App.Vector(2, 1, 3)
+        support.Shape = Part.Vertex(target)
+        start = self.screen(self.curve.Points[0])
+        self.drag(start, self.screen(target) - start + self.Core.QPointF(3, 2))
+        self.assertLess((self.curve.Points[0] - target).Length, 1e-6)
+        line = self.doc.addObject("Part::Feature", "SnapEdge")
+        target = target + App.Vector(0, 2, 2)
+        line.Shape = Part.makeLine(target - App.Vector(5, 0, 0), target + App.Vector(5, 0, 0))
+        start = self.screen(self.curve.Points[0])
+        self.drag(start, self.screen(target) - start + self.Core.QPointF(1, 2))
+        self.assertLess(line.Shape.distToShape(Part.Vertex(self.curve.Points[0]))[0], 1e-6)
+        self.table.selectAll()
+        self.button("alignSelection").click()
+        axis = Part.makeLine(self.curve.Points[0], self.curve.Points[-1])
+        for p in self.curve.Points:
+            self.assertLess(axis.distToShape(Part.Vertex(p))[0], 1e-5)
+        self.assertFalse(self.button("toggleInterpolation").isEnabled())
+        for index in range(len(self.curve.Points) - 1):
+            midpoint = (
+                self.screen(self.curve.Points[index]) + self.screen(self.curve.Points[index + 1])
+            ) / 2
+            self.click(midpoint, self.Core.Qt.ControlModifier if index else None)
+        self.assertTrue(self.button("toggleInterpolation").isEnabled())
+        self.button("toggleInterpolation").click()
+        self.assertTrue(all(self.curve.LinearSegments))
+        self.assertEqual(self.button("toggleInterpolation").text(), "Set smooth interpolation")
+        self.button("toggleInterpolation").click()
+        self.assertFalse(any(self.curve.LinearSegments))
+        self.assertEqual(self.button("toggleInterpolation").text(), "Set linear interpolation")
+        self.assertIsNone(self.button("deletePoints"))
+        self.assertEqual(self.table.horizontalHeaderItem(0).text(), "Locked to")
+        self.assertGreater(self.table.columnWidth(0), self.table.columnWidth(1))
+
+    def test_escape_and_cancel_restore_edits(self):
+        qt = self.Core.Qt
+        before = self.curve.Points
+        pos = self.screen(before[0])
+        self.mouse(self.Core.QEvent.MouseButtonPress, pos, qt.LeftButton, qt.LeftButton)
+        self.mouse(
+            self.Core.QEvent.MouseMove, pos + self.Core.QPointF(30, 10), buttons=qt.LeftButton
+        )
+        self.key(qt.Key_Escape)
+        for a, b in zip(before, self.curve.Points):
+            self.assertLess((a - b).Length, 1e-6)
+        self.table.selectRow(1)
+        self.key(qt.Key_Delete)
+        self.assertEqual(len(self.curve.Points), 3)
+        self.finish()
+        self.assertEqual(len(self.curve.Points), 4)
+        self.assertIsNone(self.Gui.getDocument(self.doc.Name).getInEdit())

--- a/src/Mod/Surface/TestSurfaceFreehandBSpline.py
+++ b/src/Mod/Surface/TestSurfaceFreehandBSpline.py
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+from SurfaceTests.TestFreehandBSpline import TestFreehandBSpline
+from SurfaceTests.TestFreehandBSplineGui import TestFreehandBSplineGui
+
+__all__ = ["TestFreehandBSpline", "TestFreehandBSplineGui"]


### PR DESCRIPTION
https://github.com/user-attachments/assets/ac90bdd0-c39f-4044-949c-7f9bbef75400

Adds a Freehand B-spline tool to the Surface workbench. 

- Drawing places interpolation points with a live preview
- End B-spline, right-click, or Escape switches to editing.

- Points and control-polygon segments can be selected and dragged.
- Editing includes axis constraints, fine movement, double-click insertion, deletion, alignment, linear spans, and inline coordinate inputs. Drawing snaps create persistent vertex/edge locks. The point table supports editing locks and choosing edge or face tangency.

The edit display uses Sketcher preferences colors.