### PR TITLE
PD/Tests: Address floating point comparison fragility

### DIFF
--- a/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
@@ -1361,12 +1361,12 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         # Assert
         if body.Shape.ElementMapVersion == "":  # Should be '4' as of Mar 2023.
             return
-        self.assertEqual(body.Shape.BoundBox.XMin, 0)
-        self.assertEqual(body.Shape.BoundBox.YMin, 0)
-        self.assertEqual(body.Shape.BoundBox.ZMin, 0)
-        self.assertEqual(body.Shape.BoundBox.XMax, 31.37)
+        self.assertAlmostEqual(body.Shape.BoundBox.XMin, 0)
+        self.assertAlmostEqual(body.Shape.BoundBox.YMin, 0)
+        self.assertAlmostEqual(body.Shape.BoundBox.ZMin, 0)
+        self.assertAlmostEqual(body.Shape.BoundBox.XMax, 31.37)
         self.assertAlmostEqual(body.Shape.BoundBox.YMax, 25.2)
-        self.assertEqual(body.Shape.BoundBox.ZMax, 20)
+        self.assertAlmostEqual(body.Shape.BoundBox.ZMax, 20)
         self.assertNotEqual(area1, area2)
 
     def testShapeBinder(self):


### PR DESCRIPTION
This test has been causing intermittent CI failures for a couple of weeks now: I *believe* that it traces back to 6d06b61c7e -- not itself incorrect, just making this test's comparisons a bit less exact than they have been to this point. IMO the right solution here is not a code change, but to let those floating point comparisons be a bit fuzzy. There's obvious precedent right in the same code block, with the YMax test already being fuzzy. This makes the rest match.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
