### PR TITLE
Feature/follow system theme

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -46,10 +46,12 @@
 #include <QThread>
 #include <QWindow>
 #include <QStyleFactory>
+#include <QStyleHints>
 
 #include <QLoggingCategory>
 #include <fmt/format.h>
 #include <list>
+#include <qguiapplication.h>
 #include <ranges>
 
 #include <App/Document.h>
@@ -2559,6 +2561,9 @@ void tryRunEventLoop(GUISingleApplication& mainApp)
         boost::interprocess::file_lock flock(filename.c_str());
         if (flock.try_lock()) {
             Base::Console().log("Init: Executing event loop…\n");
+            // hack to get dark mode detected correctly at on startup
+            QGuiApplication::styleHints()->setColorScheme(Qt::ColorScheme::Dark);
+            QGuiApplication::styleHints()->unsetColorScheme();
             QApplication::exec();
 
             // Qt can't handle exceptions thrown from event handlers, so we need

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2561,9 +2561,12 @@ void tryRunEventLoop(GUISingleApplication& mainApp)
         boost::interprocess::file_lock flock(filename.c_str());
         if (flock.try_lock()) {
             Base::Console().log("Init: Executing event loop…\n");
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
             // hack to get dark mode detected correctly at on startup
             QGuiApplication::styleHints()->setColorScheme(Qt::ColorScheme::Dark);
             QGuiApplication::styleHints()->unsetColorScheme();
+#endif
             QApplication::exec();
 
             // Qt can't handle exceptions thrown from event handlers, so we need

--- a/src/Gui/GuiApplication.cpp
+++ b/src/Gui/GuiApplication.cpp
@@ -164,6 +164,38 @@ bool GUIApplication::notify(QObject* receiver, QEvent* event)
     return true;
 }
 
+bool GUIApplication::isSystemInDarkMode()
+{
+    // Auto-detect system setting and default to light mode
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    // https://www.qt.io/blog/dark-mode-on-windows-11-with-qt-6.5
+    const auto scheme = QGuiApplication::styleHints()->colorScheme();
+    return scheme == Qt::ColorScheme::Dark;
+#elif QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
+    // https://www.qt.io/blog/dark-mode-on-windows-11-with-qt-6.5
+    const QPalette defaultPalette;
+    const auto text = defaultPalette.color(QPalette::WindowText);
+    const auto window = defaultPalette.color(QPalette::Window);
+    return text.lightness() > window.lightness();
+#else
+# ifdef FC_OS_MACOSX
+    auto key = CFSTR("AppleInterfaceStyle");
+    if (auto value = CFPreferencesCopyAppValue(key, kCFPreferencesAnyApplication)) {
+        // If the value is "Dark", Dark Mode is enabled
+        if (CFGetTypeID(value) == CFStringGetTypeID()) {
+            if (CFStringCompare((CFStringRef)value, CFSTR("Dark"), kCFCompareCaseInsensitive)
+                == kCFCompareEqualTo) {
+                CFRelease(value);
+                return true;
+            }
+        }
+        CFRelease(value);
+    }
+# endif  // FC_OS_MACOSX
+#endif   // QT_VERSION >= 6.4+
+    return false;
+}
+
 void GUIApplication::commitData(QSessionManager& manager)
 {
     if (manager.allowsInteraction()) {
@@ -206,7 +238,7 @@ bool GUIApplication::event(QEvent* ev)
             return true;
         }
     }
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+#if SYSTEM_THEMING_SUPPORTED
     else if (ev->type() == QEvent::ThemeChange) {
         ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
             "User parameter:BaseApp/Preferences/MainWindow"
@@ -235,7 +267,7 @@ bool GUIApplication::event(QEvent* ev)
 
         return true;
     }
-#endif
+#endif  // SYSTEM_THEMING_SUPPORTED
 
     return GUIApplicationNativeEventAware::event(ev);
 }

--- a/src/Gui/GuiApplication.cpp
+++ b/src/Gui/GuiApplication.cpp
@@ -22,6 +22,7 @@
 
 
 #include <FCConfig.h>
+#include <qapplication.h>
 
 #ifdef FC_OS_WIN32
 # include <Windows.h>
@@ -40,7 +41,7 @@
 #include <QFileOpenEvent>
 #include <QSessionManager>
 #include <QTimer>
-
+#include <QStyleHints>
 
 #include <QLocalServer>
 #include <QLocalSocket>
@@ -51,6 +52,7 @@
 #include <Base/Exception.h>
 
 #include "GuiApplication.h"
+#include "Gui/PreferencePackManager.h"
 #include "Application.h"
 #include "MainWindow.h"
 #include "SpaceballEvent.h"
@@ -203,6 +205,34 @@ bool GUIApplication::event(QEvent* ev)
             Application::Instance->open(fn, "FreeCAD");
             return true;
         }
+    }
+    else if (ev->type() == QEvent::ThemeChange) {
+        ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/Preferences/MainWindow"
+        );
+
+        std::string currentTheme = hGrp->GetASCII("ThemeSetting", "");
+        std::string currentLightTheme = hGrp->GetASCII("LightThemeSetting", "");
+        std::string currentDarkTheme = hGrp->GetASCII("DarkThemeSetting", "");
+
+        if (currentTheme == "Use system theme") {
+            const auto scheme = QGuiApplication::styleHints()->colorScheme();
+            currentTheme = scheme == Qt::ColorScheme::Dark ? currentDarkTheme : currentLightTheme;
+
+            hGrp->SetASCII("Theme", currentTheme);
+
+            Application::Instance->prefPackManager()->rescan();
+            auto packs = Application::Instance->prefPackManager()->preferencePacks();
+
+            for (const auto& pack : packs) {
+                if (pack.first == currentTheme) {
+                    Application::Instance->prefPackManager()->apply(pack.first);
+                    break;
+                }
+            }
+        }
+
+        return true;
     }
 
     return GUIApplicationNativeEventAware::event(ev);

--- a/src/Gui/GuiApplication.cpp
+++ b/src/Gui/GuiApplication.cpp
@@ -206,6 +206,7 @@ bool GUIApplication::event(QEvent* ev)
             return true;
         }
     }
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
     else if (ev->type() == QEvent::ThemeChange) {
         ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
             "User parameter:BaseApp/Preferences/MainWindow"
@@ -234,6 +235,7 @@ bool GUIApplication::event(QEvent* ev)
 
         return true;
     }
+#endif
 
     return GUIApplicationNativeEventAware::event(ev);
 }

--- a/src/Gui/GuiApplication.h
+++ b/src/Gui/GuiApplication.h
@@ -29,6 +29,10 @@
 #include <QList>
 #include <memory>
 
+#define SYSTEM_THEMING_SUPPORTED \
+    QT_VERSION >= QT_VERSION_CHECK(6, 5, 0) || QT_VERSION >= QT_VERSION_CHECK(6, 4, 0) \
+        || FC_OS_MACOSX
+
 class QSessionManager;
 
 namespace Gui
@@ -49,6 +53,7 @@ public:
      * where an unhandled exception comes from.
      */
     bool notify(QObject* receiver, QEvent* event) override;
+    static bool isSystemInDarkMode();
 
     /// Pointer to exceptions caught in Qt event handler
     std::shared_ptr<Base::SystemExitException> caughtException;

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
@@ -24,12 +24,14 @@
 
 
 #include <cmath>
+#include <exception>
 #include <limits>
 #include <QApplication>
 #include <QFileDialog>
 #include <QLocale>
 #include <QMessageBox>
 #include <QString>
+#include <QStyleHints>
 #include <algorithm>
 
 #include <App/Document.h>
@@ -52,6 +54,7 @@
 #include <Gui/View3DInventor.h>
 #include <Gui/View3DInventorViewer.h>
 #include <Gui/Language/Translator.h>
+#include <qt6/QtWidgets/qcombobox.h>
 
 #include "DlgSettingsGeneral.h"
 #include "ui_DlgSettingsGeneral.h"
@@ -117,6 +120,18 @@ DlgSettingsGeneral::DlgSettingsGeneral(QWidget* parent)
         );
         connect(
             ui->themesCombobox,
+            qOverload<int>(&QComboBox::activated),
+            this,
+            &DlgSettingsGeneral::onThemeChanged
+        );
+        connect(
+            ui->lightThemeCombobox,
+            qOverload<int>(&QComboBox::activated),
+            this,
+            &DlgSettingsGeneral::onThemeChanged
+        );
+        connect(
+            ui->darkThemeCombobox,
             qOverload<int>(&QComboBox::activated),
             this,
             &DlgSettingsGeneral::onThemeChanged
@@ -361,7 +376,12 @@ void DlgSettingsGeneral::loadSettings()
     );
     ui->tiledBackground->setChecked(hGrp->GetBool("TiledBackground", false));
 
-    loadThemes();
+    loadThemes(ui->themesCombobox);
+    loadThemes(ui->lightThemeCombobox);
+    loadThemes(ui->darkThemeCombobox);
+
+    // determines if light and dark theme boxes need to be shown (when using system theme)
+    onThemeChanged(0);
 }
 
 void DlgSettingsGeneral::resetSettingsToDefaults()
@@ -382,6 +402,12 @@ void DlgSettingsGeneral::resetSettingsToDefaults()
     );
     // reset "Theme" parameter
     hGrp->RemoveASCII("Theme");
+    // reset "ThemeSetting" parameter
+    hGrp->RemoveASCII("ThemeSetting");
+    // reset "LightThemeSetting" parameter
+    hGrp->RemoveASCII("LightThemeSetting");
+    // reset "DarkThemeSetting" parameter
+    hGrp->RemoveASCII("DarkThemeSetting");
     // reset "TiledBackground" parameter
     hGrp->RemoveBool("TiledBackground");
 
@@ -413,15 +439,35 @@ void DlgSettingsGeneral::saveThemes()
     );
 
     // First we check if the theme has actually changed.
-    std::string previousTheme = hGrp->GetASCII("Theme", "").c_str();
-    std::string newTheme = ui->themesCombobox->currentText().toStdString();
+    std::string previousThemeSetting = hGrp->GetASCII("ThemeSetting", "");
+    std::string previousLightThemeSetting = hGrp->GetASCII("LightThemeSetting", "");
+    std::string previousDarkThemeSetting = hGrp->GetASCII("DarkThemeSetting", "");
+    std::string newThemeSetting = ui->themesCombobox->currentText().toStdString();
+    std::string newLightThemeSetting = ui->lightThemeCombobox->currentText().toStdString();
+    std::string newDarkThemeSetting = ui->darkThemeCombobox->currentText().toStdString();
 
-    if (previousTheme == newTheme) {
+    if (previousThemeSetting == newThemeSetting && previousLightThemeSetting == newLightThemeSetting
+        && previousDarkThemeSetting == newDarkThemeSetting) {
         themeChanged = false;
         return;
     }
 
     // Save the name of the theme
+    hGrp->SetASCII("ThemeSetting", newThemeSetting);
+    hGrp->SetASCII("LightThemeSetting", newLightThemeSetting);
+    hGrp->SetASCII("DarkThemeSetting", newDarkThemeSetting);
+
+    std::string newTheme;
+
+    // Check if using system theme
+    if (newThemeSetting == "Use system theme") {
+        const auto scheme = QGuiApplication::styleHints()->colorScheme();
+        newTheme = scheme == Qt::ColorScheme::Dark ? newDarkThemeSetting : newLightThemeSetting;
+    }
+    else {
+        newTheme = newThemeSetting;
+    }
+
     hGrp->SetASCII("Theme", newTheme);
 
     // Then we apply the themepack.
@@ -444,15 +490,23 @@ void DlgSettingsGeneral::saveThemes()
     themeChanged = false;
 }
 
-void DlgSettingsGeneral::loadThemes()
+void DlgSettingsGeneral::loadThemes(QComboBox* comboBox)
 {
-    ui->themesCombobox->clear();
+    comboBox->clear();
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/MainWindow"
     );
 
-    QString currentTheme = QString::fromLatin1(hGrp->GetASCII("Theme", "").c_str());
+    std::string themeParameter = "ThemeSetting";
+    if (comboBox == ui->lightThemeCombobox) {
+        themeParameter = "LightThemeSetting";
+    }
+    else if (comboBox == ui->darkThemeCombobox) {
+        themeParameter = "DarkThemeSetting";
+    }
+
+    QString currentTheme = QString::fromLatin1(hGrp->GetASCII(themeParameter.c_str(), "").c_str());
 
     Application::Instance->prefPackManager()->rescan();
     auto packs = Application::Instance->prefPackManager()->preferencePacks();
@@ -471,25 +525,28 @@ void DlgSettingsGeneral::loadThemes()
             if (packName.contains(currentStyleSheet, Qt::CaseInsensitive)) {
                 similarTheme = QString::fromStdString(pack.first);
             }
-            ui->themesCombobox->addItem(QString::fromStdString(pack.first));
+            comboBox->addItem(QString::fromStdString(pack.first));
         }
+    }
+    if (comboBox == ui->themesCombobox) {
+        ui->themesCombobox->addItem("Use system theme");
     }
 
     if (currentTheme.isEmpty()) {
         if (!currentStyleSheet.isEmpty() && !similarTheme.isEmpty()) {  // a user upgrading from
                                                                         // 0.21 or earlier
-            hGrp->SetASCII("Theme", similarTheme.toStdString());
-            currentTheme = QString::fromLatin1(hGrp->GetASCII("Theme", "").c_str());
+            hGrp->SetASCII(themeParameter.c_str(), similarTheme.toStdString());
+            currentTheme = QString::fromLatin1(hGrp->GetASCII(themeParameter.c_str(), "").c_str());
         }
         else {  // a brand new user
-            hGrp->SetASCII("Theme", themeClassic.toStdString());
-            currentTheme = QString::fromLatin1(hGrp->GetASCII("Theme", "").c_str());
+            hGrp->SetASCII(themeParameter.c_str(), themeClassic.toStdString());
+            currentTheme = QString::fromLatin1(hGrp->GetASCII(themeParameter.c_str(), "").c_str());
         }
     }
 
-    int index = ui->themesCombobox->findText(currentTheme);
-    if (index >= 0 && index < ui->themesCombobox->count()) {
-        ui->themesCombobox->setCurrentIndex(index);
+    int index = comboBox->findText(currentTheme);
+    if (index >= 0 && index < comboBox->count()) {
+        comboBox->setCurrentIndex(index);
     }
 }
 
@@ -824,6 +881,15 @@ void DlgSettingsGeneral::onUnitSystemIndexChanged(const int index)
 void DlgSettingsGeneral::onThemeChanged(int index)
 {
     Q_UNUSED(index);
+
+    std::string selectedTheme = ui->themesCombobox->currentText().toStdString();
+
+    bool systemThemeSelected = (selectedTheme == "Use system theme");
+    ui->lightThemeLabel->setVisible(systemThemeSelected);
+    ui->lightThemeCombobox->setVisible(systemThemeSelected);
+    ui->darkThemeLabel->setVisible(systemThemeSelected);
+    ui->darkThemeCombobox->setVisible(systemThemeSelected);
+
     themeChanged = true;
 }
 

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
@@ -47,6 +47,7 @@
 #include <Gui/Dialogs/DlgPreferencesImp.h>
 #include <Gui/Dialogs/DlgPreferencePackManagementImp.h>
 #include <Gui/Dialogs/DlgRevertToBackupConfigImp.h>
+#include <Gui/GuiApplication.h>
 #include <Gui/MainWindow.h>
 #include <Gui/OverlayManager.h>
 #include <Gui/ParamHandler.h>
@@ -459,13 +460,12 @@ void DlgSettingsGeneral::saveThemes()
 
     std::string newTheme = newThemeSetting;
 
-// Check if using system theme
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+#if SYSTEM_THEMING_SUPPORTED
+    // Check if using system theme
     if (newThemeSetting == "Use system theme") {
-        const auto scheme = QGuiApplication::styleHints()->colorScheme();
-        newTheme = scheme == Qt::ColorScheme::Dark ? newDarkThemeSetting : newLightThemeSetting;
+        newTheme = GUIApplication::isSystemInDarkMode() ? newDarkThemeSetting : newLightThemeSetting;
     }
-#endif  // QT_VERSION >= 6.5
+#endif  // SYSTEM_THEMING_SUPPORTED
 
     hGrp->SetASCII("Theme", newTheme);
 
@@ -527,11 +527,11 @@ void DlgSettingsGeneral::loadThemes(QComboBox* comboBox)
             comboBox->addItem(QString::fromStdString(pack.first));
         }
     }
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+#if SYSTEM_THEMING_SUPPORTED
     if (comboBox == ui->themesCombobox) {
         ui->themesCombobox->addItem("Use system theme");
     }
-#endif
+#endif  // SYSTEM_THEMING_SUPPORTED
 
     if (currentTheme.isEmpty()) {
         if (!currentStyleSheet.isEmpty() && !similarTheme.isEmpty()) {  // a user upgrading from
@@ -885,13 +885,13 @@ void DlgSettingsGeneral::onThemeChanged(int index)
 
     std::string selectedTheme = ui->themesCombobox->currentText().toStdString();
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+#if SYSTEM_THEMING_SUPPORTED
     bool systemThemeSelected = (selectedTheme == "Use system theme");
     ui->lightThemeLabel->setVisible(systemThemeSelected);
     ui->lightThemeCombobox->setVisible(systemThemeSelected);
     ui->darkThemeLabel->setVisible(systemThemeSelected);
     ui->darkThemeCombobox->setVisible(systemThemeSelected);
-#endif
+#endif  // SYSTEM_THEMING_SUPPORTED
 
     themeChanged = true;
 }

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
@@ -457,16 +457,15 @@ void DlgSettingsGeneral::saveThemes()
     hGrp->SetASCII("LightThemeSetting", newLightThemeSetting);
     hGrp->SetASCII("DarkThemeSetting", newDarkThemeSetting);
 
-    std::string newTheme;
+    std::string newTheme = newThemeSetting;
 
-    // Check if using system theme
+// Check if using system theme
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
     if (newThemeSetting == "Use system theme") {
         const auto scheme = QGuiApplication::styleHints()->colorScheme();
         newTheme = scheme == Qt::ColorScheme::Dark ? newDarkThemeSetting : newLightThemeSetting;
     }
-    else {
-        newTheme = newThemeSetting;
-    }
+#endif  // QT_VERSION >= 6.5
 
     hGrp->SetASCII("Theme", newTheme);
 
@@ -528,9 +527,11 @@ void DlgSettingsGeneral::loadThemes(QComboBox* comboBox)
             comboBox->addItem(QString::fromStdString(pack.first));
         }
     }
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
     if (comboBox == ui->themesCombobox) {
         ui->themesCombobox->addItem("Use system theme");
     }
+#endif
 
     if (currentTheme.isEmpty()) {
         if (!currentStyleSheet.isEmpty() && !similarTheme.isEmpty()) {  // a user upgrading from
@@ -884,11 +885,13 @@ void DlgSettingsGeneral::onThemeChanged(int index)
 
     std::string selectedTheme = ui->themesCombobox->currentText().toStdString();
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
     bool systemThemeSelected = (selectedTheme == "Use system theme");
     ui->lightThemeLabel->setVisible(systemThemeSelected);
     ui->lightThemeCombobox->setVisible(systemThemeSelected);
     ui->darkThemeLabel->setVisible(systemThemeSelected);
     ui->darkThemeCombobox->setVisible(systemThemeSelected);
+#endif
 
     themeChanged = true;
 }

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.h
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.h
@@ -27,6 +27,7 @@
 
 #include <Gui/PropertyPage.h>
 #include <memory>
+#include <qt6/QtWidgets/qcombobox.h>
 #include <string>
 
 class QTabWidget;
@@ -57,7 +58,7 @@ public:
     void resetSettingsToDefaults() override;
 
     void saveThemes();
-    void loadThemes();
+    void loadThemes(QComboBox* comboBox);
 
     static void attachObserver();
 

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.ui
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.ui
@@ -219,7 +219,47 @@ dot/period will always be printed</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="0" colspan="2">
+       <item row="1" column="0">
+        <widget class="QLabel" name="lightThemeLabel">
+         <property name="text">
+          <string>Light theme</string>
+         </property>
+         <property name="visible">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="lightThemeCombobox">
+         <property name="toolTip">
+          <string>Theme to use when system is using light theme.</string>
+         </property>
+         <property name="visible">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="darkThemeLabel">
+         <property name="text">
+          <string>Dark theme</string>
+         </property>
+         <property name="visible">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QComboBox" name="darkThemeCombobox">
+         <property name="toolTip">
+          <string>Theme to use when system is using dark theme.</string>
+         </property>
+         <property name="visible">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0" colspan="2">
         <widget class="QLabel" name="moreThemesLabel">
          <property name="font">
           <font>
@@ -234,28 +274,28 @@ dot/period will always be printed</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="4" column="0">
         <widget class="QLabel" name="iconSizeLabel">
          <property name="text">
           <string>Size of toolbar icons</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="4" column="1">
         <widget class="QComboBox" name="toolbarIconSize">
          <property name="toolTip">
           <string>Icon size in the toolbar</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="0">
+       <item row="5" column="0">
         <widget class="QLabel" name="treeModeLabel">
          <property name="text">
           <string>Tree View and Property View mode</string>
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="5" column="1">
         <widget class="QComboBox" name="treeMode">
          <property name="toolTip">
           <string>Customize how the tree view is shown in the panel (restart required).
@@ -265,14 +305,14 @@ dot/period will always be printed</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="6" column="0">
         <widget class="QLabel" name="recentFileListLabel">
          <property name="text">
           <string>Size of recent file list</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="6" column="1">
         <widget class="Gui::PrefSpinBox" name="RecentFiles">
          <property name="toolTip">
           <string>How many files should be listed in recent files list</string>
@@ -288,7 +328,7 @@ dot/period will always be printed</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="0">
+       <item row="7" column="0">
         <widget class="QCheckBox" name="tiledBackground">
          <property name="toolTip">
           <string>Background of the main window (when no document is opened) will consist of tiles of an image.</string>
@@ -298,7 +338,7 @@ dot/period will always be printed</string>
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="7" column="1">
         <widget class="Gui::PrefCheckBox" name="EnableCursorBlinking">
          <property name="toolTip">
           <string>The text cursor will be blinking</string>
@@ -317,7 +357,7 @@ dot/period will always be printed</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="0">
+       <item row="8" column="0">
         <widget class="Gui::PrefCheckBox" name="SplashScreen">
          <property name="toolTip">
           <string>A splash screen is a small loading window that is shown
@@ -338,7 +378,7 @@ display the splash screen.</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="8" column="1">
         <widget class="Gui::PrefCheckBox" name="ActivateOverlay">
          <property name="toolTip">
           <string>Activate overlay handling of docked panels</string>
@@ -357,7 +397,7 @@ display the splash screen.</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="1">
+       <item row="9" column="1">
         <widget class="Gui::PrefCheckBox" name="ComboBoxWheelEventFilter">
          <property name="toolTip">
           <string>Prevent the mouse wheel from changing the value of combo boxes,
@@ -377,7 +417,7 @@ and spin boxes with hover focus</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="0">
+       <item row="9" column="0">
         <widget class="Gui::PrefCheckBox" name="FineGrainedRecompute">
          <property name="toolTip">
           <string>Activate fine-grained recomputation of documents</string>

--- a/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
+++ b/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
@@ -33,49 +33,18 @@
 #include <gsl/pointers>
 #include <App/Application.h>
 #include <Gui/Command.h>
+#include <Gui/GuiApplication.h>
 #include <Gui/PreferencePackManager.h>
 #include <Gui/Utilities.h>
 
 #include <FCConfig.h>
+#include <qguiapplication.h>
 
 #ifdef FC_OS_MACOSX
 # include <CoreFoundation/CoreFoundation.h>
 #endif
 
 using namespace StartGui;
-
-
-static bool isSystemInDarkMode()
-{
-    // Auto-detect system setting and default to light mode
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
-    // https://www.qt.io/blog/dark-mode-on-windows-11-with-qt-6.5
-    const auto scheme = QGuiApplication::styleHints()->colorScheme();
-    return scheme == Qt::ColorScheme::Dark;
-#elif QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
-    // https://www.qt.io/blog/dark-mode-on-windows-11-with-qt-6.5
-    const QPalette defaultPalette;
-    const auto text = defaultPalette.color(QPalette::WindowText);
-    const auto window = defaultPalette.color(QPalette::Window);
-    return text.lightness() > window.lightness();
-#else
-# ifdef FC_OS_MACOSX
-    auto key = CFSTR("AppleInterfaceStyle");
-    if (auto value = CFPreferencesCopyAppValue(key, kCFPreferencesAnyApplication)) {
-        // If the value is "Dark", Dark Mode is enabled
-        if (CFGetTypeID(value) == CFStringGetTypeID()) {
-            if (CFStringCompare((CFStringRef)value, CFSTR("Dark"), kCFCompareCaseInsensitive)
-                == kCFCompareEqualTo) {
-                CFRelease(value);
-                return true;
-            }
-        }
-        CFRelease(value);
-    }
-# endif  // FC_OS_MACOSX
-#endif   // QT_VERSION >= 6.4+
-    return false;
-}
 
 
 static bool shouldHideClassicTheme()
@@ -204,7 +173,7 @@ void ThemeSelectorWidget::preselectThemeFromSystemSettings()
     );
     auto styleSheetName = QString::fromStdString(hGrp->GetASCII("StyleSheet", nullStyle));
     if (styleSheetName == QString::fromStdString(nullStyle)) {
-        auto theme = isSystemInDarkMode() ? Theme::Dark : Theme::Light;
+        auto theme = Gui::GUIApplication::isSystemInDarkMode() ? Theme::Dark : Theme::Light;
         themeChanged(theme);
     }
 }


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Add support to choose different FreeCAD themes depending on the current system theme. (Only when compiled with Qt > 6.5)

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

_Note: This is my first PR to FreeCAD, please let me know if I missed any guidelines._


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Closes #29297 In FreeCAD/FreeCAD

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
Changed general settings dialog.
Before:
<img width="2152" height="1974" alt="Screenshot From 2026-09-12 17-47-37" src="https://github.com/user-attachments/assets/64b1784f-4269-4732-b83b-f7745c195834" />

After:
<img width="2096" height="1920" alt="Screenshot From 2026-09-12 17-46-50" src="https://github.com/user-attachments/assets/35cee52b-b309-460e-b5ef-163e4d00bf7d" />

## Some discussion points

1. I added `isSystemInDarkMode()` to the `GUIApplication` class. I was not sure where to put this (seen as it is a static function that does depend on anything other than Qt).
2. Same goes for the `SYSTEM_THEMING_SUPPORTED` macro. Note that I made this a macro and not a function as it depends only on other macros.
3. On startup it did not seem to detect the system theme correctly (always returned light). For this I added an ugly hack that sets and unsets the color scheme of the application. I have not been able to figure out why this happens, that is why I left it in.
4. I have only tested on Fedora 44 with Gnome. Other platforms will need to be tested.

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
