### PR TITLE
LinkArrays: add polar link arrays

### DIFF
--- a/src/Mod/Part/App/AppPart.cpp
+++ b/src/Mod/Part/App/AppPart.cpp
@@ -101,6 +101,7 @@
 #include "LinkArrayCircular.h"
 #include "LinkArrayLinear.h"
 #include "LinkArrayPath.h"
+#include "LinkArrayPolar.h"
 #include "PolarPatternExtension.h"
 #include "PathPatternExtension.h"
 #include "Geometry.h"
@@ -465,6 +466,7 @@ PyMOD_INIT_FUNC(Part)
     Part::LinkArrayCircular     ::init();
     Part::LinkArrayLinear       ::init();
     Part::LinkArrayPath         ::init();
+    Part::LinkArrayPolar        ::init();
 
     Part::Feature               ::init();
     Part::FeatureExt            ::init();

--- a/src/Mod/Part/App/CMakeLists.txt
+++ b/src/Mod/Part/App/CMakeLists.txt
@@ -225,6 +225,8 @@ SET(Features_SRCS
     LinkArrayLinear.h
     LinkArrayPath.cpp
     LinkArrayPath.h
+    LinkArrayPolar.cpp
+    LinkArrayPolar.h
     PolarPatternExtension.cpp
     PolarPatternExtension.h
     PathPatternExtension.cpp

--- a/src/Mod/Part/App/LinkArrayPolar.cpp
+++ b/src/Mod/Part/App/LinkArrayPolar.cpp
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2026 FreeCAD Project Association                         *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Lesser General Public             *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2.1 of the License, or (at your option) any later version.     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,        *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA 02111-1307, USA                                  *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "LinkArrayPolar.h"
+
+#include <Mod/Part/App/Tools.h>
+
+#include <optional>
+
+#include <gp_Ax1.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_Trsf.hxx>
+
+#include <App/Datums.h>
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+#include <App/PropertyStandard.h>
+#include <Base/Exception.h>
+#include <Base/Rotation.h>
+
+using namespace Part;
+
+PROPERTY_SOURCE_WITH_EXTENSIONS(Part::LinkArrayPolar, Part::LinkArray)
+
+namespace
+{
+
+std::string roleFromSubName(const std::string& subName)
+{
+    std::string role = subName;
+    if (!role.empty() && role.back() == '.') {
+        role.pop_back();
+    }
+
+    const auto dot = role.rfind('.');
+    if (dot != std::string::npos) {
+        role = role.substr(dot + 1);
+    }
+
+    return role;
+}
+
+std::optional<gp_Ax2> axisFromLine(App::Line* line)
+{
+    if (!line) {
+        return {};
+    }
+
+    Base::Vector3d base = line->getBasePoint();
+    Base::Vector3d dir = line->getDirection();
+    return gp_Ax2(Base::convertTo<gp_Pnt>(base), Base::convertTo<gp_Dir>(dir));
+}
+
+std::optional<gp_Ax2> axisFromLocalCoordinateSystem(
+    App::LocalCoordinateSystem* lcs,
+    const std::string& role
+)
+{
+    if (!lcs) {
+        return {};
+    }
+
+    if (role == App::LocalCoordinateSystem::AxisRoles[0]
+        || role == App::LocalCoordinateSystem::AxisRoles[1]
+        || role == App::LocalCoordinateSystem::AxisRoles[2]) {
+        return axisFromLine(lcs->getAxis(role.c_str()));
+    }
+
+    return {};
+}
+
+App::DocumentObject* resolveSubObject(App::DocumentObject* refObject, const std::string& subName)
+{
+    if (!refObject || subName.empty()) {
+        return nullptr;
+    }
+
+    std::string sub = subName;
+    if (sub.back() != '.') {
+        sub += '.';
+    }
+
+    try {
+        if (auto* resolved = refObject->getSubObject(sub.c_str())) {
+            return resolved;
+        }
+    }
+    catch (const Base::Exception&) {
+    }
+
+    if (auto* doc = refObject->getDocument()) {
+        return doc->getObject(roleFromSubName(subName).c_str());
+    }
+
+    return nullptr;
+}
+
+}  // namespace
+
+LinkArrayPolar::LinkArrayPolar()
+{
+    Part::PolarPatternExtension::initExtension(this);
+    setAxisLinkScope();
+}
+
+void LinkArrayPolar::onDocumentRestored()
+{
+    inherited::onDocumentRestored();
+    setAxisLinkScope();
+}
+
+void LinkArrayPolar::setAxisLinkScope()
+{
+    Axis.setScope(App::LinkScope::Global);
+}
+
+std::vector<Base::Placement> LinkArrayPolar::getElementPlacements()
+{
+    updateSpacings();
+    return placementsFromTransforms(calculateTransformations());
+}
+
+gp_Ax2 LinkArrayPolar::getRotation() const
+{
+    App::DocumentObject* refObject = Axis.getValue();
+    std::vector<std::string> subStrings = Axis.getSubValues();
+    std::string role;
+    if (!subStrings.empty()) {
+        role = roleFromSubName(subStrings.front());
+    }
+
+    if (!refObject && (role == "X_Axis" || role == "Y_Axis" || role == "Z_Axis")) {
+        gp_Dir direction(0.0, 0.0, 1.0);
+        if (role == "X_Axis") {
+            direction = gp_Dir(1.0, 0.0, 0.0);
+        }
+        else if (role == "Y_Axis") {
+            direction = gp_Dir(0.0, 1.0, 0.0);
+        }
+        gp_Ax2 localAxis(gp_Pnt(), direction);
+        if (Reversed.getValue()) {
+            localAxis.SetDirection(localAxis.Direction().Reversed());
+        }
+        return localAxis;
+    }
+    if (!refObject) {
+        return gp_Ax2();
+    }
+
+    std::optional<gp_Ax2> axis;
+    if (auto* lcs = freecad_cast<App::LocalCoordinateSystem*>(refObject)) {
+        axis = axisFromLocalCoordinateSystem(lcs, role);
+    }
+
+    if (!axis && !subStrings.empty()) {
+        App::DocumentObject* resolved = resolveSubObject(refObject, subStrings.front());
+        if (auto* line = freecad_cast<App::Line*>(resolved)) {
+            axis = axisFromLine(line);
+        }
+        else if (auto* lcs = freecad_cast<App::LocalCoordinateSystem*>(resolved)) {
+            axis = axisFromLocalCoordinateSystem(lcs, role);
+        }
+    }
+
+    if (!axis) {
+        axis = axisFromLine(freecad_cast<App::Line*>(refObject));
+    }
+
+    if (!axis) {
+        return PolarPatternExtension::getRotation();
+    }
+
+    gp_Ax2 transformed = *axis;
+    transformAxisToLocal(transformed);
+
+    if (Reversed.getValue()) {
+        transformed.SetDirection(transformed.Direction().Reversed());
+    }
+
+    return transformed;
+}
+
+void LinkArrayPolar::transformAxisToLocal(gp_Ax2& axis) const
+{
+    auto* prop = getPropertyByName<App::PropertyPlacement>("Placement");
+    if (!prop) {
+        return;
+    }
+
+    Base::Placement pl = prop->getValue();
+    Base::Rotation rot(pl.getRotation());
+    Base::Vector3d rotAxis;
+    double angle;
+    rot.getValue(rotAxis, angle);
+
+    gp_Trsf trf;
+    trf.SetRotation(gp_Ax1(gp_Pnt(), Base::convertTo<gp_Dir>(rotAxis)), angle);
+    trf.SetTranslationPart(Base::convertTo<gp_Vec>(pl.getPosition()));
+    trf.Invert();
+
+    gp_Pnt base = axis.Location();
+    gp_Dir direction = axis.Direction();
+    base.Transform(trf);
+    direction.Transform(trf);
+    axis = gp_Ax2(base, direction);
+}

--- a/src/Mod/Part/App/LinkArrayPolar.h
+++ b/src/Mod/Part/App/LinkArrayPolar.h
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2026 FreeCAD Project Association                         *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Lesser General Public             *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2.1 of the License, or (at your option) any later version.     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,        *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA 02111-1307, USA                                  *
+ *                                                                         *
+ ***************************************************************************/
+
+#pragma once
+
+#include "LinkArray.h"
+#include "PolarPatternExtension.h"
+
+namespace Part
+{
+
+class PartExport LinkArrayPolar: public Part::LinkArray, public Part::PolarPatternExtension
+{
+    PROPERTY_HEADER_WITH_EXTENSIONS(Part::LinkArrayPolar);
+    using inherited = Part::LinkArray;
+
+public:
+    LinkArrayPolar();
+
+    gp_Ax2 getRotation() const override;
+    void onDocumentRestored() override;
+
+protected:
+    std::vector<Base::Placement> getElementPlacements() override;
+
+private:
+    void setAxisLinkScope();
+    void transformAxisToLocal(gp_Ax2& axis) const;
+};
+
+}  // namespace Part

--- a/tests/src/Mod/Part/App/CMakeLists.txt
+++ b/tests/src/Mod/Part/App/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(Part_tests_run
         FeatureRevolution.cpp
         FuzzyBoolean.cpp
         Geometry.cpp
+        LinkArrayPolar.cpp
         PartFeature.cpp
         PartFeatures.cpp
         PartTestHelpers.cpp

--- a/tests/src/Mod/Part/App/LinkArrayPolar.cpp
+++ b/tests/src/Mod/Part/App/LinkArrayPolar.cpp
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <gtest/gtest.h>
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/Property.h>
+#include <App/SuppressibleExtension.h>
+#include <gp_Dir.hxx>
+#include <Precision.hxx>
+
+#include <Mod/Part/App/FeaturePartBox.h>
+#include <Mod/Part/App/LinkArrayLinear.h>
+#include <Mod/Part/App/LinkArrayPolar.h>
+#include <src/App/InitApplication.h>
+
+class LinkArrayPolarTest: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+        Part::LinearPatternExtension::init();
+        Part::PolarPatternExtension::init();
+        Part::LinkArray::init();
+        Part::LinkArrayLinear::init();
+        Part::LinkArrayPolar::init();
+        Part::AttachExtension::init();
+        Part::Primitive::init();
+        Part::Box::init();
+    }
+
+    void SetUp() override
+    {
+        _docName = App::GetApplication().getUniqueDocumentName("test");
+        _doc = App::GetApplication().newDocument(_docName.c_str(), "testUser");
+    }
+
+    void TearDown() override
+    {
+        App::GetApplication().closeDocument(_docName.c_str());
+    }
+
+    App::Document* _doc {};
+    std::string _docName;
+};
+
+TEST_F(LinkArrayPolarTest, objectAxes)
+{
+    Part::LinkArrayPolar array;
+
+    const auto checkAxis = [&array](const char* role, const gp_Dir& expected) {
+        array.Axis.setValue(nullptr, std::vector<std::string> {role});
+        EXPECT_TRUE(array.getRotation().Direction().IsEqual(expected, Precision::Angular()));
+    };
+
+    checkAxis("X_Axis", gp_Dir(1.0, 0.0, 0.0));
+    checkAxis("Y_Axis", gp_Dir(0.0, 1.0, 0.0));
+    checkAxis("Z_Axis", gp_Dir(0.0, 0.0, 1.0));
+}
+
+TEST_F(LinkArrayPolarTest, showElementDefaultsToExpandedAndEditable)
+{
+    Part::LinkArray array;
+
+    EXPECT_TRUE(array.ShowElement.getValue());
+    EXPECT_FALSE(array.ShowElement.testStatus(App::Property::Immutable));
+    EXPECT_FALSE(array.ShowElement.testStatus(App::Property::Hidden));
+}
+
+TEST_F(LinkArrayPolarTest, expandedElementsFollowPatternPlacementChanges)
+{
+    auto* box = _doc->addObject<Part::Box>("Box");
+    auto* array = _doc->addObject<Part::LinkArrayLinear>("LinearArray");
+    array->LinkedObject.setValue(box);
+    array->Occurrences.setValue(2);
+    array->Occurrences2.setValue(1);
+    array->Length.setValue(10.0);
+
+    array->execute();
+
+    auto elements = array->ElementList.getValues();
+    ASSERT_EQ(2, elements.size());
+    auto* secondPlacement = elements[1]->getPropertyByName<App::PropertyPlacement>("Placement");
+    ASSERT_NE(secondPlacement, nullptr);
+    EXPECT_DOUBLE_EQ(secondPlacement->getValue().getPosition().x, 10.0);
+
+    array->Length.setValue(20.0);
+    array->execute();
+
+    elements = array->ElementList.getValues();
+    ASSERT_EQ(2, elements.size());
+    EXPECT_EQ(elements[1]->getPropertyByName<App::PropertyPlacement>("Placement"), secondPlacement);
+    EXPECT_DOUBLE_EQ(secondPlacement->getValue().getPosition().x, 20.0);
+}
+
+TEST_F(LinkArrayPolarTest, suppressedExpandedElementIsOmittedFromSubObjects)
+{
+    auto* box = _doc->addObject<Part::Box>("Box");
+    auto* array = _doc->addObject<Part::LinkArrayLinear>("LinearArray");
+    array->LinkedObject.setValue(box);
+    array->Occurrences.setValue(2);
+    array->Occurrences2.setValue(1);
+
+    array->execute();
+
+    auto elements = array->ElementList.getValues();
+    ASSERT_EQ(2, elements.size());
+
+    auto* suppressible = elements[1]->getExtensionByType<App::SuppressibleExtension>(true);
+    ASSERT_NE(suppressible, nullptr);
+    suppressible->Suppressed.setValue(true);
+
+    auto subObjects = array->getSubObjects();
+    ASSERT_EQ(1, subObjects.size());
+    EXPECT_EQ("0.", subObjects[0]);
+    EXPECT_EQ(elements[1], array->getSubObject("1."));
+    EXPECT_EQ(nullptr, array->getSubObject("1.Face1"));
+}


### PR DESCRIPTION
Add Part::LinkArrayPolar using the merged polar pattern extension. Resolve rotation axes from geometry, datum lines, local coordinate systems and object axes, accounting for array placement and reversal.

Part of #30840. Based directly on main after the linear-array PR merged; independent of the other open LinkArrays PRs. Adds the core object and C++ regression tests, with task-panel wiring and commands left to later commits. 404 added lines.

Validation: MSVC C++20 syntax checks passed for LinkArrayPolar.cpp, AppPart.cpp and the C++ regression test file. Three focused runtime checks passed using a temporary native harness compiled from this branch: reference axes, reversal and expanded-instance placement updates. This is focused validation, not a full build or execution of the C++ test suite.

Prepared with assistance from OpenAI Codex.