### PR TITLE
Gui: open the expression dialog on = for string fields

### DIFF
--- a/src/Gui/Widgets.cpp
+++ b/src/Gui/Widgets.cpp
@@ -1739,9 +1739,25 @@ void ExpLineEdit::finishFormulaDialog()
 
 void ExpLineEdit::keyPressEvent(QKeyEvent* event)
 {
-    if (m_tentativeDiscard || !hasExpression()) {
-        QLineEdit::keyPressEvent(event);
+    // A bound expression is edited via the formula dialog (or after a double-click
+    // stash). Ignore keys until then so they don't clobber the expression text.
+    if (!(m_tentativeDiscard || !hasExpression())) {
+        return;
     }
+
+    // Same '=' shortcut as numeric spinboxes, but only at the start or when the
+    // whole string is selected so '=' can still be typed in the middle.
+    if (isBound() && event->text() == QLatin1String("=")) {
+        const bool allSelected = !text().isEmpty() && selectedText() == text();
+        const bool atStart = cursorPosition() == 0 && selectedText().isEmpty();
+        if (allSelected || atStart) {
+            event->accept();
+            openFormulaDialog();
+            return;
+        }
+    }
+
+    QLineEdit::keyPressEvent(event);
 }
 
 void ExpLineEdit::stashExpression()


### PR DESCRIPTION
Fixes #32603

String property editors already show the fx icon but pressing = just typed "=" into the text  numeric fields already open the expression dialog on that key

ExpLineEdit now does the same but only when the cursor is at the start or the whole string is selected  = in the middle of the text is still inserted so existing string editing is unchanged Spinboxes and the fx click path are untouched

Manually verified

https://github.com/user-attachments/assets/372b6381-6a06-4bcf-9b07-c1bfd4e71115



AI assistance: Cursor