### PR TITLE
Sketcher: fix #32635 crash on mouse move for some sketches

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3899,8 +3899,18 @@ void ViewProviderSketch::slotSolverUpdate()
             + getSketchObject()->getHighestCurveIndex() + 1
         == getSolvedSketch().getGeometrySize()) {
 
-        Gui::MDIView* mdi =
-            Gui::Application::Instance->editViewOfNode(editCoinManager->getRootEditNode());
+        Gui::MDIView* mdi = Gui::Application::Instance->editViewOfNode(
+            editCoinManager->getRootEditNode()
+        );
+
+        if (mdi == nullptr) {
+            if (auto editDoc = Gui::Application::Instance->editDocument(
+                    [this](Gui::Document* editdoc) { return editdoc->getEditViewProvider() == this; }
+                )) {
+                mdi = editDoc->getActiveView();
+            }
+        }
+
         if (mdi && mdi->isDerivedFrom<Gui::View3DInventor>()) {
             draw(false, true);
         }


### PR DESCRIPTION
* Closes #32635

Fixes a null deref caused by 16a836743a4b60ef919e5f003eb1427cdb766d19 improperly launching sketch edit mode, meaning `EditModeGeometryCoinConverter::convert()` ended up not being called and not populating sketcher Coin editor data.

Note for code review: all this does is reinstate the logic that existed prior to 16a836743a4b60ef919e5f003eb1427cdb766d19 if the new way of fetching the `MDIView` returns a `nullptr`, which it will if the `EditView` for the sketch wasn't opened yet.

@maxwxyz FYI

* [x] :robot: → :wastebasket: