### PR TITLE
Packaging: preserve FreeCAD executable casing on macOS

### DIFF
--- a/package/bundle/osx/create_bundle.sh
+++ b/package/bundle/osx/create_bundle.sh
@@ -47,7 +47,7 @@ rm -rf ${conda_env}/share/vim
 
 mv ${conda_env}/bin ${conda_env}/bin_tmp
 mkdir ${conda_env}/bin
-cp ${conda_env}/bin_tmp/freecad ${conda_env}/bin/
+cp ${conda_env}/bin_tmp/freecad ${conda_env}/bin/FreeCAD
 cp ${conda_env}/bin_tmp/freecadcmd ${conda_env}/bin
 cp ${conda_env}/bin_tmp/ccx ${conda_env}/bin/
 cp ${conda_env}/bin_tmp/python ${conda_env}/bin/

--- a/package/bundle/osx/launcher/FreeCAD.cpp
+++ b/package/bundle/osx/launcher/FreeCAD.cpp
@@ -10,7 +10,7 @@
 int main(int argc, char *argv[], char *const *envp) {
     char *cwd = dirname(realpath(argv[0], NULL));
 
-    std::string FreeCAD = realpath((std::string(cwd) + "/../Resources/bin/freecad").c_str(), NULL);
+    std::string FreeCAD = realpath((std::string(cwd) + "/../Resources/bin/FreeCAD").c_str(), NULL);
 
     std::map<std::string, std::string> env;
     for(int i = 0; envp[i] != NULL; ++i) {


### PR DESCRIPTION
## Summary

Preserve the `FreeCAD` executable casing inside the macOS app bundle and update the launcher to execute that path.

This addresses #21118.

## Change

- Copy the bundled GUI executable to `Contents/Resources/bin/FreeCAD` instead of `.../freecad`.
- Update the macOS launcher to resolve and execute `../Resources/bin/FreeCAD`.

This matches the root cause identified in #21118: when the bundled executable path is lowercase, Qt can fall back to the executable basename and display `freecad` in the macOS application menus.

## Testing

Reviewed the packaging and launcher changes together to confirm both sides use the same path and casing. The branch contains only these two one-line changes and is based on current `main`.

AI assistance was used while preparing this contribution. I reviewed and understand the change and can explain or revise it as needed.