### PR TITLE
Make calling `convertToNurbs` on a spline a no-op

### DIFF
--- a/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
@@ -22,6 +22,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <cmath>
 #include <limits>
 
 #include <Inventor/nodes/SoCamera.h>
@@ -342,10 +343,11 @@ void GridExtensionP::createGridPart(
     grid->vertexProperty = vts;
 
     float gridDimension = 1.5 * camMaxDimension;
-    int vlines = static_cast<int>(gridDimension / computedGridValue);  // total number of vertical lines
-    int nlines = 2 * vlines;                                           // total number of lines
+    // Use a double here: casting an infinite or oversized division result to int is undefined.
+    double requestedLines = 2.0 * gridDimension / computedGridValue;
+    constexpr double maxNumberOfLines = 2000.0;
 
-    if (nlines > 2000) {
+    if (!std::isfinite(requestedLines) || requestedLines > maxNumberOfLines) {
         if (!isTooManySegmentsNotified) {
             Base::Console().warning(
                 "The grid is too dense, so it is being disabled. Consider zooming in or changing "
@@ -360,6 +362,9 @@ void GridExtensionP::createGridPart(
     else {
         isTooManySegmentsNotified = false;
     }
+
+    int vlines = static_cast<int>(gridDimension / computedGridValue);  // total number of vertical lines
+    int nlines = 2 * vlines;                                           // total number of lines
 
     // set the grid indices
     grid->numVertices.setNum(nlines);

--- a/src/Mod/Sketcher/App/SketchObjectOperations.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectOperations.cpp
@@ -2819,6 +2819,10 @@ bool SketchObject::convertToNURBS(int GeoId)
     if (geo->is<Part::GeomPoint>())
         return false;
 
+    // Converting a B-spline again would only strip its internal alignment constraints.
+    if (geo->is<Part::GeomBSplineCurve>())
+        return true;
+
     const auto* geo1 = static_cast<const Part::GeomCurve*>(geo);
 
     Part::GeomBSplineCurve* bspline;

--- a/src/Mod/Sketcher/SketcherTests/TestConstraintCommandsGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestConstraintCommandsGui.py
@@ -25,8 +25,10 @@ class TestConstraintCommandsGui(SketcherGuiTestCase):
         )
         self.doc.recompute()
         Gui.activeDocument().setEdit(self.sketch.Name)
+        self.flush_gui(50)
         self.view = Gui.activeDocument().activeView()
         self.view.viewTop()
+        self.flush_gui(50)
         self.view.fitAll()
         self.flush_gui(150)
         self.viewport = self.view.graphicsView().viewport()
@@ -313,39 +315,6 @@ class TestConstraintCommandsGui(SketcherGuiTestCase):
                     self.assertEqual(self.viewport.cursor().shape(), QtCore.Qt.ArrowCursor)
         finally:
             notifications.SetBool("NonIntrusiveNotificationsEnabled", saved)
-
-    def test_converting_existing_bspline_preserves_constraints(self):
-        spline = Part.BSplineCurve()
-        spline.interpolate([App.Vector(0, 0, 0), App.Vector(10, 20, 0), App.Vector(30, 0, 0)])
-        self.sketch.addGeometry(spline, False)
-        self.sketch.exposeInternalGeometry(1)
-        self.doc.recompute()
-        constraints = [c.Content for c in self.sketch.Constraints]
-        geometry = [g.Content for g in self.sketch.Geometry]
-
-        # The API must also be safe for scripts that do not pre-filter their geometry.
-        self.sketch.convertToNURBS(1)
-        self.assertEqual([c.Content for c in self.sketch.Constraints], constraints)
-        self.assertEqual([g.Content for g in self.sketch.Geometry], geometry)
-
-        self.select("Edge2")
-        Gui.runCommand("Sketcher_BSplineConvertToNURBS")
-        self.assertEqual([c.Content for c in self.sketch.Constraints], constraints)
-        self.assertEqual([g.Content for g in self.sketch.Geometry], geometry)
-        self.assertEqual(self.sketch.solve(), 0)
-
-        # A mixed selection must still convert the line while leaving the spline intact.
-        self.select("Edge1", "Edge2")
-        Gui.runCommand("Sketcher_BSplineConvertToNURBS")
-        self.assertIsInstance(self.sketch.Geometry[0], Part.BSplineCurve)
-        self.assertEqual(self.sketch.Geometry[1].Content, geometry[1])
-        self.assertEqual(
-            [c.Content for c in self.sketch.Constraints[: len(constraints)]], constraints
-        )
-        self.assertEqual(self.sketch.solve(), 0)
-        self.doc.undo()
-        self.assertEqual([g.Content for g in self.sketch.Geometry], geometry)
-        self.assertEqual([c.Content for c in self.sketch.Constraints], constraints)
 
     def test_switching_continuous_commands_preserves_sketch(self):
         for name in (

--- a/src/Mod/Sketcher/SketcherTests/TestConstraintCommandsGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestConstraintCommandsGui.py
@@ -316,6 +316,39 @@ class TestConstraintCommandsGui(SketcherGuiTestCase):
         finally:
             notifications.SetBool("NonIntrusiveNotificationsEnabled", saved)
 
+    def test_converting_existing_bspline_preserves_constraints(self):
+        spline = Part.BSplineCurve()
+        spline.interpolate([App.Vector(0, 0, 0), App.Vector(10, 20, 0), App.Vector(30, 0, 0)])
+        self.sketch.addGeometry(spline, False)
+        self.sketch.exposeInternalGeometry(1)
+        self.doc.recompute()
+        constraints = [c.Content for c in self.sketch.Constraints]
+        geometry = [g.Content for g in self.sketch.Geometry]
+
+        # The API must also be safe for scripts that do not pre-filter their geometry.
+        self.sketch.convertToNURBS(1)
+        self.assertEqual([c.Content for c in self.sketch.Constraints], constraints)
+        self.assertEqual([g.Content for g in self.sketch.Geometry], geometry)
+
+        self.select("Edge2")
+        Gui.runCommand("Sketcher_BSplineConvertToNURBS")
+        self.assertEqual([c.Content for c in self.sketch.Constraints], constraints)
+        self.assertEqual([g.Content for g in self.sketch.Geometry], geometry)
+        self.assertEqual(self.sketch.solve(), 0)
+
+        # A mixed selection must still convert the line while leaving the spline intact.
+        self.select("Edge1", "Edge2")
+        Gui.runCommand("Sketcher_BSplineConvertToNURBS")
+        self.assertIsInstance(self.sketch.Geometry[0], Part.BSplineCurve)
+        self.assertEqual(self.sketch.Geometry[1].Content, geometry[1])
+        self.assertEqual(
+            [c.Content for c in self.sketch.Constraints[: len(constraints)]], constraints
+        )
+        self.assertEqual(self.sketch.solve(), 0)
+        self.doc.undo()
+        self.assertEqual([g.Content for g in self.sketch.Geometry], geometry)
+        self.assertEqual([c.Content for c in self.sketch.Constraints], constraints)
+
     def test_switching_continuous_commands_preserves_sketch(self):
         for name in (
             "Horizontal",


### PR DESCRIPTION
~~The first two commits in the PR are from #32638 and will fall out once that is merged.~~ The actual work of this PR re-instates the `convertToNURBS` test that PR drops, and actually makes it pass by making a call to `convertToNURBS` on something that is *already* a spline a true no-op. This has the effect of preserving any constraints that had been placed on that spline.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
