### PR TITLE
Gui: remove extra blank line from selection radius tooltip

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsSelection.ui
+++ b/src/Gui/PreferencePages/DlgSettingsSelection.ui
@@ -94,8 +94,7 @@
           </property>
           <property name="toolTip">
            <string>Area for selecting elements in the 3D view.
-A larger value makes it easier to select elements, but may prevent selection of small features.
-      </string>
+A larger value makes it easier to select elements, but may prevent selection of small features.</string>
           </property>
           <property name="inputMethodHints">
            <set>Qt::InputMethodHint::ImhPreferNumbers</set>


### PR DESCRIPTION
Summary

Remove the extra empty line at the end of the General → Selection → Radius tooltip in Preferences.

This addresses item 3 of #28272.

Change

The tooltip already contains the intended two lines; this removes only the trailing whitespace/newline that renders an additional empty line.

Testing

Reviewed the .ui change and confirmed it only changes tooltip text formatting; no runtime logic is modified.

AI assistance was used while preparing this contribution. I reviewed and understand the change and can explain or revise it as needed.