### PR TITLE
App: update only properties from the newly opened documents

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -1161,7 +1161,7 @@ std::vector<Document*> Application::openDocuments(const std::vector<std::string>
         Base::Console().log("%s restore time: %f\n", doc.getDocumentName(), timing.d1.count());
         Base::Console().log("%s postprocess time: %f\n", doc.getDocumentName(), timing.d2.count());
     }
-    PropertyLinkBase::updateAllElementReferences();
+    PropertyLinkBase::updateAllElementReferences(openedDocs);
     _isRestoring = false;
 
     signalFinishOpenDocument();

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -23,6 +23,7 @@
  ***************************************************************************/
 
 #include <algorithm>
+#include <set>
 
 #include <QDir>
 #include <QFileInfo>
@@ -301,11 +302,22 @@ void PropertyLinkBase::updateElementReferences(DocumentObject* feature, bool rev
     }
 }
 
-void PropertyLinkBase::updateAllElementReferences(bool reverse)
+void PropertyLinkBase::updateAllElementReferences(const std::vector<App::DocumentT>& newDocs, bool reverse)
 {
+    std::set<App::Document*> newDocSet;
+    for (const auto& doc : newDocs) {
+        if (auto* d = doc.getDocument()) {
+            newDocSet.insert(d);
+        }
+    }
+
     for (auto reference : _ElementRefMap) {
         for (auto prop : reference.second) {
             if (prop->getContainer()) {
+                const auto docObj = freecad_cast<App::DocumentObject*>(prop->getContainer());
+                if (!docObj || !newDocSet.count(docObj->getDocument())) {
+                    continue;
+                }
                 try {
                     prop->updateElementReference(reference.first, reverse, true);
                 }

--- a/src/App/PropertyLinks.h
+++ b/src/App/PropertyLinks.h
@@ -43,6 +43,7 @@ namespace App
 {
 class DocumentObject;
 class Document;
+class DocumentT;
 class GeoFeature;
 class SubObjectT;
 
@@ -394,7 +395,7 @@ public:
     static void updateElementReferences(DocumentObject* feature, bool reverse = false);
 
     /// Update all element references in the _ElementRefMap
-    static void updateAllElementReferences(bool reverse = false);
+    static void updateAllElementReferences(const std::vector<DocumentT>& newDocs, bool reverse = false);
 
     /// Obtain link properties that contain element references to a given object
     static const std::unordered_set<PropertyLinkBase*>& getElementReferences(DocumentObject*);


### PR DESCRIPTION
Fixes #32195 (@jffmichi)

@drwho495 can you review this for me? I lack background on how FreeCAD manages documents and properties, and I'm not certain of this change.

I believe that as of #23263 we redundantly update property references on document load. I don't know if there are other relevant pathways, but in #32195, `onDocumentRestored` loads freecad documents for each of the tools referenced in the CAM job. Each of these tool document loads calls `updateAllElementReferences`, recomputing all properties, not just properties in the (inner) tool document. For files with many tools, this is a lot of redundant recompute, and causes very slow file loads.

My proposed fix is to pass the list of newly opened documents to `updateAllElementReferences` and only update references from those new documents. @drwho495 is this the appropriate fix, and have I done it properly?

I have validated my change by testing with @jffmichi 's test file from #32195. I added temporary debug output on the `prop->updateElementReference(reference.first, reverse, true);` line to log which property is being updated, and which document it belongs to. Before this change, all properties update on all document loads. After this change, the tool loads only update properties from the tool document.
