### PR TITLE
Core: Show bundled Clipper2 version in About

### DIFF
--- a/cMake/FreeCAD_Helpers/SetupClipper2.cmake
+++ b/cMake/FreeCAD_Helpers/SetupClipper2.cmake
@@ -14,6 +14,16 @@ else()
 
     add_subdirectory(src/3rdParty/Clipper2)
     add_library(Clipper2::Clipper2Z ALIAS Clipper2Z)
+    get_directory_property(
+        _clipper2_version
+        DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src/3rdParty/Clipper2"
+        DEFINITION Clipper2_VERSION
+    )
+    if(NOT _clipper2_version)
+        message(FATAL_ERROR "Bundled Clipper2 did not provide a version")
+    endif()
+    set(Clipper2_VERSION "${_clipper2_version}")
+    unset(_clipper2_version)
 endif()
 
 endmacro(SetupClipper2)


### PR DESCRIPTION
About printed `Clipper2 ,` because the bundled version never left the Clipper2 subdirectory this copies that version up so it prints `Clipper2 2.0.1,`

Fixes #32627

Checked with Help > About > Copy to clipboard

The pr is manually verified by me
AI assistance- Cursor

"OS: macOS 26.5.2
Architecture: arm64
Version: 26.3.0dev.48603 (Git)
Build date: 2026/09/12 06:15:16
Build type: Debug
Branch: fix-32627-clipper2-about-version
Hash: 74d738d022452ecb1f00eb48675b1c9efb92abed
Python 3.11.14, Qt 6.8.3, Coin 4.0.10 (bundled), Pivy 0.6.11 (bundled), Vtk 9.3.1, boost 1_86, Eigen3 3.4.0, PySide 6.8.3
shiboken 6.8.3, xerces-c 3.3.0, Clipper2 2.0.1, IfcOpenShell 0.8.2, OCC 7.8.1
Locale: English/India (en_IN)
Stylesheet/Theme/QtStyle: FreeCAD.qss/FreeCAD Dark/
QPA/File dialog/Color dialog: cocoa/via Qt/via Qt
Navigation Style/Orbit Style/Rotation Mode: CAD/Rounded Arcball/Window center
Logical DPI/Physical DPI/Pixel Ratio: 72/133/2
OpenGL version/vendor/renderer: 2.1 Metal - 90.5/Apple/Apple M4
"
New about FreeCAD